### PR TITLE
Add owner editing mode with in-page module controls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ description              : ""
 repository               : "wtwu95/wtwu95.github.io"
 google_scholar_stats_use_cdn : true
 
+# Owner editing settings
+owner_edit_hash          : "" # Set to the SHA-256 hash of your private editing password
+
 # google analytics
 google_analytics_id      : # "https://analytics.google.com/analytics/e2ban1wAAAAJ" 
 

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -8,6 +8,7 @@
 <meta name="msapplication-config" content="images/browserconfig.xml?v=M44lzPylqQ">
 <meta name="theme-color" content="#ffffff">
 <link rel="stylesheet" href="assets/css/academicons.css"/>
+<meta name="owner-edit-hash" content="{{ site.owner_edit_hash | default: '' }}">
 
 <script type="text/x-mathjax-config"> MathJax.Hub.Config({ TeX: { equationNumbers: { autoNumber: "all" } } }); </script>
 <script type="text/x-mathjax-config">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="assets/js/main.min.js"></script>
 <script src="assets/js/news-window.js"></script>
+<script src="assets/js/editor.js"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="awards" data-edit-title="荣誉奖项" markdown="1">
+
 <span class='anchor' id='-awards'></span>
 # 🎖 Awards
 
@@ -16,4 +18,6 @@
 - 2020 &nbsp; Outstanding Graduate of Dalian
 - 2020 &nbsp; First Prize of Liaoning Provincial Graduate Electronic Design Contest
 - 2019 · 2020 &nbsp; First Prizes of National Graduate Electronic Design Contest in Northeast Division
+
+</section>
 

--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="education" data-edit-title="教育背景">
+
 # 🎓 Educations
 
 <ul class="cv-list">
@@ -5,7 +7,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>), 
+        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
         <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
       </div>
       <div class="cv-date">09/2021–03/2025</div>
@@ -17,7 +19,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>, 
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
         <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
       </div>
       <div class="cv-date">09/2018–06/2021</div>
@@ -29,10 +31,12 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>, 
+        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
         <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
       </div>
       <div class="cv-date">09/2014–06/2018</div>
     </div>
   </li>
 </ul>
+
+</section>

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="experience" data-edit-title="工作经历">
+
 # 📖 Experiences
 <ul class="cv-list">
   <li class="cv-item">
@@ -5,7 +7,7 @@
       <div class="cv-main">
         <span class="cv-role">Postdoctoral Fellow</span> in
         <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>, 
+        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
         <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
       </div>
       <div class="cv-date">04/2025–Present</div>
@@ -17,7 +19,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>, 
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
         <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
       </div>
       <div class="cv-date">01/2024–11/2024</div>
@@ -25,3 +27,5 @@
     <div class="cv-sub">Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi (施阳)</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)</div>
   </li>
 </ul>
+
+</section>

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,11 +1,15 @@
+<section class="editable-block" data-editable-id="bio" data-edit-title="个人简介" markdown="1">
+
 # 👨🏻‍🎓 Biography
 
 I am currently a Postdoctoral Fellow in [Research Centre for Low Altitude Economy](https://www.polyu.edu.hk/rclae/), [Department of Aeronautical and Aviation Engineering](https://www.polyu.edu.hk/aae/), [The Hong Kong Polytechnic University](https://www.polyu.edu.hk/), under the supervision of Prof. [Wen-Hua Chen](https://scholar.google.com/citations?user=UfIb9GkAAAAJ).
 
 I am a Youth Editorial Board Member of the [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS). I am also an origanizer for Special Session 2 of the 2025 10th ACIRS. He was selected for the inaugural **Doctoral Special Program of Young Elite Scientist Sponsorship Program** by China Association for Science and Technology (CAST) in 2025. I obtained **National Scholarships** for Graduate Students (Top 1%) in 2020, 2023, and 2024. My master thesis received the **Excellent Master Dissertation Award** of Liaoning Province!
 
-My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. 
+My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems.
 I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a>
 in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
 
 Welcome to contact me for academic collaboration! Please feel free to email me at [wtwu95@gmail.com](mailto:wtwu95@gmail.com) or [wen-tao.wu@polyu.edu.hk](mailto:wen-tao.wu@polyu.edu.hk).
+
+</section>

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="news" data-edit-title="最新动态" data-edit-refresh="news:data-updated" markdown="1">
+
 # 💬 News
 
 <div class="news-window" data-news-window data-visible-count="5" tabindex="0" aria-label="Latest news" markdown="1">
@@ -36,3 +38,5 @@
 {: .news-list}
 
 </div>
+
+</section>

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="publications" data-edit-title="论文成果" data-edit-refresh="publication:data-updated" markdown="1">
+
 # 📝 Publications
 
 <!-- ### Selected Papers
@@ -242,6 +244,8 @@
     </div>
   </div>
 </div>
+
+</section>
 
 <style>
 :root {

--- a/_pages/includes/serv.md
+++ b/_pages/includes/serv.md
@@ -1,3 +1,5 @@
+<section class="editable-block" data-editable-id="services" data-edit-title="学术服务" markdown="1">
+
 # 💻 Professional Services:
 
 ## Journal Editorial Boards
@@ -6,28 +8,28 @@
 ## Conference Program Committee and Editorial
 - **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
 
-## Teaching 
+## Teaching
 
 - **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
 
 ## Journal Reviewer
-- [IEEE Transactions on Automatic Control](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9)  
-- [IEEE Control Systems Letters](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673) 
-- [IEEE Transactions on Cybernetics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)  
-- [IEEE Transactions on Industrial Cyber-Physical Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8254253)  
-- [IEEE Transactions on Vehicular Technology](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25)  
-- [IEEE Transactions on Transportation Electrification](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6687312)  
-- [IEEE Open Journal of the Industrial Electronics Society](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8782712)  
-- [IEEE/CAA Journal of Automatica Sinica](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)  
-- [IEEE Transactions on Industrial Electronics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=41)  
-- [IEEE Transactions on Intelligent Vehicles](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)  
-- [IEEE Transactions on Systems, Man, and Cybernetics: Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021)  
-- [IEEE Internet of Things Journal](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6488907)  
-- [Ocean Engineering](https://www.sciencedirect.com/journal/ocean-engineering)  
-- [ISA Transactions](https://www.sciencedirect.com/journal/isa-transactions)  
-- [Circuits, Systems, and Signal Processing](https://link.springer.com/journal/34)  
-- [International Journal of Robust and Nonlinear Control](https://onlinelibrary.wiley.com/journal/10991239)  
-- [Nonlinear Dynamics](https://link.springer.com/journal/11071)  
+- [IEEE Transactions on Automatic Control](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9)
+- [IEEE Control Systems Letters](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673)
+- [IEEE Transactions on Cybernetics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)
+- [IEEE Transactions on Industrial Cyber-Physical Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8254253)
+- [IEEE Transactions on Vehicular Technology](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25)
+- [IEEE Transactions on Transportation Electrification](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6687312)
+- [IEEE Open Journal of the Industrial Electronics Society](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8782712)
+- [IEEE/CAA Journal of Automatica Sinica](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)
+- [IEEE Transactions on Industrial Electronics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=41)
+- [IEEE Transactions on Intelligent Vehicles](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)
+- [IEEE Transactions on Systems, Man, and Cybernetics: Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021)
+- [IEEE Internet of Things Journal](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6488907)
+- [Ocean Engineering](https://www.sciencedirect.com/journal/ocean-engineering)
+- [ISA Transactions](https://www.sciencedirect.com/journal/isa-transactions)
+- [Circuits, Systems, and Signal Processing](https://link.springer.com/journal/34)
+- [International Journal of Robust and Nonlinear Control](https://onlinelibrary.wiley.com/journal/10991239)
+- [Nonlinear Dynamics](https://link.springer.com/journal/11071)
 
 ## Conference Reviewer
 - IEEE Conference on Decision and Control (CDC)
@@ -35,3 +37,5 @@
 - Annual Conference of the IEEE Industrial Electronics Society (IECON)
 - Chinese Control Conference (CCC)
 - Chinese Control and Decision Conference (CCDC)
+
+</section>

--- a/_sass/_editor.scss
+++ b/_sass/_editor.scss
@@ -1,0 +1,339 @@
+.owner-toolbar {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  z-index: 1200;
+  font-family: inherit;
+}
+
+.owner-toolbar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+.owner-toolbar__button {
+  appearance: none;
+  border: 1px solid rgba(0, 54, 159, 0.3);
+  background: rgba(255, 255, 255, 0.94);
+  color: #00369f;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 14px;
+  line-height: 1.2;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.owner-toolbar__button:hover,
+.owner-toolbar__button:focus {
+  background: #00369f;
+  color: #fff;
+  border-color: #00369f;
+  outline: none;
+}
+
+.owner-toolbar__hint {
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  max-width: 260px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+}
+
+.owner-toolbar__hint strong {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 2px;
+}
+
+.editable-block {
+  position: relative;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body.owner-mode-active .editable-block {
+  outline: 1.5px dashed rgba(0, 54, 159, 0.35);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.editable-block__controls {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 6px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 2;
+}
+
+body.owner-mode-active .editable-block:hover .editable-block__controls,
+body.owner-mode-active .editable-block:focus-within .editable-block__controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.editable-block__button {
+  appearance: none;
+  border: none;
+  background: rgba(0, 54, 159, 0.92);
+  color: #fff;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.15);
+  transition: background 0.2s ease;
+}
+
+.editable-block__button--ghost {
+  background: rgba(255, 255, 255, 0.92);
+  color: #00369f;
+  border: 1px solid rgba(0, 54, 159, 0.4);
+}
+
+.editable-block__button:hover,
+.editable-block__button:focus {
+  background: #00297a;
+  outline: none;
+}
+
+.editable-block__button--ghost:hover,
+.editable-block__button--ghost:focus {
+  background: rgba(0, 54, 159, 0.1);
+}
+
+.owner-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1300;
+}
+
+.owner-modal.is-visible {
+  display: flex;
+}
+
+.owner-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(9, 12, 25, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.owner-modal__dialog {
+  position: relative;
+  width: min(900px, 92vw);
+  max-height: min(86vh, 900px);
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 25px 65px rgba(10, 16, 38, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.owner-modal__header {
+  padding: 18px 24px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.owner-modal__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0c1d4a;
+  margin: 0;
+}
+
+.owner-modal__close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+}
+
+.owner-modal__close:hover,
+.owner-modal__close:focus {
+  color: #111827;
+  outline: none;
+}
+
+.owner-modal__tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 24px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.owner-modal__tab {
+  flex: 1;
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #6b7280;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s ease, border 0.2s ease;
+}
+
+.owner-modal__tab.is-active {
+  color: #00369f;
+  border-color: #00369f;
+}
+
+.owner-modal__body {
+  padding: 16px 24px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.owner-modal__editor,
+.owner-modal__source {
+  min-height: 320px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  padding: 14px;
+  font-size: 15px;
+  line-height: 1.5;
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: #f9fafc;
+}
+
+.owner-modal__editor {
+  font-family: inherit;
+  background: #fff;
+  overflow-y: auto;
+}
+
+.owner-modal__source {
+  resize: vertical;
+}
+
+.owner-modal__hint {
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.owner-modal__footer {
+  padding: 14px 24px 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.owner-modal__footer-spacer {
+  flex: 1;
+}
+
+.owner-modal__action {
+  appearance: none;
+  border-radius: 8px;
+  padding: 9px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.owner-modal__action--primary {
+  background: #00369f;
+  color: #fff;
+}
+
+.owner-modal__action--secondary {
+  background: rgba(0, 54, 159, 0.12);
+  color: #00369f;
+}
+
+.owner-modal__action--ghost {
+  background: transparent;
+  border-color: rgba(0, 54, 159, 0.2);
+  color: #00369f;
+}
+
+.owner-modal__action:hover,
+.owner-modal__action:focus {
+  outline: none;
+  filter: brightness(0.95);
+}
+
+.owner-modal__action--ghost:hover,
+.owner-modal__action--ghost:focus {
+  background: rgba(0, 54, 159, 0.08);
+}
+
+.owner-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 40px;
+  transform: translateX(-50%);
+  background: rgba(0, 23, 71, 0.95);
+  color: #fff;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  z-index: 1400;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.owner-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 640px) {
+  .owner-toolbar {
+    right: 16px;
+    bottom: 16px;
+  }
+
+  body.owner-mode-active .editable-block {
+    padding: 10px;
+  }
+
+  .owner-modal__dialog {
+    width: 96vw;
+    max-height: 92vh;
+  }
+
+  .owner-modal__editor,
+  .owner-modal__source {
+    min-height: 240px;
+  }
+}
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -30,6 +30,8 @@
 
 @import "forms";
 
+@import "editor";
+
 @import "page";
 @import "archive";
 @import "sidebar";

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,0 +1,648 @@
+(function () {
+  'use strict';
+
+  var hashMeta = document.querySelector('meta[name="owner-edit-hash"]');
+  if (!hashMeta) {
+    return;
+  }
+
+  var ownerHash = (hashMeta.getAttribute('content') || '').trim().toLowerCase();
+  if (!ownerHash) {
+    return;
+  }
+
+  var sections = Array.prototype.slice.call(document.querySelectorAll('.editable-block[data-editable-id]'));
+  if (!sections.length) {
+    return;
+  }
+
+  var STORAGE_KEY = 'owner:overrides';
+  var SESSION_KEY = 'owner:session';
+  var ownerMode = false;
+  var toolbar = null;
+  var modal = null;
+  var toast = null;
+  var activeSection = null;
+
+  function toHex(buffer) {
+    var view = new Uint8Array(buffer);
+    var result = '';
+    for (var i = 0; i < view.length; i += 1) {
+      var value = view[i].toString(16);
+      result += value.length === 1 ? '0' + value : value;
+    }
+    return result;
+  }
+
+  function simpleHash(str) {
+    var hash = 5381;
+    for (var i = 0; i < str.length; i += 1) {
+      hash = (hash * 33) ^ str.charCodeAt(i);
+    }
+    return (hash >>> 0).toString(16);
+  }
+
+  function hashString(str) {
+    if (window.crypto && window.crypto.subtle && window.TextEncoder) {
+      var encoder = new TextEncoder();
+      return window.crypto.subtle
+        .digest('SHA-256', encoder.encode(str))
+        .then(function (buffer) {
+          return toHex(buffer);
+        })
+        .catch(function () {
+          return simpleHash(str);
+        });
+    }
+    return Promise.resolve(simpleHash(str));
+  }
+
+  function sanitize(html) {
+    var template = document.createElement('template');
+    template.innerHTML = html;
+    Array.prototype.slice.call(template.content.querySelectorAll('script')).forEach(function (node) {
+      node.parentNode.removeChild(node);
+    });
+    Array.prototype.slice.call(template.content.querySelectorAll('*')).forEach(function (element) {
+      Array.prototype.slice.call(element.attributes).forEach(function (attribute) {
+        if (/^on/i.test(attribute.name)) {
+          element.removeAttribute(attribute.name);
+        }
+      });
+    });
+    return template.innerHTML;
+  }
+
+  function getStorage(key) {
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setStorage(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (error) {
+      // ignore storage errors
+    }
+  }
+
+  function removeStorage(key) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      // ignore storage errors
+    }
+  }
+
+  function loadOverrides() {
+    var raw = getStorage(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    try {
+      var parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        return parsed;
+      }
+    } catch (error) {
+      // ignore malformed data
+    }
+    return {};
+  }
+
+  function saveOverrides(map) {
+    setStorage(STORAGE_KEY, JSON.stringify(map));
+  }
+
+  function showToast(message) {
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.className = 'owner-toast';
+      document.body.appendChild(toast);
+    }
+
+    toast.textContent = message;
+    toast.classList.add('is-visible');
+
+    window.clearTimeout(showToast.timerId);
+    showToast.timerId = window.setTimeout(function () {
+      toast.classList.remove('is-visible');
+    }, 2800);
+  }
+
+  function dispatchRefresh(section) {
+    var refreshNames = section.getAttribute('data-edit-refresh');
+    if (!refreshNames) {
+      return;
+    }
+
+    refreshNames
+      .split(/\s+/)
+      .map(function (name) {
+        return name.trim();
+      })
+      .filter(Boolean)
+      .forEach(function (name) {
+        var event;
+        try {
+          event = new CustomEvent(name, { bubbles: false });
+        } catch (error) {
+          // IE fallback
+          event = document.createEvent('CustomEvent');
+          event.initCustomEvent(name, false, false, {});
+        }
+        document.dispatchEvent(event);
+      });
+  }
+
+  sections.forEach(function (section) {
+    if (!section.hasAttribute('data-edit-original')) {
+      section.setAttribute('data-edit-original', sanitize(section.innerHTML));
+    }
+  });
+
+  var overrides = loadOverrides();
+
+  function applyOverrides() {
+    sections.forEach(function (section) {
+      var id = section.getAttribute('data-editable-id');
+      if (!id || !overrides[id]) {
+        return;
+      }
+      var sanitized = sanitize(overrides[id]);
+      section.innerHTML = sanitized;
+    });
+  }
+
+  applyOverrides();
+
+  function ensureControls(section) {
+    if (section.querySelector('.editable-block__controls')) {
+      return;
+    }
+
+    var controls = document.createElement('div');
+    controls.className = 'editable-block__controls';
+
+    var editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'editable-block__button';
+    editButton.textContent = '编辑';
+    editButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      openEditor(section);
+    });
+    controls.appendChild(editButton);
+
+    var resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.className = 'editable-block__button editable-block__button--ghost';
+    resetButton.textContent = '恢复';
+    resetButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      resetSection(section, true);
+    });
+    controls.appendChild(resetButton);
+
+    section.appendChild(controls);
+  }
+
+  function getOverrideMap() {
+    overrides = loadOverrides();
+    return overrides;
+  }
+
+  function updateOverride(id, value) {
+    var map = getOverrideMap();
+    if (value) {
+      map[id] = value;
+    } else {
+      delete map[id];
+    }
+    overrides = map;
+    saveOverrides(map);
+  }
+
+  function resetSection(section, notify) {
+    var id = section.getAttribute('data-editable-id');
+    if (!id) {
+      return;
+    }
+
+    var original = section.getAttribute('data-edit-original');
+    if (typeof original !== 'string') {
+      return;
+    }
+
+    section.innerHTML = original;
+    updateOverride(id, null);
+    dispatchRefresh(section);
+
+    if (ownerMode) {
+      ensureControls(section);
+    }
+
+    if (notify) {
+      showToast('已恢复“' + (section.getAttribute('data-edit-title') || id) + '”模块');
+    }
+  }
+
+  function clearAllOverrides() {
+    var confirmed = window.confirm('确定要清除全部模块的本地修改吗？');
+    if (!confirmed) {
+      return;
+    }
+
+    saveOverrides({});
+    overrides = {};
+
+    sections.forEach(function (section) {
+      resetSection(section, false);
+    });
+
+    showToast('已清除全部自定义内容');
+  }
+
+  function ensureToolbar() {
+    if (toolbar) {
+      return toolbar;
+    }
+
+    toolbar = document.createElement('div');
+    toolbar.className = 'owner-toolbar';
+    document.body.appendChild(toolbar);
+    return toolbar;
+  }
+
+  function createButton(label) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'owner-toolbar__button';
+    button.textContent = label;
+    return button;
+  }
+
+  function updateToolbar() {
+    ensureToolbar();
+    toolbar.innerHTML = '';
+
+    var group = document.createElement('div');
+    group.className = 'owner-toolbar__group';
+    toolbar.appendChild(group);
+
+    if (ownerMode) {
+      var exitButton = createButton('退出编辑模式');
+      exitButton.addEventListener('click', function () {
+        ownerMode = false;
+        document.body.classList.remove('owner-mode-active');
+        removeStorage(SESSION_KEY);
+        updateToolbar();
+        showToast('已退出编辑模式');
+      });
+      group.appendChild(exitButton);
+
+      var clearButton = createButton('清除全部修改');
+      clearButton.addEventListener('click', clearAllOverrides);
+      group.appendChild(clearButton);
+    } else {
+      var loginButton = createButton('登录编辑模式');
+      loginButton.addEventListener('click', function () {
+        requestLogin();
+      });
+      group.appendChild(loginButton);
+
+      var hint = document.createElement('div');
+      hint.className = 'owner-toolbar__hint';
+      hint.innerHTML = '<strong>站长提示</strong>使用授权密码可直接在线维护页面内容。';
+      toolbar.appendChild(hint);
+    }
+  }
+
+  function synchronizeViews(modalInstance, tab) {
+    if (tab === 'html') {
+      modalInstance.source.value = sanitize(modalInstance.editor.innerHTML);
+    } else {
+      modalInstance.editor.innerHTML = sanitize(modalInstance.source.value);
+    }
+  }
+
+  function setActiveTab(modalInstance, tab) {
+    if (modalInstance.activeTab === tab) {
+      return;
+    }
+
+    modalInstance.tabs.forEach(function (button) {
+      if (button.getAttribute('data-tab') === tab) {
+        button.classList.add('is-active');
+      } else {
+        button.classList.remove('is-active');
+      }
+    });
+
+    if (tab === 'visual') {
+      modalInstance.editor.style.display = 'block';
+      modalInstance.source.style.display = 'none';
+    } else {
+      modalInstance.editor.style.display = 'none';
+      modalInstance.source.style.display = 'block';
+    }
+
+    modalInstance.activeTab = tab;
+    synchronizeViews(modalInstance, tab);
+  }
+
+  function ensureModal() {
+    if (modal) {
+      return modal;
+    }
+
+    var root = document.createElement('div');
+    root.className = 'owner-modal';
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-modal', 'true');
+
+    var backdrop = document.createElement('div');
+    backdrop.className = 'owner-modal__backdrop';
+    root.appendChild(backdrop);
+
+    var dialog = document.createElement('div');
+    dialog.className = 'owner-modal__dialog';
+    root.appendChild(dialog);
+
+    var header = document.createElement('div');
+    header.className = 'owner-modal__header';
+    dialog.appendChild(header);
+
+    var title = document.createElement('h3');
+    title.className = 'owner-modal__title';
+    header.appendChild(title);
+
+    var close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'owner-modal__close';
+    close.setAttribute('aria-label', '关闭编辑窗口');
+    close.textContent = '×';
+    header.appendChild(close);
+
+    var tabs = document.createElement('div');
+    tabs.className = 'owner-modal__tabs';
+    dialog.appendChild(tabs);
+
+    var visualTab = document.createElement('button');
+    visualTab.type = 'button';
+    visualTab.className = 'owner-modal__tab';
+    visualTab.textContent = '可视化编辑';
+    visualTab.setAttribute('data-tab', 'visual');
+    tabs.appendChild(visualTab);
+
+    var htmlTab = document.createElement('button');
+    htmlTab.type = 'button';
+    htmlTab.className = 'owner-modal__tab';
+    htmlTab.textContent = 'HTML 源码';
+    htmlTab.setAttribute('data-tab', 'html');
+    tabs.appendChild(htmlTab);
+
+    var body = document.createElement('div');
+    body.className = 'owner-modal__body';
+    dialog.appendChild(body);
+
+    var editor = document.createElement('div');
+    editor.className = 'owner-modal__editor';
+    editor.setAttribute('contenteditable', 'true');
+    body.appendChild(editor);
+
+    var source = document.createElement('textarea');
+    source.className = 'owner-modal__source';
+    source.setAttribute('spellcheck', 'false');
+    body.appendChild(source);
+
+    var hint = document.createElement('p');
+    hint.className = 'owner-modal__hint';
+    hint.textContent = '保存后内容仅在本地浏览器中生效，同时可复制 HTML 更新仓库源文件。';
+    body.appendChild(hint);
+
+    var footer = document.createElement('div');
+    footer.className = 'owner-modal__footer';
+    dialog.appendChild(footer);
+
+    var copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'owner-modal__action owner-modal__action--ghost';
+    copyButton.setAttribute('data-action', 'copy');
+    copyButton.textContent = '复制 HTML';
+    footer.appendChild(copyButton);
+
+    var resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.className = 'owner-modal__action owner-modal__action--ghost';
+    resetButton.setAttribute('data-action', 'reset');
+    resetButton.textContent = '恢复原始内容';
+    footer.appendChild(resetButton);
+
+    var spacer = document.createElement('div');
+    spacer.className = 'owner-modal__footer-spacer';
+    footer.appendChild(spacer);
+
+    var cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'owner-modal__action owner-modal__action--secondary';
+    cancelButton.setAttribute('data-action', 'cancel');
+    cancelButton.textContent = '取消';
+    footer.appendChild(cancelButton);
+
+    var saveButton = document.createElement('button');
+    saveButton.type = 'button';
+    saveButton.className = 'owner-modal__action owner-modal__action--primary';
+    saveButton.setAttribute('data-action', 'save');
+    saveButton.textContent = '保存修改';
+    footer.appendChild(saveButton);
+
+    document.body.appendChild(root);
+
+    modal = {
+      root: root,
+      dialog: dialog,
+      title: title,
+      close: close,
+      tabs: [visualTab, htmlTab],
+      editor: editor,
+      source: source,
+      copyButton: copyButton,
+      resetButton: resetButton,
+      cancelButton: cancelButton,
+      saveButton: saveButton,
+      activeTab: 'visual'
+    };
+
+    close.addEventListener('click', function () {
+      hideModal();
+    });
+
+    backdrop.addEventListener('click', function () {
+      hideModal();
+    });
+
+    visualTab.addEventListener('click', function () {
+      setActiveTab(modal, 'visual');
+    });
+
+    htmlTab.addEventListener('click', function () {
+      setActiveTab(modal, 'html');
+    });
+
+    copyButton.addEventListener('click', function () {
+      synchronizeViews(modal, modal.activeTab);
+      var value = modal.activeTab === 'visual' ? sanitize(modal.editor.innerHTML) : sanitize(modal.source.value);
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard
+          .writeText(value)
+          .then(function () {
+            showToast('已复制到剪贴板');
+          })
+          .catch(function () {
+            showToast('复制失败，请手动选择内容');
+          });
+      } else {
+        try {
+          var temp = document.createElement('textarea');
+          temp.value = value;
+          temp.setAttribute('readonly', '');
+          temp.style.position = 'absolute';
+          temp.style.left = '-9999px';
+          document.body.appendChild(temp);
+          temp.select();
+          document.execCommand('copy');
+          document.body.removeChild(temp);
+          showToast('已复制到剪贴板');
+        } catch (error) {
+          showToast('复制失败，请手动选择内容');
+        }
+      }
+    });
+
+    resetButton.addEventListener('click', function () {
+      if (!activeSection) {
+        return;
+      }
+      var original = activeSection.getAttribute('data-edit-original');
+      if (typeof original !== 'string') {
+        return;
+      }
+      modal.editor.innerHTML = original;
+      modal.source.value = original;
+      showToast('已载入原始内容');
+    });
+
+    cancelButton.addEventListener('click', function () {
+      hideModal();
+    });
+
+    saveButton.addEventListener('click', function () {
+      if (!activeSection) {
+        hideModal();
+        return;
+      }
+      synchronizeViews(modal, modal.activeTab);
+      var value = modal.activeTab === 'visual' ? modal.editor.innerHTML : modal.source.value;
+      var sanitized = sanitize(value);
+      activeSection.innerHTML = sanitized;
+      var id = activeSection.getAttribute('data-editable-id');
+      updateOverride(id, sanitized);
+      dispatchRefresh(activeSection);
+      showToast('已保存“' + (activeSection.getAttribute('data-edit-title') || id) + '”模块');
+      if (ownerMode) {
+        ensureControls(activeSection);
+      }
+      hideModal();
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && modal.root.classList.contains('is-visible')) {
+        hideModal();
+      }
+    });
+
+    setActiveTab(modal, 'visual');
+
+    return modal;
+  }
+
+  function showModal() {
+    ensureModal();
+    modal.root.classList.add('is-visible');
+  }
+
+  function hideModal() {
+    if (!modal) {
+      return;
+    }
+    modal.root.classList.remove('is-visible');
+    activeSection = null;
+  }
+
+  function openEditor(section) {
+    ensureModal();
+    activeSection = section;
+    modal.title.textContent = '编辑：' + (section.getAttribute('data-edit-title') || section.getAttribute('data-editable-id'));
+    var currentHtml = sanitize(section.innerHTML);
+    modal.editor.innerHTML = currentHtml;
+    modal.source.value = currentHtml;
+    setActiveTab(modal, 'visual');
+    showModal();
+  }
+
+  function isAuthenticated() {
+    var session = getStorage(SESSION_KEY);
+    return session && session.toLowerCase() === ownerHash;
+  }
+
+  function activateOwnerMode() {
+    ownerMode = true;
+    document.body.classList.add('owner-mode-active');
+    sections.forEach(function (section) {
+      ensureControls(section);
+    });
+    updateToolbar();
+    showToast('已进入编辑模式');
+  }
+
+  function requestLogin() {
+    var password = window.prompt('请输入站长编辑密码');
+    if (password === null) {
+      return;
+    }
+    password = password.trim();
+    if (!password) {
+      showToast('密码不能为空');
+      return;
+    }
+
+    hashString(password).then(function (hashed) {
+      if (hashed && hashed.toLowerCase() === ownerHash) {
+        setStorage(SESSION_KEY, ownerHash);
+        activateOwnerMode();
+      } else {
+        showToast('密码错误，无法进入编辑模式');
+      }
+    });
+  }
+
+  function initialize() {
+    if (isAuthenticated()) {
+      ownerMode = true;
+      document.body.classList.add('owner-mode-active');
+      sections.forEach(function (section) {
+        ensureControls(section);
+      });
+    }
+    updateToolbar();
+  }
+
+  initialize();
+})();
+

--- a/assets/js/news-window.js
+++ b/assets/js/news-window.js
@@ -73,4 +73,8 @@
   } else {
     init();
   }
+
+  document.addEventListener('news:data-updated', function () {
+    init();
+  });
 })();

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -8,21 +8,32 @@
   }
 
   ready(function () {
-    var sourceList = document.querySelector('#publication-source');
-    var listEl = document.querySelector('#publication-list');
-    var typeSelect = document.querySelector('#publication-type-filter');
-    var yearSelect = document.querySelector('#publication-year-filter');
-    var sortButton = document.querySelector('#publication-year-sort');
-    var searchInput = document.querySelector('#publication-search');
-    var citationModal = document.querySelector('#citation-modal');
-    var citationContent = citationModal ? citationModal.querySelector('#citation-modal-content') : null;
-    var citationTabs = citationModal ? Array.prototype.slice.call(citationModal.querySelectorAll('.citation-modal__tab')) : [];
-    var citationClose = citationModal ? citationModal.querySelector('.citation-modal__close') : null;
-    var citationActions = citationModal ? citationModal.querySelector('.citation-modal__actions') : null;
-    var citationFeedback = citationModal ? citationModal.querySelector('.citation-modal__feedback') : null;
+    var sourceList;
+    var listEl;
+    var typeSelect;
+    var yearSelect;
+    var sortButton;
+    var searchInput;
+    var citationModal;
+    var citationContent;
+    var citationTabs = [];
+    var citationClose;
+    var citationActions;
+    var citationFeedback;
 
-    if (!sourceList || !listEl || !typeSelect || !yearSelect || !sortButton) {
-      return;
+    function captureElements() {
+      sourceList = document.querySelector('#publication-source');
+      listEl = document.querySelector('#publication-list');
+      typeSelect = document.querySelector('#publication-type-filter');
+      yearSelect = document.querySelector('#publication-year-filter');
+      sortButton = document.querySelector('#publication-year-sort');
+      searchInput = document.querySelector('#publication-search');
+      citationModal = document.querySelector('#citation-modal');
+      citationContent = citationModal ? citationModal.querySelector('#citation-modal-content') : null;
+      citationTabs = citationModal ? Array.prototype.slice.call(citationModal.querySelectorAll('.citation-modal__tab')) : [];
+      citationClose = citationModal ? citationModal.querySelector('.citation-modal__close') : null;
+      citationActions = citationModal ? citationModal.querySelector('.citation-modal__actions') : null;
+      citationFeedback = citationModal ? citationModal.querySelector('.citation-modal__feedback') : null;
     }
 
     var typeLabels = {
@@ -38,6 +49,8 @@
     var activeCitationFormat = 'plain';
     var currentCitation = null;
     var copyFeedbackTimer = null;
+    var sortOrder = 'desc';
+    var publications = [];
 
     function sanitizeNode(node) {
       var clone = node.cloneNode(true);
@@ -60,55 +73,76 @@
       return replaced;
     }
 
-    var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
-      var year = parseInt(item.getAttribute('data-year'), 10);
-      var plainCitation = item.getAttribute('data-citation-plain') || '';
-      var bibCitation = item.getAttribute('data-citation-bibtex') || '';
-      var sanitized = sanitizeNode(item);
-      var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
-      var normalizedText = normalizeQuotes(textContent);
-      return {
-        type: item.getAttribute('data-type') || 'other',
-        year: isNaN(year) ? null : year,
-        date: item.getAttribute('data-date') || '',
-        content: item.innerHTML.trim(),
-        rawText: normalizedText,
-        searchText: normalizedText.toLowerCase(),
-        plainCitation: plainCitation,
-        bibCitation: bibCitation
-      };
-    });
+    function refreshPublicationsData() {
+      if (!sourceList) {
+        publications = [];
+        return;
+      }
 
-    publications = publications.map(function (pub) {
-      pub.citations = generateCitations(pub);
-      return pub;
-    });
+      publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
+        var year = parseInt(item.getAttribute('data-year'), 10);
+        var plainCitation = item.getAttribute('data-citation-plain') || '';
+        var bibCitation = item.getAttribute('data-citation-bibtex') || '';
+        var sanitized = sanitizeNode(item);
+        var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
+        var normalizedText = normalizeQuotes(textContent);
+        return {
+          type: item.getAttribute('data-type') || 'other',
+          year: isNaN(year) ? null : year,
+          date: item.getAttribute('data-date') || '',
+          content: item.innerHTML.trim(),
+          rawText: normalizedText,
+          searchText: normalizedText.toLowerCase(),
+          plainCitation: plainCitation,
+          bibCitation: bibCitation
+        };
+      });
 
-    var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
-      return pub.type;
-    }).filter(Boolean)));
+      publications = publications.map(function (pub) {
+        pub.citations = generateCitations(pub);
+        return pub;
+      });
 
-    var orderedOptions = typeOrder.map(function (type) {
-      return {
-        value: type,
-        label: typeLabels[type] || type
-      };
-    });
+      var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
+        return pub.type;
+      }).filter(Boolean)));
 
-    uniqueTypes.forEach(function (type) {
-      if (typeOrder.indexOf(type) === -1) {
-        orderedOptions.push({
+      var orderedOptions = typeOrder.map(function (type) {
+        return {
           value: type,
           label: typeLabels[type] || type
-        });
-      }
-    });
+        };
+      });
 
-    typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
-      return '<option value="' + type.value + '">' + type.label + '</option>';
-    }).join('');
+      uniqueTypes.forEach(function (type) {
+        if (typeOrder.indexOf(type) === -1) {
+          orderedOptions.push({
+            value: type,
+            label: typeLabels[type] || type
+          });
+        }
+      });
+
+      if (typeSelect) {
+        var previousType = typeSelect.value;
+        typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
+          return '<option value="' + type.value + '">' + type.label + '</option>';
+        }).join('');
+        if (previousType && typeSelect.querySelector('option[value="' + previousType + '"]')) {
+          typeSelect.value = previousType;
+        } else {
+          typeSelect.value = 'all';
+        }
+      }
+
+      updateYearOptions();
+    }
 
     function updateYearOptions() {
+      if (!yearSelect) {
+        return;
+      }
+      var previousYear = yearSelect.value;
       var years = Array.from(new Set(publications.map(function (pub) {
         return pub.year;
       }).filter(Boolean)));
@@ -116,11 +150,12 @@
       yearSelect.innerHTML = '<option value="all">Date</option>' + years.map(function (year) {
         return '<option value="' + year + '">' + year + '</option>';
       }).join('');
+      if (previousYear && yearSelect.querySelector('option[value="' + previousYear + '"]')) {
+        yearSelect.value = previousYear;
+      } else {
+        yearSelect.value = 'all';
+      }
     }
-
-    updateYearOptions();
-
-    var sortOrder = 'desc';
 
     function normalizeDate(dateStr, year) {
       if (!dateStr) {
@@ -141,6 +176,9 @@
     }
 
     function render() {
+      if (!listEl || !typeSelect || !yearSelect) {
+        return;
+      }
       var selectedType = typeSelect.value;
       var selectedYear = yearSelect.value;
       var highlightTerm = searchInput ? searchInput.value.trim() : '';
@@ -291,19 +329,39 @@
       });
     }
 
-    typeSelect.addEventListener('change', render);
-    yearSelect.addEventListener('change', render);
-    sortButton.addEventListener('click', function () {
+    function handleSortClick() {
       sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
-      sortButton.textContent = sortOrder === 'desc' ? '⬇' : '⬆';
+      if (sortButton) {
+        sortButton.textContent = sortOrder === 'desc' ? '⬇' : '⬆';
+      }
       render();
-    });
+    }
 
-    if (searchInput) {
-      searchInput.addEventListener('input', function () {
-        searchTerm = this.value.trim().toLowerCase();
-        render();
-      });
+    function handleSearchInput(event) {
+      searchTerm = (event.target.value || '').trim().toLowerCase();
+      render();
+    }
+
+    function bindControlEvents() {
+      if (typeSelect) {
+        typeSelect.removeEventListener('change', render);
+        typeSelect.addEventListener('change', render);
+      }
+
+      if (yearSelect) {
+        yearSelect.removeEventListener('change', render);
+        yearSelect.addEventListener('change', render);
+      }
+
+      if (sortButton) {
+        sortButton.removeEventListener('click', handleSortClick);
+        sortButton.addEventListener('click', handleSortClick);
+      }
+
+      if (searchInput) {
+        searchInput.removeEventListener('input', handleSearchInput);
+        searchInput.addEventListener('input', handleSearchInput);
+      }
     }
 
     function enhanceDisplay(container) {
@@ -594,68 +652,92 @@
       citationContent.textContent = citationText;
     }
 
-    if (citationTabs.length) {
-      citationTabs.forEach(function (tab) {
-        tab.addEventListener('click', function () {
-          var format = tab.getAttribute('data-format');
-          if (!format || format === activeCitationFormat) {
-            return;
-          }
-          activeCitationFormat = format;
-          updateCitationContent();
-        });
-      });
+    function handleCitationTabClick(event) {
+      var tab = event.currentTarget;
+      var format = tab ? tab.getAttribute('data-format') : null;
+      if (!format || format === activeCitationFormat) {
+        return;
+      }
+      activeCitationFormat = format;
+      updateCitationContent();
     }
 
-    if (citationClose) {
-      citationClose.addEventListener('click', closeCitation);
+    function handleCitationModalClick(event) {
+      if (event.target === citationModal) {
+        closeCitation();
+      }
     }
 
-    if (citationModal) {
-      citationModal.addEventListener('click', function (event) {
-        if (event.target === citationModal) {
-          closeCitation();
-        }
-      });
-    }
+    function handleCitationActions(event) {
+      var actionButton = event.target.closest('button[data-action]');
+      if (!actionButton || !currentCitation) {
+        return;
+      }
+      var format = activeCitationFormat;
+      var citationText = format === 'bib' ? currentCitation.bib : currentCitation.plain;
 
-    if (citationActions) {
-      citationActions.addEventListener('click', function (event) {
-        var actionButton = event.target.closest('button[data-action]');
-        if (!actionButton || !currentCitation) {
-          return;
-        }
-        var format = activeCitationFormat;
-        var citationText = format === 'bib' ? currentCitation.bib : currentCitation.plain;
-
-        if (actionButton.getAttribute('data-action') === 'copy') {
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(citationText).then(function () {
-              showCopyFeedback('Citation copied to clipboard');
-            }).catch(function () {
-              fallbackCopy(citationText);
-              showCopyFeedback('Citation copied to clipboard');
-            });
-          } else {
+      if (actionButton.getAttribute('data-action') === 'copy') {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(citationText).then(function () {
+            showCopyFeedback('Citation copied to clipboard');
+          }).catch(function () {
             fallbackCopy(citationText);
             showCopyFeedback('Citation copied to clipboard');
-          }
-        } else if (actionButton.getAttribute('data-action') === 'download') {
-          hideCopyFeedback();
-          var extension = format === 'bib' ? 'bib' : 'txt';
-          var filename = 'citation-' + currentCitation.index + '.' + extension;
-          var blob = new Blob([citationText], { type: 'text/plain;charset=utf-8' });
-          var link = document.createElement('a');
-          link.href = URL.createObjectURL(blob);
-          link.download = filename;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          setTimeout(function () {
-            URL.revokeObjectURL(link.href);
-          }, 0);
+          });
+        } else {
+          fallbackCopy(citationText);
+          showCopyFeedback('Citation copied to clipboard');
         }
+      } else if (actionButton.getAttribute('data-action') === 'download') {
+        hideCopyFeedback();
+        var extension = format === 'bib' ? 'bib' : 'txt';
+        var filename = 'citation-' + currentCitation.index + '.' + extension;
+        var blob = new Blob([citationText], { type: 'text/plain;charset=utf-8' });
+        var link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(function () {
+          URL.revokeObjectURL(link.href);
+        }, 0);
+      }
+    }
+
+    function bindCitationEvents() {
+      if (!citationModal) {
+        citationTabs = [];
+        citationClose = null;
+        citationActions = null;
+        citationFeedback = null;
+        citationContent = null;
+        return;
+      }
+
+      citationTabs = Array.prototype.slice.call(citationModal.querySelectorAll('.citation-modal__tab'));
+      citationTabs.forEach(function (tab) {
+        tab.removeEventListener('click', handleCitationTabClick);
+        tab.addEventListener('click', handleCitationTabClick);
       });
+
+      citationClose = citationModal.querySelector('.citation-modal__close');
+      if (citationClose) {
+        citationClose.removeEventListener('click', closeCitation);
+        citationClose.addEventListener('click', closeCitation);
+      }
+
+      citationActions = citationModal.querySelector('.citation-modal__actions');
+      if (citationActions) {
+        citationActions.removeEventListener('click', handleCitationActions);
+        citationActions.addEventListener('click', handleCitationActions);
+      }
+
+      citationFeedback = citationModal.querySelector('.citation-modal__feedback');
+      citationContent = citationModal.querySelector('#citation-modal-content');
+
+      citationModal.removeEventListener('click', handleCitationModalClick);
+      citationModal.addEventListener('click', handleCitationModalClick);
     }
 
     document.addEventListener('keydown', function (event) {
@@ -706,6 +788,34 @@
       document.body.removeChild(textarea);
     }
 
-    render();
+    function initialize() {
+      captureElements();
+
+      if (!sourceList || !listEl || !typeSelect || !yearSelect || !sortButton) {
+        return;
+      }
+
+      bindControlEvents();
+      bindCitationEvents();
+
+      sortOrder = 'desc';
+      if (sortButton) {
+        sortButton.textContent = '⬇';
+      }
+
+      searchTerm = searchInput ? (searchInput.value || '').trim().toLowerCase() : '';
+      activeCitationFormat = 'plain';
+      currentCitation = null;
+      hideCopyFeedback();
+
+      refreshPublicationsData();
+      render();
+    }
+
+    document.addEventListener('publication:data-updated', function () {
+      initialize();
+    });
+
+    initialize();
   });
 })();


### PR DESCRIPTION
## Summary
- add owner edit hash configuration and expose it to the frontend for secure editing mode toggling
- implement a client-side owner editing toolkit with toolbar, modal editor, local overrides and copy helpers
- mark homepage sections as editable blocks and refresh news/publication widgets when edited, with dedicated styling for the UI

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b3a000d0832da7c894f7b9a294b1