### PR TITLE
Update publication venue styling

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -396,15 +396,18 @@ ol.publication-list > li {
 }
 
 .publication-body em {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.2em;
+  text-decoration: none;
 }
 
 .publication-venue {
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.2em;
+  font-style: normal;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.publication-venue a {
+  font-weight: inherit;
+  text-decoration: none;
 }
 
 .publication-venue--ieee-journal,
@@ -435,7 +438,7 @@ ol.publication-list > li {
 .publication-body em:focus,
 .publication-body em a:hover,
 .publication-body em a:focus {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 mark.publication-highlight {


### PR DESCRIPTION
## Summary
- make publication venue names appear bold instead of italicized
- ensure venue links have no underline styling in normal or hover states

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef051c91c832dab93383e96a073bd