### PR TITLE
Adjust publication layout for badges and year display

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -260,7 +260,9 @@
   background-color: #fff;
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  height: 2.25rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  box-sizing: border-box;
 }
 
 .publication-search {
@@ -298,10 +300,11 @@ ol.publication-list {
 
 ol.publication-list > li {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
   gap: 1rem;
   margin-bottom: 1.25rem;
   line-height: 1.65;
+  align-items: flex-start;
 }
 
 .publication-index {
@@ -325,6 +328,7 @@ ol.publication-list > li {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: center;
 }
 
 .publication-cite {
@@ -339,6 +343,30 @@ ol.publication-list > li {
 .publication-cite img {
   display: block;
   height: 20px;
+}
+
+.publication-badge {
+  display: inline-flex;
+  align-items: center;
+}
+
+.publication-badge__image,
+.publication-actions img {
+  display: block;
+  height: 20px;
+}
+
+.publication-year {
+  align-self: flex-start;
+  justify-self: end;
+  padding: 0.25rem 0.65rem;
+  border-radius: 0.45rem;
+  border: 1px solid #d0d7de;
+  background: #f6f8fa;
+  font-weight: 600;
+  color: #24292f;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
 }
 
 .publication-empty {
@@ -457,10 +485,17 @@ ol.publication-list > li {
 
   ol.publication-list > li {
     gap: 0.65rem;
+    grid-template-columns: auto 1fr;
   }
 
   .publication-index {
     min-width: 2.5rem;
+  }
+
+  .publication-year {
+    grid-column: 2;
+    justify-self: flex-start;
+    margin-top: 0.25rem;
   }
 }
 </style>

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -194,9 +194,11 @@
 
         enhanceDisplay(bodyEl);
 
+        var actions = document.createElement('div');
+        actions.className = 'publication-actions';
+        var hasActions = false;
+
         if (citationModal && pub.citations) {
-          var actions = document.createElement('div');
-          actions.className = 'publication-actions';
           var citeButton = document.createElement('button');
           citeButton.type = 'button';
           citeButton.className = 'publication-cite';
@@ -206,11 +208,81 @@
             openCitation(number, pub.citations);
           });
           actions.appendChild(citeButton);
+          hasActions = true;
+        }
+
+        var findAncestorLink = function (node) {
+          var current = node;
+          while (current) {
+            if (current.tagName && current.tagName.toLowerCase() === 'a') {
+              return current;
+            }
+            if (current === bodyEl) {
+              return null;
+            }
+            current = current.parentNode;
+          }
+          return null;
+        };
+
+        var badgeImages = Array.prototype.slice.call(bodyEl.querySelectorAll('a img'));
+        var pdfBadges = [];
+        var videoBadges = [];
+        var otherBadges = [];
+
+        badgeImages.forEach(function (img) {
+          var link = findAncestorLink(img);
+          if (!link) {
+            return;
+          }
+          var altText = (img.getAttribute('alt') || '').toLowerCase();
+          if (altText.indexOf('pdf') !== -1 && altText.indexOf('badge') !== -1) {
+            pdfBadges.push(link);
+            return;
+          }
+          if (altText.indexOf('video') !== -1 && altText.indexOf('badge') !== -1) {
+            videoBadges.push(link);
+            return;
+          }
+          if (altText.indexOf('badge') !== -1) {
+            otherBadges.push(link);
+          }
+        });
+
+        var appendedBadges = [];
+        var appendBadge = function (link) {
+          if (!link || appendedBadges.indexOf(link) !== -1) {
+            return;
+          }
+          if (link.parentNode) {
+            link.parentNode.removeChild(link);
+          }
+          link.classList.add('publication-badge');
+          var badgeImage = link.querySelector('img');
+          if (badgeImage) {
+            badgeImage.classList.add('publication-badge__image');
+          }
+          actions.appendChild(link);
+          appendedBadges.push(link);
+          hasActions = true;
+        };
+
+        pdfBadges.forEach(appendBadge);
+        videoBadges.forEach(appendBadge);
+        otherBadges.forEach(appendBadge);
+
+        if (hasActions) {
           bodyEl.appendChild(actions);
         }
 
         li.appendChild(indexEl);
         li.appendChild(bodyEl);
+
+        var yearEl = document.createElement('span');
+        yearEl.className = 'publication-year';
+        yearEl.textContent = pub.year ? String(pub.year) : '';
+        li.appendChild(yearEl);
+
         listEl.appendChild(li);
       });
     }


### PR DESCRIPTION
## Summary
- group cite, PDF, and video badges into a unified actions row per publication and add a dedicated year label
- update publication list styling so the new year column and badge row render cleanly on desktop and mobile
- align the "Search publications" input height with the other controls for a consistent filter bar

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ceb159d944832d8241901ca2630737