### PR TITLE
Enhance publications section with sorting and filters

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,20 +1,20 @@
-# 📝 Publications 
+# 📝 Publications
 
 ### Selected Papers
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
-[Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf) 
+[Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)
 
-**Wentao Wu**, Zhouhua Peng, Dan Wang, Lu Liu, Qing-Long Han 
+**Wentao Wu**, Zhouhua Peng, Dan Wang, Lu Liu, Qing-Long Han
 
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4) 
+[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:W7OEmFMy1HYC'></span></strong>
 
-- 
-- 
-- 
+-
+-
+-
 </div>
 </div>
 
@@ -22,14 +22,14 @@
 <div class='paper-box-text' markdown="1">
 
 [A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043) \\
-**Wentao Wu**, Zhouhua Peng, Lu Liu, Dan Wang 
+**Wentao Wu**, Zhouhua Peng, Lu Liu, Dan Wang
 
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4) 
+[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4)
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:UeHWp8X0CEIC'></span></strong>
 
-- 
-- 
-- 
+-
+-
+-
 </div>
 </div>
 
@@ -43,9 +43,9 @@
 [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.mp4)
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ufrVoPGSRksC'></span></strong>
 
-- 
-- 
-- 
+-
+-
+-
 </div>
 </div>
 
@@ -60,9 +60,9 @@
 [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
 
-- 
-- 
-- 
+-
+-
+-
 </div>
 </div>
 
@@ -77,125 +77,193 @@
 [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.mp4)  [![Video-Expa](https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4)  [![Video-Expb](https://img.shields.io/badge/%F0%9F%A4%97%20Expb--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASb.mp4)
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
 
-- 
-- 
+-
+-
 </div>
 </div>
-<!-- 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-ITS 2023</div><img src='assets/Video/Video-Sim/WuWentao-2023-IEEE-TITS.gif' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
 
-[Transient-Reinforced Tunnel Coordinated Control of Underactuated Marine Surface Vehicles with Actuator Faults](https://ieeexplore.ieee.org/document/10292769)
+### Publications Explorer
 
-**Wentao Wu**, Ruihang Ji, Weidong Zhang, Yibo Zhang
+<p>使用下方筛选器按类型与年份快速浏览全部文献，默认按照发表时间从新到旧排序。</p>
 
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TITS.pdf) [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TITS.mp4) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
-
-- 
-- 
-- 
+<div class="publication-controls">
+  <label for="publication-type-filter">类型筛选</label>
+  <select id="publication-type-filter">
+    <option value="all">全部类型</option>
+  </select>
+  <label for="publication-year-filter">年份筛选</label>
+  <select id="publication-year-filter">
+    <option value="all">全部年份</option>
+  </select>
+  <button type="button" id="publication-year-sort" class="publication-sort">按年份 ↓</button>
 </div>
-</div> -->
 
+<ol id="publication-list" class="publication-list"></ol>
 
+<ul id="publication-source" class="publication-source" hidden>
+  <li data-type="journal" data-year="2024" data-date="2024-08">
+    <p><code>2024/08</code> <strong>Wentao Wu</strong>, Yibo Zhang, Weidong Zhang, Ruihang Ji, and Hongtian Chen, ''Saturation-Tolerant Tunnel Prescribed Control for Vessel-Train Formation of Underactuated MSVs,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25">IEEE Trans. Veh. Tech.</a></em>, Aug. 2024, Accepted. [中科院 2区, JCR 1区, Top, IF: 6.8] <a href="/assets/papers/SCI/WuWentao-2024-IEEE-TVT.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2024" data-date="2024-07">
+    <p><code>2024/07</code> Zhenhua Li, Hongtian Chen, Hak-Keung Lam, <strong>Wentao Wu</strong>, and Weidong Zhang*, ''<a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91">Switched Command-Filtered-Based Adaptive Fuzzy Output-Feedback Funnel Control for Switched Nonlinear MIMO Delayed Systems</a>,'' <em>IEEE Trans. Fuzzy Syst.</em>, Jul. 2024, doi: 10.1109/TFUZZ.2024.3434711. [中科院 1区, JCR 1区, Top, IF: 11.9] <a href="/assets/papers/SCI/WuWentao-2024-IEEE-TFS.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2024" data-date="2024-03">
+    <p><code>2024/03</code> <strong>Wentao Wu</strong>, Yibo Zhang, Zehua Jia, Jun-Guo Lu, and Weidong Zhang*, ''<a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91">Adaptive Fault-Tolerant Fuzzy Containment Control for Networked Autonomous Surface Vehicles: A Noncooperative Game Approach</a>,'' <em>IEEE Trans. Fuzzy Syst.</em>, Mar. 2024, doi: 10.1109/TFUZZ.2024.3386849. [中科院 1区, JCR 1区, Top, IF: 11.9] <a href="/assets/papers/SCI/WuWentao-2024-IEEE-TFS.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2024-IEEE-TFS.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2024" data-date="2024-02">
+    <p><code>2024/02</code> Di Wu, Yibo Zhang, <strong>Wentao Wu</strong>, Edmond Q. Wu, and Weidong Zhang, ''<a href="https://ieeexplore.ieee.org/document/10462491">Tunnel Prescribed Performance Control for Distributed Path Maneuvering of Multi-UAV Swarms via Distributed Neural Predictor</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8920">IEEE Trans. Circuits Syst. II Express Briefs</a></em>, Feb. 2024, doi: 10.1109/TCSII.2024.3371981. [中科院 2区, JCR 2区, Top, IF: 4.4] <a href="/assets/papers/SCI/WuDi-2024-IEEE-TCSII.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2024" data-date="2024-02">
+    <p><code>2024/02</code> Zhenhua Li, Hongtian Chen, <strong>Wentao Wu</strong>, and Weidong Zhang, ''<a href="https://ieeexplore.ieee.org/document/10449447">Dynamic Output Feedback Fault-Tolerant Control for Switched Vehicle Active Suspension Delayed Systems</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25">IEEE Trans. Veh. Tech.</a></em>, Feb. 2024, doi: 10.1109/TVT.2024.3370094. [中科院 2区, JCR 1区, Top, IF: 6.8] <a href="/assets/papers/SCI/LiZhenhua-2024-IEEE-TVT.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-12">
+    <p><code>2023/12</code> Yibo Zhang, <strong>Wentao Wu</strong>, Weixing Chen, Haibo Lu, and Weidong Zhang*, ''<a href="https://ieeexplore.ieee.org/document/10416809">Output-Feedback Consensus Maneuvering of Uncertain MIMO Strict-Feedback Multiagent Systems Based on a High-Order Neural Observer</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036">IEEE Trans. Cybern.</a></em>, Dec. 2023, doi: 10.1109/TCYB.2024.3351476. [中科院 1区, JCR 1区, Top, IF: 11.8] <a href="/assets/papers/SCI/ZhangYibo-2023-IEEE-TCYB.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-12">
+    <p><code>2023/12</code> <strong>Wentao Wu</strong>, Yibo Zhang, Zhenhua Li, Jun-Guo Lu, and Weidong Zhang*, ''<a href="https://ieeexplore.ieee.org/document/10414035">Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021">IEEE Trans. Syst. Man, Cybern., Syst.</a></em>, Dec. 2023, doi: 10.1109/TSMC.2023.3345847. [中科院 1区, JCR 1区, Top, IF: 8.7] <a href="/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-12">
+    <p><code>2023/12</code> Yibo Zhang, Di Wu, Peng Cheng, <strong>Wentao Wu</strong>, and Weidong Zhang, ''<a href="https://www.sciencedirect.com/science/article/pii/S0029801823029256?dgcid=coauthor">Robust Adaptive Fault-tolerant Control for Path Maneuvering of Autonomous Surface Vehicles with Actuator Faults Based on the Noncooperative Game Strategy</a>,'' <em><a href="https://www.sciencedirect.com/journal/ocean-engineering">Ocean. Eng.</a></em>, Dec. 2023, doi: 10.1016/j.oceaneng.2023.116541. [中科院 2区, JCR 1区, Top, IF: 5.0] <a href="/assets/papers/SCI/ZhangYibo-2023-OE.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:YOwf2qJgpHMC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-09">
+    <p><code>2023/09</code> <strong>Wentao Wu</strong>, Ruihang Ji, Weidong Zhang, and Yibo Zhang, ''<a href="https://ieeexplore.ieee.org/document/10292769">Transient-Reinforced Tunnel Coordinated Control of Underactuated Marine Surface Vehicles with Actuator Faults</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979">IEEE Trans. Intell. Transp. Syst.</a></em>, 2023, doi: 10.1109/TITS.2023.3324346. [中科院 1区, JCR 1区, Top, IF: 8.5] <a href="/assets/papers/SCI/WuWentao-2023-IEEE-TITS.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2023-IEEE-TITS.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-08">
+    <p><code>2023/08</code> <strong>Wentao Wu</strong>, Di Wu, Yibo Zhang, Shukang Chen, and Weidong Zhang, ''<a href="/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf">Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570654">IEEE/CAA J. Autom. Sinica</a></em>, 2023, doi: 10.1109/JAS.2023.123864. [中科院 1区, JCR 1区, Top, IF: 11.8] <a href="/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a> <a href="/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video" alt="Video badge"></a> <a href="/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASb.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Expb--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2023" data-date="2023-02">
+    <p><code>2023/02</code> Yibo Zhang, <strong>Wentao Wu</strong>, Jinhui Lu, and Weidong Zhang, ''<a href="https://ieeexplore.ieee.org/abstract/document/10059139">Neural Predictor-based Dynamic Surface Parallel Control for MIMO Uncertain Nonlinear Strict-feedback Systems</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8920">IEEE Trans. Circuits Syst. II Express Briefs</a></em>, Feb. 2023, doi: 10.1109/TCSII.2023.3252562. [中科院 2区, JCR 2区, Top, IF: 4.4] <a href="/assets/papers/SCI/ZhangYibo-2023-IEEE-TCASII.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:8k81kl-MbHgC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-11">
+    <p><code>2022/11</code> Yibo Zhang, <strong>Wentao Wu</strong>, and Weidong Zhang, ''<a href="https://ieeexplore.ieee.org/abstract/document/9950329">Noncooperative Game-Based Cooperative Maneuvering of Intelligent Surface Vehicles Via Accelerated Learning-Based Neural Predictors</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857">IEEE Trans. Intell. Veh.</a></em>, vol. 8, no. 3, pp. 2212-2221, Mar. 2023. [中科院 1区, JCR 1区, IF: 8.2] <a href="/assets/papers/SCI/ZhangYibo-2022-IEEE-TIV.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:KlAtU1dfN6UC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-10">
+    <p><code>2022/10</code> <strong>Wentao Wu</strong>, Yibo Zhang, Weidong Zhang, and Wei Xie, ''<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497">Distributed Finite-Time Performance-Prescribed Time-Varying Formation Control of Autonomous Surface Vehicles with Saturated Inputs</a>,'' <em><a href="https://www.sciencedirect.com/journal/ocean-engineering">Ocean. Eng.</a></em>, vol. 266, 12866, Oct. 2022. [中科院 2区, JCR 1区, Top, IF: 5.0] <a href="/assets/papers/SCI/WuWentao-2022-OEb.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2022-OEb.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:LkGwnXOMwfcC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-09">
+    <p><code>2022/09</code> <strong>Wentao Wu</strong>, Yibo Zhang, Weidong Zhang, and Wei Xie, ''<a href="https://ieeexplore.ieee.org/abstract/document/9900363">Output-Feedback Finite-Time Safety-Critical Coordinated Control of Path-Guided Marine Surface Vehicles Based on Neurodynamic Optimization</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021">IEEE Trans. Syst. Man, Cybern., Syst.</a></em>, vol. 53, no. 3, pp. 1788-1800, Sep. 2022. [中科院 1区, JCR 1区, Top, IF: 8.7] <a href="/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ufrVoPGSRksC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-08">
+    <p><code>2022/08</code> Xiangxuan Ren, Min Li, Zhi Liu, Zhenhua Li, <strong>Wentao Wu</strong>, Lin Bai, and Weidong Zhang, ''<a href="https://ieeexplore.ieee.org/abstract/document/9878245">Curiosity-Driven Attention for Anomaly Road Obstacles Segmentation in Autonomous Driving</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857">IEEE Trans. Intell. Veh.</a></em>, vol. 8, no. 3, pp. 2233-2243, Mar. 2023. [中科院 1区, JCR 1区, IF: 8.2] <a href="/assets/papers/SCI/RenXiangxuan-2022-IEEE-TIV.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:Y0pCki6q_DkC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-04">
+    <p><code>2022/04</code> <strong>Wentao Wu</strong>, Zhouhua Peng, Lu Liu, and Dan Wang, ''<a href="https://ieeexplore.ieee.org/abstract/document/9762043">A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857">IEEE Trans. Intell. Veh.</a></em>, vol. 7, no. 3, pp. 627-637, Sep. 2022. [中科院 1区, JCR 1区, IF: 8.2] <a href="/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <a href="/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video" alt="Video badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:UeHWp8X0CEIC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2022" data-date="2022-01">
+    <p><code>2022/01</code> <strong>Wentao Wu</strong>, Zhouhua Peng, Dan Wang, Lu Liu, and Gu Nan, ''<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445">Anti-Disturbance Leader–Follower Synchronization Control of Marine Vessels for Underway Replenishment Based on Robust Exact Differentiators</a>,'' <em><a href="https://www.sciencedirect.com/journal/ocean-engineering">Ocean. Eng.</a></em>, vol. 248, 110686, 2022. [中科院 2区, JCR 1区, Top, IF: 5.0] <a href="/assets/papers/SCI/WuWentao-2022-OE.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:qjMakFHDy7sC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2021" data-date="2021-04">
+    <p><code>2021/04</code> <strong>Wentao Wu</strong>, Zhouhua Peng, Dan Wang, Lu Liu, and Qing-Long Han*, ''<a href="https://ieeexplore.ieee.org/abstract/document/9440777">Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results</a>,'' <em><a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036">IEEE Trans. Cybern.</a></em>, vol. 52, no. 10, pp. 10937-10947, Oct. 2022. [中科院 1区, JCR 1区, Top, IF: 11.8] <a href="/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:W7OEmFMy1HYC'></span></strong>
+  </li>
+  <li data-type="review" data-year="2021" data-date="2021-01">
+    <p><code>2021/01</code> 彭周华，<strong>吴文涛</strong>，王丹，刘陆, "<a href="http://zgjcyj.xml-journal.net/cn/article/doi/10.19693/j.issn.1673-3185.01923">多无人艇集群协同控制研究进展与未来趋势</a>," <em><a href="http://zgjcyj.xml-journal.net/index.htm">中国舰船研究</a></em>, vol. 61, no. 1, pp. 51-64, 2021. <a href="/assets/papers/ZWHX/J-核心-2020-Pengzhouhua-中国舰船研究.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:0EnyYjriUFMC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2021" data-date="2021-01">
+    <p><code>2021/01</code> <strong>吴文涛</strong>, 彭周华*, 王丹, 刘陆, 姜继洲, 任帅, ''<a href="http://www.ship-research.com/cn/article/doi/10.19693/j.issn.1673-3185.01665?viewType=HTML">基于扩张状态观测器的双桨推进无人艇抗干扰目标跟踪控制</a>,'' <em><a href="http://zgjcyj.xml-journal.net/index.htm">中国舰船研究</a></em>, vol. 61, no. 1, pp. 128-135, 2021. <a href="/assets/papers/ZWHX/J-核心-2020-WuWentao-中国舰船研究a.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:Tyk-4Ss8FVUC'></span></strong>
+  </li>
+  <li data-type="journal" data-year="2020" data-date="2020-09">
+    <p><code>2020/09</code> <strong>吴文涛</strong>，古楠，彭周华，刘陆，王丹, ''<a href="https://web.archive.org/web/20201126111532id_/http://html.rhhz.net/ZGJCYJ/html/2020-1-21.htm">多领航者导引无人船集群的分布式时变队形控制</a>,'' <em><a href="http://zgjcyj.xml-journal.net/index.htm">中国舰船研究</a></em>, vol. 15, no. 1, pp. 21-30, 2020. <a href="/assets/papers/ZWHX/J-核心-2020-WuWentao-中国舰船研究b.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+    <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:5nxA0vEk-isC'></span></strong>
+  </li>
+  <li data-type="conference" data-year="2024" data-date="2024-07">
+    <p><code>2024/07</code> Yibo Zhang*, <strong>Wentao Wu</strong>, Tao Xie, Peng Cheng, Di Wu, and Weidong Zhang, "<a href="https://review.cacpaper.com/914/paper">Maneuvering Control of Uncertain Nonlinear Systems: An Output Regulation Viewpoint</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/1000188/all-proceedings">2024 63rd IEEE Conference on Decision and Control (CDC)</a></em>, 2024. <a href=""><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="conference" data-year="2023" data-date="2023-09">
+    <p><code>2023/09</code> <strong>Wentao Wu</strong>, Chenming Zhang, Zhenhua Li, Weidong Zhang, and Yibo Zhang, "Finite-time Extended State Observer-Based Performance-Critical Control for Uncertain MIMO Nonlinear Systems," <em><a href="http://ccsicc.c2.org.cn/">2023 7th Chinese Conference on Swarm Intelligence and Cooperative Control (CCSICC)</a></em>, Sept. 2023. <a href="/assets/papers/EI/2023-CCSICC.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a> <img src="https://img.shields.io/badge/Best%20Student%20Paper%20Nomination%20Award-8A2BE2" alt="Best Student Paper Nomination Award"></p>
+  </li>
+  <li data-type="conference" data-year="2023" data-date="2023-09">
+    <p><code>2023/09</code> <strong>Wentao Wu</strong>, Zhenhua Li, Yibo Zhang, and Weidong Zhang, "<a href="https://review.cacpaper.com/914/paper">Noncooperative Containment Control for Multiple Unmanned Surface Vehicles With Improved Extended State Observer</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/10054511/proceeding">2023 China Automation Congress (CAC)</a></em>, 2023. <a href="/assets/papers/EI/2023-CAC.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="conference" data-year="2022" data-date="2022-09">
+    <p><code>2022/09</code> Yibo Zhang, <strong>Wentao Wu</strong>, Di Wu, Yuanhui Wang, Weidong Zhang, "<a href="https://ieeexplore.ieee.org/abstract/document/10056005">DSC-based Parallel Control for Consensus Maneuvering of Multi-agent Systems subject to Unmatched Uncertainties based on Distributed Nash Equilibrium Seeking</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/10054511/proceeding">2022 China Automation Congress (CAC)</a></em>, IEEE, pp. 1125-1130, 2022. <a href="/assets/papers/EI/ZhangYibo-2022-CAC.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="conference" data-year="2022" data-date="2022-04">
+    <p><code>2022/04</code> <strong>Wentao Wu</strong>, Yibo Zhang, Weidong Zhang, and Di Wu, "<a href="https://ieeexplore.ieee.org/abstract/document/9902172">Safety-Certified Consensus Control of Multi-Agent Systems Based on Finite-Time Control Barrier Function</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/9901509/proceeding">2022 41th Chinese Control Conference (CCC)</a></em>, IEEE, pp. 4661-4665, 2022. <a href="/assets/papers/EI/2022-CCC.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="conference" data-year="2020" data-date="2020-04">
+    <p><code>2020/04</code> <strong>Wentao Wu</strong>, Dan Wang, Mingao Lv, Jizhou Jiang, Lu Liu, and Zhouhua Peng, "<a href="https://ieeexplore.ieee.org/abstract/document/9189015">Event-triggered LOS Guidance for Path Following of an Unmanned Surface Vehicle over Wireless Network</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/9181388/proceeding">2020 39th Chinese Control Conference (CCC)</a></em>, IEEE, pp. 4475-4480, 2020. <a href="/assets/papers/EI/2020-CCC.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="conference" data-year="2020" data-date="2020-04">
+    <p><code>2020/04</code> Haoliang Wang, Jizhou Jiang, <strong>Wentao Wu</strong>, Lu Liu, Dan Wang, Zhouhua Peng, "<a href="https://ieeexplore.ieee.org/abstract/document/9230166">Robust distributed guidance and control of multiple autonomous surface vehicles based on extended state observers and finite-set model predictive control</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/9229471/proceeding">2020 5th International Conference on Automation, Control and Robotics Engineering (CACRE)</a></em>, IEEE, pp. 235-239, 2020. <a href="/assets/papers/EI/WangHaoliang-2020-CACRE.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
+  </li>
+  <li data-type="patent" data-year="2023" data-date="2023-12">
+    <p><code>2023/12 [已受理]</code> <strong>吴文涛</strong>，张卫东，张义博，李镇华，李兰. 一种无人船容饱和预设性能船舶列车编队控制系统及方法[P]. 上海市：202311691127.8, 2023-12-11.</p>
+  </li>
+  <li data-type="patent" data-year="2023" data-date="2023-12">
+    <p><code>2023/12 [已公开]</code> 张卫东，郑建文, <strong>吴文涛</strong>等. 一种基于领导者协同的多无人船编队的严格安全控制方法[P]. 上海市：CN115903800A, 2023-04-04.</p>
+  </li>
+  <li data-type="patent" data-year="2023" data-date="2023-12">
+    <p><code>2023/12 [已授权]</code> 王丹, 张宝, 孙邱越, 彭周华, 刘陆, 李铁山, <strong>吴文涛</strong>, 姜继州. 一种海洋机器人轨迹跟踪控制结构的设计方法[P]. 辽宁省：CN110262513B, 2022-01-28.</p>
+  </li>
+</ul>
 
-### Review Papers
-- ``2021/01`` 彭周华，**吴文涛**，王丹， 刘陆, "[多无人艇集群协同控制研究进展与未来趋势](http://zgjcyj.xml-journal.net/cn/article/doi/10.19693/j.issn.1673-3185.01923)," [*中国舰船研究*](http://zgjcyj.xml-journal.net/index.htm), vol. 61, no. 1, pp. 51-64, 2021. 
- [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/ZWHX/J-核心-2020-Pengzhouhua-中国舰船研究.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:0EnyYjriUFMC'></span></strong>
+<style>
+.publication-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.publication-controls label {
+  font-weight: 600;
+}
+.publication-controls select,
+.publication-controls button {
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.4rem;
+  border: 1px solid #d0d7de;
+  background-color: #fff;
+  font-size: 0.95rem;
+}
+.publication-controls button {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+.publication-controls button:hover {
+  background-color: #f6f8fa;
+}
+ol.publication-list {
+  list-style: none;
+  padding-left: 0;
+  counter-reset: publication-counter;
+}
+ol.publication-list > li {
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+.publication-index {
+  font-weight: 600;
+  margin-right: 0.5rem;
+  color: #57606a;
+}
+.publication-empty {
+  color: #57606a;
+  font-style: italic;
+}
+.publication-source[hidden] {
+  display: none !important;
+}
+</style>
 
-### Journal Papers
-
-- ``2024/08`` **Wentao Wu**, Yibo Zhang, Weidong Zhang, Ruihang Ji, and Hongtian Chen, ''[Saturation-Tolerant Tunnel Prescribed Control for
-Vessel-Train Formation of Underactuated MSVs](),'' [*IEEE Trans. Veh. Tech.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25), Aug. 2024, Accepted. [中科院 2区, JCR 1区, Top, IF: 6.8] [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2024-IEEE-TVT.pdf) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-
-- ``2024/07``  Zhenhua Li, Hongtian Chen, Hak-Keung Lam, **Wentao Wu**, and Weidong Zhang*, ''[Switched Command-Filtered-Based Adaptive Fuzzy Output-Feedback Funnel Control for Switched Nonlinear MIMO Delayed Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91),'' [*IEEE Trans. Fuzzy Syst.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91), Jul. 2024, doi:10.1109/TFUZZ.2024.3434711. [中科院 1区, JCR 1区, Top, IF: 11.9]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2024-IEEE-TFS.pdf) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-- ``2024/03`` **Wentao Wu**, Yibo Zhang, Zehua Jia, Jun-Guo Lu, and Weidong Zhang*, ''[Adaptive Fault-Tolerant Fuzzy Containment Control for Networked Autonomous Surface Vehicles: A Noncooperative Game Approach](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91),'' [*IEEE Trans. Fuzzy Syst.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=91), Mar. 2024, doi: 10.1109/TFUZZ.2024.3386849. [中科院 1区, JCR 1区, Top, IF: 11.9]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2024-IEEE-TFS.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2024-IEEE-TFS.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-- ``2024/02`` Di Wu, Yibo Zhang, **Wentao Wu**, Edmond Q. Wu, and Weidong Zhang, ''[Tunnel Prescribed Performance Control for Distributed Path Maneuvering of Multi-UAV Swarms via Distributed Neural Predictor](https://ieeexplore.ieee.org/document/10462491),'' [*IEEE Trans. Circuits Syst. II Express Briefs*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8920), Feb. 2024, doi: 10.1109/TCSII.2024.3371981. [中科院 2区, JCR 2区, Top, IF: 4.4] [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuDi-2024-IEEE-TCSII.pdf) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-- ``2024/02`` Zhenhua Li, Hongtian Chen, **Wentao Wu**, and Weidong Zhang, ''[Dynamic Output Feedback Fault-Tolerant Control for Switched Vehicle Active Suspension Delayed Systems](https://ieeexplore.ieee.org/document/10449447),'' [*IEEE Trans. Veh. Tech.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25), Feb. 2024, doi: 10.1109/TVT.2024.3370094. [中科院 2区, JCR 1区, Top, IF: 6.8] [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/LiZhenhua-2024-IEEE-TVT.pdf) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-
-- ``2023/12`` Yibo Zhang, **Wentao Wu**, Weixing Chen, Haibo Lu, and Weidong Zhang*, ''[Output-Feedback Consensus Maneuvering of Uncertain MIMO Strict-Feedback Multiagent Systems Based on a High-Order Neural Observer](https://ieeexplore.ieee.org/document/10416809),'' [*IEEE Trans. Cybern.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036), Dec. 2023, doi: 10.1109/TCYB.2024.3351476. [中科院 1区, JCR 1区, Top, IF: 11.8]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/ZhangYibo-2023-IEEE-TCYB.pdf) 
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-
-- ``2023/12`` **Wentao Wu**, Yibo Zhang, Zhenhua Li, Jun-Guo Lu, and Weidong Zhang*, ''[Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach](https://ieeexplore.ieee.org/document/10414035),'' [*IEEE Trans. Syst. Man, Cybern. , Syst.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021), Dec. 2023, doi: 10.1109/TSMC.2023.3345847. [中科院 1区, JCR 1区, Top, IF: 8.7]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
-- ``2023/12`` Yibo Zhang, Di Wu, Peng Cheng, **Wentao Wu**, and Weidong Zhang, ''[Robust Adaptive Fault-tolerant Control for Path Maneuvering of Autonomous Surface Vehicles with Actuator Faults Based on the Noncooperative Game Strategy](https://www.sciencedirect.com/science/article/pii/S0029801823029256?dgcid=coauthor),'' [*Ocean. Eng.*](https://www.sciencedirect.com/journal/ocean-engineering), Dec. 2023, doi: 10.1016/j.oceaneng.2023.116541. [中科院 2区, JCR 1区, Top, IF: 5.0]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/ZhangYibo-2023-OE.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:YOwf2qJgpHMC'></span></strong>
-
-- ``2023/09`` **Wentao Wu**, Ruihang Ji, Weidong Zhang, and Yibo Zhang, ''[Transient-Reinforced Tunnel Coordinated Control of Underactuated Marine Surface Vehicles with Actuator Faults](https://ieeexplore.ieee.org/document/10292769),'' [*IEEE Trans. Intell. Transp. Syst.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979), 2023, doi: 10.1109/TITS.2023.3324346. [中科院 1区, JCR 1区, Top, IF: 8.5]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TITS.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TITS.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
-
-
-- ``2023/08`` **Wentao Wu**, Di Wu, Yibo Zhang, Shukang Chen, and Weidong Zhang, ''[Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf),'' [*IEEE/CAA J. Autom. Sinica*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570654), 2023, doi: 10.1109/JAS.2023.123864. [中科院 1区, JCR 1区, Top, IF: 11.8]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.mp4)  [![Video-Expa](https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4)  [![Video-Expb](https://img.shields.io/badge/%F0%9F%A4%97%20Expb--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASb.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
-
-
-- ``2023/02`` Yibo Zhang, **Wentao Wu**, Jinhui Lu, and Weidong Zhang, ''[Neural Predictor-based Dynamic Surface Parallel Control for MIMO Uncertain Nonlinear Strict-feedback Systems](https://ieeexplore.ieee.org/abstract/document/10059139),'' [*IEEE Trans. Circuits Syst. II Express Briefs*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8920), Feb. 2023, doi: 10.1109/TCSII.2023.3252562. [中科院 2区, JCR 2区, Top, IF: 4.4]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/ZhangYibo-2023-IEEE-TCASII.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:8k81kl-MbHgC'></span></strong>
-
-
-- ``2022/11`` Yibo Zhang, **Wentao Wu**, and Weidong Zhang, ''[Noncooperative Game-Based Cooperative Maneuvering of Intelligent Surface Vehicles Via Accelerated Learning-Based Neural Predictors](https://ieeexplore.ieee.org/abstract/document/9950329),'' [*IEEE Trans. Intell. Veh.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857), vol. 8, no. 3, pp. 2212-2221, Mar. 2023. [中科院 1区, JCR 1区, IF: 8.2]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/ZhangYibo-2022-IEEE-TIV.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:KlAtU1dfN6UC'></span></strong>
-
-
-- ``2022/10`` **Wentao Wu**, Yibo Zhang, Weidong Zhang, and Wei Xie, ''[Distributed Finite-Time Performance-Prescribed Time-Varying Formation Control of Autonomous Surface Vehicles with Saturated Inputs](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497),'' [*Ocean. Eng.*](https://www.sciencedirect.com/journal/ocean-engineering), vol. 266, pp. 12866, Oct. 2022. [中科院 2区, JCR 1区, Top, IF: 5.0]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-OEb.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-OEb.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:LkGwnXOMwfcC'></span></strong>
-
-
-- ``2022/09`` **Wentao Wu**, Yibo Zhang, Weidong Zhang, and Wei Xie, ''[Output-Feedback Finite-Time Safety-Critical Coordinated Control of Path-Guided Marine Surface Vehicles Based on Neurodynamic Optimization](https://ieeexplore.ieee.org/abstract/document/9900363),'' [*IEEE Trans. Syst. Man, Cybern., Syst.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021), vol. 53, no. 3, pp. 1788-1800, Sep. 2022. [中科院 1区, JCR 1区, Top, IF: 8.7]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ufrVoPGSRksC'></span></strong>
-
-- ``2022/08`` Xiangxuan Ren, Min Li, Zhi Liu, Zhenhua Li, **Wentao Wu**, Lin Bai, and Weidong Zhang, ''[Curiosity-Driven Attention for Anomaly Road Obstacles Segmentation in Autonomous Driving](https://ieeexplore.ieee.org/abstract/document/9878245),'' [*IEEE Trans. Intell. Veh.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857), vol. 8, no. 3, pp. 2233-2243, Mar. 2023. [中科院 1区, JCR 1区, IF: 8.2]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/RenXiangxuan-2022-IEEE-TIV.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:Y0pCki6q_DkC'></span></strong>
-
-- ``2022/04`` **Wentao Wu**, Zhouhua Peng, Lu Liu, and Dan Wang, ''[A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043),'' [*IEEE Trans. Intell. Veh.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857), vol. 7, no. 3, pp. 627-637, Sep. 2022. [中科院 1区, JCR 1区, IF: 8.2]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:UeHWp8X0CEIC'></span></strong>
-
-- ``2022/01`` **Wentao Wu**, Zhouhua Peng, Dan Wang, Lu Liu, and Gu Nan, ''[Anti-Disturbance Leader–Follower Synchronization Control of Marine Vessels for Underway Replenishment Based on Robust Exact Differentiators](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445),'' [*Ocean. Eng.*](https://www.sciencedirect.com/journal/ocean-engineering), vol. 248, pp. 110686, 2022. [中科院 2区, JCR 1区, Top, IF: 5.0]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-OE.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:qjMakFHDy7sC'></span></strong>
-
-- ``2021/04`` **Wentao Wu**, Zhouhua Peng, Dan Wang, Lu Liu, and Qing-Long Han*, ''[Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](https://ieeexplore.ieee.org/abstract/document/9440777),'' [*IEEE Trans. Cybern.*](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036), vol. 52, no. 10, pp. 10937-10947, Oct. 2022. [中科院 1区, JCR 1区, Top, IF: 11.8]  [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:W7OEmFMy1HYC'></span></strong>
-
-
-- ``2021/01`` **吴文涛**, 彭周华*, 王丹, 刘陆, 姜继洲, 任帅, ''[基于扩张状态观测器的双桨推进无人艇抗干扰目标跟踪控制](http://www.ship-research.com/cn/article/doi/10.19693/j.issn.1673-3185.01665?viewType=HTML),'' [*中国舰船研究*](http://zgjcyj.xml-journal.net/index.htm), vol. 61, no. 1, pp. 128-135, 2021. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/ZWHX/J-核心-2020-WuWentao-中国舰船研究a.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:Tyk-4Ss8FVUC'></span></strong>
-
-- ``2020/09`` **吴文涛**，古楠，彭周华，刘陆，王丹, ''[多领航者导引无人船集群的分布式时变队形控制](https://web.archive.org/web/20201126111532id_/http://html.rhhz.net/ZGJCYJ/html/2020-1-21.htm),'' [*中国舰船研究*](http://zgjcyj.xml-journal.net/index.htm), vol. 15, no. 1, pp. 21-30, 2020. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/ZWHX/J-核心-2020-WuWentao-中国舰船研究b.pdf)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:5nxA0vEk-isC'></span></strong>
-
-### Conference Papers
-- ``2024/07`` Yibo zhang*, **Wentao Wu**, Tao Xie, Peng Cheng, Di Wu, and Weidong Zhang, "[Maneuvering Control of Uncertain Nonlinear Systems: An Output Regulation Viewpoint](https://review.cacpaper.com/914/paper)," [*2024 63rd IEEE Conference on Decision and Control (CDC)*](https://ieeexplore.ieee.org/xpl/conhome/1000188/all-proceedings), 2024. [![PDF](https://img.shields.io/badge/Link-PDF-gree)]()
-
-- ``2023/09`` **Wentao Wu**, Chenming Zhang, Zhenhua Li, Weidong Zhang, and Yibo Zhang, "Finite-time Extended State Observer-Based Performance-Critical Control for Uncertain MIMO Nonlinear Systems," [*2023 7th Chinese Conference on Swarm Intelligence and Cooperative Control (CCSICC)*](http://ccsicc.c2.org.cn/), Sept., 2023. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/2023-CCSICC.pdf)  ![Awards](https://img.shields.io/badge/Best%20Student%20Paper%20Nomination%20Award-8A2BE2)
-
-- ``2023/09`` **Wentao Wu**, Zhenhua Li, Yibo Zhang, and Weidong Zhang, "[Noncooperative Containment Control for Multiple Unmanned Surface Vehicles With Improved Extended State Observer](https://review.cacpaper.com/914/paper)," [*2023 China Automation Congress (CAC)*](https://ieeexplore.ieee.org/xpl/conhome/10054511/proceeding), 2023. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/2023-CAC.pdf)
-
-- ``2022/09`` Yibo Zhang, **Wentao Wu**, Di Wu, Yuanhui Wang, Weidong Zhang, "[DSC-based Parallel Control for Consensus Maneuvering of Multi-agent Systems subject to Unmatched Uncertainties based on Distributed Nash Equilibrium Seeking](https://ieeexplore.ieee.org/abstract/document/10056005),” [*2022 China Automation Congress (CAC)*](https://ieeexplore.ieee.org/xpl/conhome/10054511/proceeding), IEEE, pp. 1125-1130, 2022. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/ZhangYibo-2022-CAC.pdf)
-
-- ``2022/04`` **Wentao Wu**, Yibo Zhang, Weidong Zhang, and Di Wu, "[Safety-Certified Consensus Control of Multi-Agent Systems Based on Finite-Time Control Barrier Function](https://ieeexplore.ieee.org/abstract/document/9902172),” [*2022 41th Chinese Control Conference (CCC)*](https://ieeexplore.ieee.org/xpl/conhome/9901509/proceeding), IEEE, pp. 4661-4665, 2022. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/2022-CCC.pdf)
-
-- ``2020/04`` **Wentao Wu**, Dan Wang, Mingao Lv, Jizhou Jiang, Lu Liu, and Zhouhua Peng, "[Event-triggered LOS Guidance for Path Following of an Unmanned Surface Vehicle over Wireless Network](https://ieeexplore.ieee.org/abstract/document/9189015),” [*2020 39th Chinese Control Conference (CCC)*](https://ieeexplore.ieee.org/xpl/conhome/9181388/proceeding), IEEE, pp. 4475-4480, 2020. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/2020-CCC.pdf)
-
-- ``2020/04`` Haoliang Wang, Jizhou Jiang, **Wentao Wu**, Lu Liu, Dan Wang, Zhouhua Peng, "[Robust distributed guidance and control of multiple autonomous surface vehicles based on extended state observers and finite-set model predictive control](https://ieeexplore.ieee.org/abstract/document/9230166),” [*2020 5th International Conference on Automation, Control and Robotics Engineering (CACRE)*](https://ieeexplore.ieee.org/xpl/conhome/9229471/proceeding), IEEE, pp. 235-239, 2020. [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/EI/WangHaoliang-2020-CACRE.pdf)
-
-### Patents
-
-- ``2023/12 [已受理]`` **吴文涛**，张卫东，张义博，李镇华，李兰. 一种无人船容饱和预设性能船舶列车编队控制系统及方法[P]. 上海市：202311691127.8, 2023-12-11. 
-
-- ``2023/12 [已公开]`` 张卫东，郑建文, **吴文涛**等. 一种基于领导者协同的多无人船编队的严格安全控制方法[P]. 上海市：CN115903800A,2023-04-04.
-
-- ``2023/12 [已授权]`` 王丹, 张宝, 孙邱越, 彭周华, 刘陆, 李铁山, **吴文涛**, 姜继州. 一种海洋机器人轨迹跟踪控制结构的设计方法[P]. 辽宁省：CN110262513B, 2022-01-28.
+<script src="{{ '/assets/js/publications.js' | relative_url }}"></script>

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -1,0 +1,140 @@
+(function () {
+  function ready(fn) {
+    if (document.readyState !== 'loading') {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  ready(function () {
+    var sourceList = document.querySelector('#publication-source');
+    var listEl = document.querySelector('#publication-list');
+    var typeSelect = document.querySelector('#publication-type-filter');
+    var yearSelect = document.querySelector('#publication-year-filter');
+    var sortButton = document.querySelector('#publication-year-sort');
+
+    if (!sourceList || !listEl || !typeSelect || !yearSelect || !sortButton) {
+      return;
+    }
+
+    var typeLabels = {
+      journal: '期刊',
+      conference: '会议',
+      patent: '专利',
+      review: '综述'
+    };
+
+    var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
+      var year = parseInt(item.getAttribute('data-year'), 10);
+      return {
+        type: item.getAttribute('data-type') || 'other',
+        year: isNaN(year) ? null : year,
+        date: item.getAttribute('data-date') || '',
+        content: item.innerHTML.trim()
+      };
+    });
+
+    var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
+      return pub.type;
+    }).filter(Boolean)));
+
+    uniqueTypes.sort(function (a, b) {
+      var labelA = typeLabels[a] || a;
+      var labelB = typeLabels[b] || b;
+      return labelA.localeCompare(labelB, 'zh-Hans-CN');
+    });
+
+    typeSelect.innerHTML = '<option value="all">全部类型</option>' + uniqueTypes.map(function (type) {
+      var label = typeLabels[type] || type;
+      return '<option value="' + type + '">' + label + '</option>';
+    }).join('');
+
+    function updateYearOptions() {
+      var years = Array.from(new Set(publications.map(function (pub) {
+        return pub.year;
+      }).filter(Boolean)));
+      years.sort(function (a, b) { return b - a; });
+      yearSelect.innerHTML = '<option value="all">全部年份</option>' + years.map(function (year) {
+        return '<option value="' + year + '">' + year + '</option>';
+      }).join('');
+    }
+
+    updateYearOptions();
+
+    var sortOrder = 'desc';
+
+    function normalizeDate(dateStr, year) {
+      if (!dateStr) {
+        return year ? String(year) + '-01-01' : '0000-01-01';
+      }
+      var normalized = dateStr.trim();
+      if (/^\d{4}$/.test(normalized)) {
+        return normalized + '-12-31';
+      }
+      if (/^\d{4}-\d{2}$/.test(normalized)) {
+        return normalized + '-01';
+      }
+      if (/^\d{4}\/\d{2}/.test(normalized)) {
+        var parts = normalized.split('/');
+        return parts[0] + '-' + parts[1] + '-01';
+      }
+      return normalized;
+    }
+
+    function render() {
+      var selectedType = typeSelect.value;
+      var selectedYear = yearSelect.value;
+
+      var filtered = publications.filter(function (pub) {
+        if (selectedType !== 'all' && pub.type !== selectedType) {
+          return false;
+        }
+        if (selectedYear !== 'all' && String(pub.year) !== selectedYear) {
+          return false;
+        }
+        return true;
+      });
+
+      filtered.sort(function (a, b) {
+        var dateA = normalizeDate(a.date, a.year);
+        var dateB = normalizeDate(b.date, b.year);
+        if (dateA === dateB) {
+          return 0;
+        }
+        if (sortOrder === 'desc') {
+          return dateA > dateB ? -1 : 1;
+        }
+        return dateA > dateB ? 1 : -1;
+      });
+
+      listEl.innerHTML = '';
+
+      if (filtered.length === 0) {
+        var emptyItem = document.createElement('li');
+        emptyItem.className = 'publication-empty';
+        emptyItem.textContent = '暂无符合条件的文献。';
+        listEl.appendChild(emptyItem);
+        return;
+      }
+
+      var total = filtered.length;
+      filtered.forEach(function (pub, index) {
+        var li = document.createElement('li');
+        var number = sortOrder === 'desc' ? total - index : index + 1;
+        li.innerHTML = '<span class="publication-index">[' + number + ']</span>' + pub.content;
+        listEl.appendChild(li);
+      });
+    }
+
+    typeSelect.addEventListener('change', render);
+    yearSelect.addEventListener('change', render);
+    sortButton.addEventListener('click', function () {
+      sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
+      sortButton.textContent = sortOrder === 'desc' ? '按年份 ↓' : '按年份 ↑';
+      render();
+    });
+
+    render();
+  });
+})();


### PR DESCRIPTION
## Summary
- restructure the publications include with a filter toolbar, hidden source data, and styles so entries render in a numbered list sorted by date by default
- add publication records for recent journal, conference, review, and patent items so filtering can cover all content
- create a small JavaScript module to build the publication list, support type/year filters, toggle sort order, and manage the descending bracket numbering

## Testing
- bundle exec jekyll build *(fails: bundler is unable to install dependencies because of HTTP 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ce42b1c7f4832da7033dee7f2d99f1