### PR TITLE
Refine publications layout and formatting

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -209,15 +209,6 @@
   <li data-type="conference" data-year="2020" data-date="2020-04">
     <p>Haoliang Wang, Jizhou Jiang, <strong>Wentao Wu</strong>, Lu Liu, Dan Wang, Zhouhua Peng, "<a href="https://ieeexplore.ieee.org/abstract/document/9230166">Robust distributed guidance and control of multiple autonomous surface vehicles based on extended state observers and finite-set model predictive control</a>," <em><a href="https://ieeexplore.ieee.org/xpl/conhome/9229471/proceeding">2020 5th International Conference on Automation, Control and Robotics Engineering (CACRE)</a></em>, IEEE, pp. 235-239, 2020. <a href="/assets/papers/EI/WangHaoliang-2020-CACRE.pdf"><img src="https://img.shields.io/badge/Link-PDF-gree" alt="PDF badge"></a></p>
   </li>
-  <li data-type="patent" data-year="2023" data-date="2023-12">
-    <p><strong>吴文涛</strong>，张卫东，张义博，李镇华，李兰. 一种无人船容饱和预设性能船舶列车编队控制系统及方法[P]. 上海市：202311691127.8, 2023-12-11.</p>
-  </li>
-  <li data-type="patent" data-year="2023" data-date="2023-12">
-    <p>张卫东，郑建文, <strong>吴文涛</strong>等. 一种基于领导者协同的多无人船编队的严格安全控制方法[P]. 上海市：CN115903800A, 2023-04-04.</p>
-  </li>
-  <li data-type="patent" data-year="2023" data-date="2023-12">
-    <p>王丹, 张宝, 孙邱越, 彭周华, 刘陆, 李铁山, <strong>吴文涛</strong>, 姜继州. 一种海洋机器人轨迹跟踪控制结构的设计方法[P]. 辽宁省：CN110262513B, 2022-01-28.</p>
-  </li>
 </ul>
 
 <div id="citation-modal" class="citation-modal" hidden>
@@ -238,15 +229,11 @@
 
 <style>
 .publication-controls {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 0.75rem;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 1.5rem;
-  padding: 0.75rem;
-  border-radius: 0.6rem;
-  border: 1px solid #d0d7de;
-  background: #f6f8fa;
 }
 
 .publication-controls select,
@@ -258,11 +245,17 @@
   background-color: #fff;
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 2.75rem;
+}
+
+.publication-controls select,
+.publication-controls button {
+  width: 100%;
 }
 
 .publication-search {
-  flex: 1 1 240px;
-  min-width: 200px;
+  width: 100%;
+  min-width: 0;
 }
 
 .publication-controls select:focus,
@@ -278,10 +271,24 @@
   background-color: #0969da;
   color: #fff;
   border-color: #0969da;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .publication-controls button:hover {
   background-color: #0550ae;
+}
+
+.publication-resources {
+  margin-top: 0.6rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.publication-resources a {
+  display: inline-flex;
 }
 
 ol.publication-list {
@@ -448,7 +455,7 @@ ol.publication-list > li {
 
 @media (max-width: 600px) {
   .publication-controls {
-    padding: 0.75rem 0.65rem;
+    grid-template-columns: 1fr;
   }
 
   ol.publication-list > li {

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -28,11 +28,10 @@
       journal: 'journal papers',
       conference: 'conference papers',
       review: 'review papers',
-      patent: 'patents',
       preprint: 'preprints'
     };
 
-    var typeOrder = ['journal', 'conference', 'review', 'patent', 'preprint'];
+    var typeOrder = ['journal', 'conference', 'review', 'preprint'];
 
     var searchTerm = '';
     var activeCitationFormat = 'gbt';
@@ -57,6 +56,86 @@
         return '“' + title.trim().replace(/[\s,;:.]+$/, '') + '”';
       });
       return replaced;
+    }
+
+    function extractPublicationMeta(html) {
+      var wrapper = document.createElement('div');
+      wrapper.innerHTML = html;
+      var firstParagraph = wrapper.querySelector('p');
+      var primaryLink = null;
+      var badgeLinks = [];
+      var extraLinks = [];
+
+      if (firstParagraph) {
+        Array.prototype.slice.call(firstParagraph.querySelectorAll('a')).forEach(function (anchor) {
+          if (anchor.querySelector('img')) {
+            badgeLinks.push(anchor.cloneNode(true));
+          } else if (!primaryLink && anchor.textContent && anchor.textContent.trim()) {
+            primaryLink = anchor.cloneNode(true);
+          } else if (anchor.textContent && anchor.textContent.trim()) {
+            extraLinks.push(anchor.cloneNode(true));
+          }
+        });
+      }
+
+      var extras = Array.prototype.slice.call(wrapper.childNodes)
+        .filter(function (node) {
+          if (node === firstParagraph) {
+            return false;
+          }
+          if (node.nodeType === 3) {
+            return node.textContent.trim().length > 0;
+          }
+          return true;
+        })
+        .map(function (node) {
+          return node.cloneNode(true);
+        });
+
+      return {
+        primaryLink: primaryLink,
+        badges: badgeLinks,
+        extras: extras,
+        extraLinks: extraLinks
+      };
+    }
+
+    function appendRestWithLinks(container, restText, links) {
+      if (!restText) {
+        return;
+      }
+
+      if (!links || !links.length) {
+        container.appendChild(document.createTextNode(restText));
+        return;
+      }
+
+      var remainingText = restText;
+      var lowerRemaining = remainingText.toLowerCase();
+
+      links.forEach(function (link) {
+        var label = link.textContent ? link.textContent.trim() : '';
+        if (!label) {
+          return;
+        }
+        var lowerLabel = label.toLowerCase();
+        var index = lowerRemaining.indexOf(lowerLabel);
+        if (index === -1) {
+          return;
+        }
+        if (index > 0) {
+          container.appendChild(document.createTextNode(remainingText.slice(0, index)));
+        }
+        var clone = link.cloneNode(true);
+        clone.textContent = label;
+        container.appendChild(clone);
+        remainingText = remainingText.slice(index + label.length);
+        lowerRemaining = lowerRemaining.slice(index + label.length);
+      });
+
+      if (remainingText) {
+        container.appendChild(document.createTextNode(remainingText));
+      }
     }
 
     var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
@@ -187,9 +266,65 @@
 
         var bodyEl = document.createElement('div');
         bodyEl.className = 'publication-body';
-        bodyEl.innerHTML = pub.content;
 
-        enhanceDisplay(bodyEl);
+        var citationInfo = pub.citations || {};
+        var meta = extractPublicationMeta(pub.content);
+        var textEl = document.createElement('p');
+
+        if (citationInfo.authorsText) {
+          textEl.appendChild(document.createTextNode(citationInfo.authorsText));
+        }
+
+        if (citationInfo.title) {
+          if (citationInfo.authorsText) {
+            textEl.appendChild(document.createTextNode(' '));
+          }
+          textEl.appendChild(document.createTextNode('“'));
+          if (meta.primaryLink) {
+            meta.primaryLink.textContent = citationInfo.title;
+            textEl.appendChild(meta.primaryLink);
+          } else {
+            textEl.appendChild(document.createTextNode(citationInfo.title));
+          }
+          textEl.appendChild(document.createTextNode('.”'));
+          if (citationInfo.restText) {
+            textEl.appendChild(document.createTextNode(' '));
+            appendRestWithLinks(textEl, citationInfo.restText, meta.extraLinks);
+          }
+        } else if (citationInfo.restText) {
+          if (citationInfo.authorsText) {
+            textEl.appendChild(document.createTextNode(' '));
+          }
+          appendRestWithLinks(textEl, citationInfo.restText, meta.extraLinks);
+        }
+
+        if (!textEl.textContent.trim() && citationInfo.gbt) {
+          textEl.textContent = citationInfo.gbt;
+        }
+
+        var usedStructured = textEl.textContent.trim().length > 0;
+
+        if (usedStructured) {
+          bodyEl.appendChild(textEl);
+
+          if (meta.badges && meta.badges.length) {
+            var resourcesEl = document.createElement('div');
+            resourcesEl.className = 'publication-resources';
+            meta.badges.forEach(function (badge) {
+              resourcesEl.appendChild(badge);
+            });
+            bodyEl.appendChild(resourcesEl);
+          }
+
+          if (meta.extras && meta.extras.length) {
+            meta.extras.forEach(function (node) {
+              bodyEl.appendChild(node);
+            });
+          }
+        } else {
+          bodyEl.innerHTML = pub.content;
+          enhanceDisplay(bodyEl);
+        }
 
         if (citationModal && pub.citations) {
           var actions = document.createElement('div');
@@ -278,21 +413,31 @@
         gbtAuthors = authorTokens.join('');
       }
 
-      var gbtParts = [];
+      var authorsText = '';
       if (gbtAuthors) {
-        gbtParts.push(gbtAuthors + '.');
+        authorsText = gbtAuthors + '.';
+      }
+
+      var restText = '';
+      if (restPart) {
+        restText = restPart.replace(/\s*$/g, '');
+        if (restText && !/[。.!?]$/.test(restText)) {
+          restText += '.';
+        }
+      }
+
+      var gbtParts = [];
+      if (authorsText) {
+        gbtParts.push(authorsText);
       }
       if (title) {
         gbtParts.push('“' + title.replace(/\.$/, '') + '.”');
       }
-      if (restPart) {
-        gbtParts.push(restPart.replace(/\s*$/g, ''));
+      if (restText) {
+        gbtParts.push(restText);
       }
 
       var gbtText = gbtParts.join(' ');
-      if (gbtText && !/[。.!?]$/.test(gbtText)) {
-        gbtText += '.';
-      }
 
       var bibAuthor = authorTokens.join(' and ');
       var bibYear = pub.year || (pub.date ? pub.date.slice(0, 4) : '');
@@ -317,7 +462,10 @@
 
       return {
         gbt: gbtText,
-        bib: bibLines.join('\n')
+        bib: bibLines.join('\n'),
+        title: title,
+        authorsText: authorsText,
+        restText: restText
       };
     }
 


### PR DESCRIPTION
## Summary
- remove patent entries from the publications data and filter labels
- restyle the publications control bar so each control aligns without an outer frame and add a resource badge row
- restructure the publications renderer to produce uniform citation-style text while preserving resource links

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5dcacccc832d982e887115b17026