### PR TITLE
Keep publication search highlight minimal update

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -96,7 +96,7 @@
   <select id="publication-year-filter">
     <option value="all">Date</option>
   </select>
-  <button type="button" id="publication-year-sort" class="publication-sort">Year ↓</button>
+  <button type="button" id="publication-year-sort" class="publication-sort">Year ⬇</button>
 </div>
 
 <ol id="publication-list" class="publication-list"></ol>
@@ -392,6 +392,13 @@ ol.publication-list > li {
 .publication-empty {
   color: #57606a;
   font-style: italic;
+}
+
+mark.publication-highlight {
+  background: #e5e7eb;
+  color: inherit;
+  padding: 0 0.15em;
+  border-radius: 0.2em;
 }
 
 .publication-source[hidden] {

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -193,6 +193,7 @@
         bodyEl.innerHTML = pub.content;
 
         enhanceDisplay(bodyEl);
+        applySearchHighlight(bodyEl, normalizedSearch);
 
         var actions = document.createElement('div');
         actions.className = 'publication-actions';
@@ -291,7 +292,7 @@
     yearSelect.addEventListener('change', render);
     sortButton.addEventListener('click', function () {
       sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
-      sortButton.textContent = sortOrder === 'desc' ? 'Year ↓' : 'Year ↑';
+      sortButton.textContent = sortOrder === 'desc' ? 'Year ⬇' : 'Year ⬆';
       render();
     });
 
@@ -312,6 +313,49 @@
           }
           return '“' + trimmed + '.”';
         });
+      });
+    }
+
+    function applySearchHighlight(container, term) {
+      if (!term) {
+        return;
+      }
+      var walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null, false);
+      var nodes = [];
+      while (walker.nextNode()) {
+        nodes.push(walker.currentNode);
+      }
+      var termLength = term.length;
+      nodes.forEach(function (node) {
+        if (!node.parentNode) {
+          return;
+        }
+        var text = node.nodeValue;
+        if (!text) {
+          return;
+        }
+        var lower = text.toLowerCase();
+        var start = lower.indexOf(term);
+        if (start === -1) {
+          return;
+        }
+        var fragment = document.createDocumentFragment();
+        var index = 0;
+        while (start !== -1) {
+          if (start > index) {
+            fragment.appendChild(document.createTextNode(text.slice(index, start)));
+          }
+          var mark = document.createElement('mark');
+          mark.className = 'publication-highlight';
+          mark.textContent = text.slice(start, start + termLength);
+          fragment.appendChild(mark);
+          index = start + termLength;
+          start = lower.indexOf(term, index);
+        }
+        if (index < text.length) {
+          fragment.appendChild(document.createTextNode(text.slice(index)));
+        }
+        node.parentNode.replaceChild(fragment, node);
       });
     }
 


### PR DESCRIPTION
## Summary
- retain the "Year" sort toggle arrow glyph update while leaving the filtering logic untouched
- keep the live search highlighting by wrapping text matches in `<mark class="publication-highlight">` with a lighter-weight helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced995a9fc832d9950b5ed209d87ac