### PR TITLE
Remove link underlines across site

### DIFF
--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -15,10 +15,10 @@
   }
 
   a {
-    text-decoration: underline;
+    text-decoration: none;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
 
       img {
         box-shadow: 0 0 10px rgba(#000, 0.25);
@@ -80,7 +80,7 @@
   }
 
   .archive__item-title {
-    text-decoration: underline;
+    text-decoration: none;
   }
 }
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -118,14 +118,17 @@ blockquote {
 /* links */
 
 a {
-  
+  text-decoration: none;
+
   &:focus {
     @extend %tab-focus;
+    text-decoration: none;
   }
 
   &:hover,
   &:active {
     outline: 0;
+    text-decoration: none;
   }
 }
 

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -41,7 +41,7 @@
     text-decoration: none;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -326,7 +326,7 @@
     color: inherit;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -84,10 +84,10 @@
   }
 
   a {
-    text-decoration: underline;
+    text-decoration: none;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
 
       img {
         box-shadow: 0 0 10px rgba(#000, 0.25);

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -248,7 +248,7 @@
     text-decoration: none;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 }
@@ -261,7 +261,7 @@
     color: inherit;
     text-decoration: none;
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
   @include breakpoint($large) {

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -455,7 +455,7 @@ a.reversefootnote {
   text-decoration: none;
 
   &:hover {
-    text-decoration: underline;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove default underline styling from anchor elements and keep links underline-free on hover and focus
- update archive, navigation, sidebar, footer, and page-specific styles to avoid reintroducing underlines

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not installed)*
- `bundle install` *(fails: rubygems.org returns 403 Forbidden while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68cf876e3bc4832da2501d42dba7f0af