### PR TITLE
Make news section scrollable

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="assets/js/main.min.js"></script>
+<script src="assets/js/news-scroll.js"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,4 +1,6 @@
 # 💬 News
+<div class="news-window">
+  <div class="news-scroll" role="region" aria-label="Latest news" markdown="1" tabindex="0">
 - *2024.09* &nbsp;👏👏👏 I have been awarded the **National Scholarship** for Ph.D. Students at Shanghai Jiao Tong University!
 - *2024.08* &nbsp;🎉 One paper has been accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!
 - *2024.07* &nbsp;🎉  One co-author's's paper has been accepted by IEEE **CDC** ([Link]())!
@@ -26,3 +28,5 @@
 - *2022.04* &nbsp;🎉  One paper has been accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!
 - *2022.01* &nbsp;🎉  One paper has been accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!
 - *2021.04* &nbsp;🎉  One paper has been accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!
+  </div>
+</div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -143,3 +143,55 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   .cv-row { grid-template-columns: 1fr; gap: 4px; }
   .cv-date { order: 2; }
 }
+/* Scrollable news list */
+.news-window {
+  margin-top: 0.75rem;
+}
+
+.news-scroll {
+  --news-visible-rows: 5;
+  position: relative;
+  overflow-y: auto;
+  max-height: calc(var(--news-visible-rows) * 3.2rem);
+  padding-right: 0.5rem;
+  scrollbar-gutter: stable both-edges;
+}
+
+.news-scroll:focus-visible {
+  outline: 2px solid #00369f;
+  outline-offset: 2px;
+}
+
+.news-scroll > ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.news-scroll > ul > li {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.news-scroll > ul > li:last-child {
+  margin-bottom: 0;
+}
+
+.news-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.news-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 54, 159, 0.5);
+  border-radius: 999px;
+}
+
+.news-scroll::-webkit-scrollbar-track {
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 999px;
+}
+
+@media (max-width: 640px) {
+  .news-scroll {
+    max-height: calc(var(--news-visible-rows) * 3.8rem);
+  }
+}

--- a/assets/js/news-scroll.js
+++ b/assets/js/news-scroll.js
@@ -1,0 +1,59 @@
+(function () {
+  'use strict';
+
+  var VISIBLE_COUNT = 5;
+
+  function toNumber(value) {
+    var parsed = parseFloat(value);
+    return isNaN(parsed) ? 0 : parsed;
+  }
+
+  function setHeight(wrapper) {
+    if (!wrapper) {
+      return;
+    }
+
+    var items = wrapper.querySelectorAll('li');
+    if (!items.length) {
+      wrapper.style.maxHeight = '';
+      return;
+    }
+
+    if (items.length <= VISIBLE_COUNT) {
+      wrapper.style.maxHeight = '';
+      return;
+    }
+
+    var total = 0;
+    var count = Math.min(VISIBLE_COUNT, items.length);
+
+    for (var i = 0; i < count; i += 1) {
+      var item = items[i];
+      var styles = window.getComputedStyle(item);
+
+      total += item.offsetHeight;
+      total += toNumber(styles.marginTop) + toNumber(styles.marginBottom);
+    }
+
+    wrapper.style.maxHeight = Math.ceil(total) + 'px';
+  }
+
+  function updateAll() {
+    var wrappers = document.querySelectorAll('.news-scroll');
+    Array.prototype.forEach.call(wrappers, function (wrapper) {
+      setHeight(wrapper);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', updateAll);
+  } else {
+    updateAll();
+  }
+
+  var resizeTimer;
+  window.addEventListener('resize', function () {
+    window.clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(updateAll, 150);
+  });
+})();


### PR DESCRIPTION
## Summary
- wrap the news list in a scrollable container so only the five most recent items show by default
- add dedicated styling and a helper script to size the news window and provide keyboard-accessible scrolling

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` executable is not installed in the environment)*
- `bundle install` *(fails: repeated 403 Forbidden responses from rubygems.org when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5e5f8174832d857bb94f4c5e9b9a