### PR TITLE
Refine news panel scrolling behavior

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="assets/js/main.min.js"></script>
+<script src="assets/js/news-window.js"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,5 +1,7 @@
 # 💬 News
 
+<div class="news-window" data-news-window data-visible-count="5" tabindex="0" aria-label="Latest news" markdown="1">
+
 - *2024.09* &nbsp;👏👏👏 I have been awarded the **National Scholarship** for Ph.D. Students at Shanghai Jiao Tong University!
 - *2024.08* &nbsp;🎉 One paper has been accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!
 - *2024.07* &nbsp;🎉  One co-author's's paper has been accepted by IEEE **CDC** ([Link]())!
@@ -27,3 +29,6 @@
 - *2022.04* &nbsp;🎉  One paper has been accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!
 - *2022.01* &nbsp;🎉  One paper has been accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!
 - *2021.04* &nbsp;🎉  One paper has been accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!
+{: .news-list}
+
+</div>

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -111,6 +111,44 @@
     font-size: $type-size-6;
   }
 
+  .news-window {
+    --news-window-max-height: calc(5 * 3.5rem);
+    position: relative;
+    max-height: var(--news-window-max-height);
+    overflow-y: auto;
+    margin: 1rem 0;
+    padding: 0.75rem 1.25rem 0.75rem 1.5rem;
+    border: 1px solid $border-color;
+    border-radius: $border-radius;
+    background-color: rgba(#fff, 0.85);
+    box-shadow: 0 2px 6px rgba(#000, 0.06);
+    transition: box-shadow 0.2s ease;
+
+    &:focus {
+      outline: 2px solid rgba($link-color, 0.55);
+      outline-offset: 2px;
+      box-shadow: 0 4px 12px rgba(#000, 0.12);
+    }
+
+    &.news-window--scroll {
+      padding-right: 1.75rem;
+    }
+
+    .news-list {
+      margin: 0;
+      padding-left: 0;
+      list-style-position: outside;
+
+      li {
+        margin-bottom: 0.75rem;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
   /* blockquote citations */
   blockquote + .small {
     margin-top: -1.5em;

--- a/assets/js/news-window.js
+++ b/assets/js/news-window.js
@@ -1,0 +1,76 @@
+(function () {
+  'use strict';
+
+  function parseVisibleCount(value, fallback) {
+    var parsed = parseInt(value, 10);
+    return isNaN(parsed) || parsed < 1 ? fallback : parsed;
+  }
+
+  function computeVisibleHeight(items, count) {
+    var total = 0;
+
+    for (var index = 0; index < count && index < items.length; index += 1) {
+      var item = items[index];
+      var styles = window.getComputedStyle(item);
+      var marginTop = parseFloat(styles.marginTop || 0);
+      var marginBottom = parseFloat(styles.marginBottom || 0);
+
+      total += item.offsetHeight + marginTop + marginBottom;
+    }
+
+    return Math.ceil(total);
+  }
+
+  function enhance(container) {
+    if (!container) {
+      return;
+    }
+
+    var list = container.querySelector('.news-list');
+    if (!list) {
+      return;
+    }
+
+    var items = list.querySelectorAll('li');
+    if (!items.length) {
+      return;
+    }
+
+    var visibleCount = parseVisibleCount(container.getAttribute('data-visible-count'), 5);
+
+    if (items.length <= visibleCount) {
+      container.classList.remove('news-window--scroll');
+      container.style.removeProperty('--news-window-max-height');
+      return;
+    }
+
+    var height = computeVisibleHeight(items, visibleCount);
+    if (height > 0) {
+      container.style.setProperty('--news-window-max-height', height + 'px');
+    }
+
+    container.classList.add('news-window--scroll');
+
+    if (!container.hasAttribute('tabindex')) {
+      container.setAttribute('tabindex', '0');
+    }
+  }
+
+  function init() {
+    var containers = document.querySelectorAll('[data-news-window]');
+
+    if (!containers || !containers.length) {
+      return;
+    }
+
+    for (var i = 0; i < containers.length; i += 1) {
+      enhance(containers[i]);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- wrap the homepage news list in an accessible scrollable container that defaults to five visible entries
- restyle the news section to match the new container shell and focus treatment
- add a standalone script that sizes the panel based on the first five items and include it in the global scripts bundle

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing in environment)*
- bundle install *(fails: rubygems.org returns 403 Forbidden from the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8ab47424832d908144460ce00e70