### PR TITLE
Align publication body color with DOI

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -330,6 +330,10 @@ ol.publication-list > li {
   font-variant-numeric: tabular-nums;
 }
 
+.publication-body {
+  color: #0969da;
+}
+
 .publication-body p {
   margin: 0;
 }
@@ -385,12 +389,12 @@ ol.publication-list > li {
 
 .publication-body p a:first-of-type {
   text-decoration: none;
-  color: #111;
+  color: inherit;
 }
 
 .publication-body p a:first-of-type:hover,
 .publication-body p a:first-of-type:focus {
-  color: #111;
+  color: inherit;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- update publication body text color to match the DOI styling
- ensure publication links inherit the shared color, including hover state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cece8b9248832db18b4b9934891870