### PR TITLE
Add owner editing overlay and publications editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Some examples:
         > A: Enter your google scholar homepage and click the paper name. Then you can see the paper ID from `citation_for_view=XXXX`, where `XXXX` is the required paper ID.
 1. Your page will be published at `https://USERNAME.github.io`.
 
+## Owner Editing Panel
+
+- Click the floating **Owner** button (bottom-right) to log in and open the editing toolbar. The default password is `changeme`.
+- Update the password by replacing `owner_tools.password_hash` in `_config.yml` with the SHA-256 hash of a new password.
+- After logging in you can edit each section in-place, save changes to the browser, export all edits as JSON, or clear local modifications.
+- Content edits are stored in your browser via `localStorage`. Export your edits before deploying them to keep an offline backup.
+
 ## Debug Locally
 
 1. Clone your REPO to local using `git clone`.

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,11 @@ description              : ""
 repository               : "wtwu95/wtwu95.github.io"
 google_scholar_stats_use_cdn : true
 
+owner_tools:
+  password_hash: "057ba03d6c44104863dc7361fe4578965d1887360f90a0895882e58a6248fc86" # SHA-256 for default password "changeme"
+  password_hint: "The default password is 'changeme'. Update owner_tools.password_hash in _config.yml to customize."
+  storage_prefix: "owner-edit"
+
 # google analytics
 google_analytics_id      : # "https://analytics.google.com/analytics/e2ban1wAAAAJ" 
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,9 @@
 <script src="assets/js/main.min.js"></script>
 <script src="assets/js/news-window.js"></script>
+<script>
+  window.__OWNER_CONFIG__ = {{ site.owner_tools | jsonify | default: '{}' }};
+</script>
+<script src="{{ '/assets/js/admin-editor.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="awards" data-editable-type="richtext" data-editable-title="Awards" markdown="1">
 <span class='anchor' id='-awards'></span>
 # 🎖 Awards
 
@@ -16,4 +17,5 @@
 - 2020 &nbsp; Outstanding Graduate of Dalian
 - 2020 &nbsp; First Prize of Liaoning Provincial Graduate Electronic Design Contest
 - 2019 · 2020 &nbsp; First Prizes of National Graduate Electronic Design Contest in Northeast Division
+</div>
 

--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="educations" data-editable-type="richtext" data-editable-title="Educations" markdown="1">
 # 🎓 Educations
 
 <ul class="cv-list">
@@ -5,7 +6,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>), 
+        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
         <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
       </div>
       <div class="cv-date">09/2021–03/2025</div>
@@ -17,7 +18,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>, 
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
         <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
       </div>
       <div class="cv-date">09/2018–06/2021</div>
@@ -29,10 +30,12 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>, 
+        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
         <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
       </div>
       <div class="cv-date">09/2014–06/2018</div>
     </div>
   </li>
 </ul>
+</div>
+

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="experiences" data-editable-type="richtext" data-editable-title="Experiences" markdown="1">
 # 📖 Experiences
 <ul class="cv-list">
   <li class="cv-item">
@@ -5,7 +6,7 @@
       <div class="cv-main">
         <span class="cv-role">Postdoctoral Fellow</span> in
         <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>, 
+        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
         <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
       </div>
       <div class="cv-date">04/2025–Present</div>
@@ -17,7 +18,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>, 
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
         <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
       </div>
       <div class="cv-date">01/2024–11/2024</div>
@@ -25,3 +26,5 @@
     <div class="cv-sub">Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi (施阳)</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)</div>
   </li>
 </ul>
+</div>
+

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,11 +1,14 @@
+<div class="editable-block" data-editable-key="intro" data-editable-type="richtext" data-editable-title="Biography" markdown="1">
 # 👨🏻‍🎓 Biography
 
 I am currently a Postdoctoral Fellow in [Research Centre for Low Altitude Economy](https://www.polyu.edu.hk/rclae/), [Department of Aeronautical and Aviation Engineering](https://www.polyu.edu.hk/aae/), [The Hong Kong Polytechnic University](https://www.polyu.edu.hk/), under the supervision of Prof. [Wen-Hua Chen](https://scholar.google.com/citations?user=UfIb9GkAAAAJ).
 
 I am a Youth Editorial Board Member of the [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS). I am also an origanizer for Special Session 2 of the 2025 10th ACIRS. He was selected for the inaugural **Doctoral Special Program of Young Elite Scientist Sponsorship Program** by China Association for Science and Technology (CAST) in 2025. I obtained **National Scholarships** for Graduate Students (Top 1%) in 2020, 2023, and 2024. My master thesis received the **Excellent Master Dissertation Award** of Liaoning Province!
 
-My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. 
+My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems.
 I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a>
 in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
 
 Welcome to contact me for academic collaboration! Please feel free to email me at [wtwu95@gmail.com](mailto:wtwu95@gmail.com) or [wen-tao.wu@polyu.edu.hk](mailto:wen-tao.wu@polyu.edu.hk).
+</div>
+

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="news" data-editable-type="richtext" data-editable-title="News" markdown="1">
 # 💬 News
 
 <div class="news-window" data-news-window data-visible-count="5" tabindex="0" aria-label="Latest news" markdown="1">
@@ -36,3 +37,5 @@
 {: .news-list}
 
 </div>
+</div>
+

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="publications" data-editable-type="publication-list" data-editable-title="Publications" data-editable-target="#publication-source" markdown="1">
 # 📝 Publications
 
 <!-- ### Selected Papers
@@ -632,4 +633,6 @@ mark.publication-highlight {
 }
 </style>
 
+</div>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
+

--- a/_pages/includes/serv.md
+++ b/_pages/includes/serv.md
@@ -1,3 +1,4 @@
+<div class="editable-block" data-editable-key="services" data-editable-type="richtext" data-editable-title="Professional Services" markdown="1">
 # 💻 Professional Services:
 
 ## Journal Editorial Boards
@@ -6,28 +7,28 @@
 ## Conference Program Committee and Editorial
 - **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
 
-## Teaching 
+## Teaching
 
 - **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
 
 ## Journal Reviewer
-- [IEEE Transactions on Automatic Control](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9)  
-- [IEEE Control Systems Letters](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673) 
-- [IEEE Transactions on Cybernetics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)  
-- [IEEE Transactions on Industrial Cyber-Physical Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8254253)  
-- [IEEE Transactions on Vehicular Technology](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25)  
-- [IEEE Transactions on Transportation Electrification](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6687312)  
-- [IEEE Open Journal of the Industrial Electronics Society](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8782712)  
-- [IEEE/CAA Journal of Automatica Sinica](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)  
-- [IEEE Transactions on Industrial Electronics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=41)  
-- [IEEE Transactions on Intelligent Vehicles](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)  
-- [IEEE Transactions on Systems, Man, and Cybernetics: Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021)  
-- [IEEE Internet of Things Journal](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6488907)  
-- [Ocean Engineering](https://www.sciencedirect.com/journal/ocean-engineering)  
-- [ISA Transactions](https://www.sciencedirect.com/journal/isa-transactions)  
-- [Circuits, Systems, and Signal Processing](https://link.springer.com/journal/34)  
-- [International Journal of Robust and Nonlinear Control](https://onlinelibrary.wiley.com/journal/10991239)  
-- [Nonlinear Dynamics](https://link.springer.com/journal/11071)  
+- [IEEE Transactions on Automatic Control](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9)
+- [IEEE Control Systems Letters](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673)
+- [IEEE Transactions on Cybernetics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)
+- [IEEE Transactions on Industrial Cyber-Physical Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8254253)
+- [IEEE Transactions on Vehicular Technology](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25)
+- [IEEE Transactions on Transportation Electrification](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6687312)
+- [IEEE Open Journal of the Industrial Electronics Society](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8782712)
+- [IEEE/CAA Journal of Automatica Sinica](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)
+- [IEEE Transactions on Industrial Electronics](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=41)
+- [IEEE Transactions on Intelligent Vehicles](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)
+- [IEEE Transactions on Systems, Man, and Cybernetics: Systems](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021)
+- [IEEE Internet of Things Journal](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6488907)
+- [Ocean Engineering](https://www.sciencedirect.com/journal/ocean-engineering)
+- [ISA Transactions](https://www.sciencedirect.com/journal/isa-transactions)
+- [Circuits, Systems, and Signal Processing](https://link.springer.com/journal/34)
+- [International Journal of Robust and Nonlinear Control](https://onlinelibrary.wiley.com/journal/10991239)
+- [Nonlinear Dynamics](https://link.springer.com/journal/11071)
 
 ## Conference Reviewer
 - IEEE Conference on Decision and Control (CDC)
@@ -35,3 +36,5 @@
 - Annual Conference of the IEEE Industrial Electronics Society (IECON)
 - Chinese Control Conference (CCC)
 - Chinese Control and Decision Conference (CCDC)
+</div>
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -139,3 +139,384 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   .cv-row { grid-template-columns: 1fr; gap: 4px; }
   .cv-date { order: 2; }
 }
+
+/* Owner editing interface */
+.owner-toolbar {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1600;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.owner-toolbar__button {
+  background: #00369f;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.3rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.owner-toolbar__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.22);
+}
+
+.owner-toolbar--active .owner-toolbar__button {
+  background: #0b67f3;
+}
+
+.owner-toolbar__menu {
+  display: none;
+  min-width: 11rem;
+  padding: 0.35rem 0;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.22);
+}
+
+.owner-toolbar__menu.is-open {
+  display: block;
+}
+
+.owner-toolbar__menu button {
+  display: block;
+  width: 100%;
+  text-align: right;
+  padding: 0.55rem 1rem;
+  background: transparent;
+  border: none;
+  font-size: 0.9rem;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.owner-toolbar__menu button:hover {
+  background: rgba(0, 54, 159, 0.08);
+  color: #0b67f3;
+}
+
+.owner-admin .owner-editable {
+  position: relative;
+  border-radius: 12px;
+  transition: box-shadow 0.2s ease;
+  box-shadow: 0 0 0 1px rgba(0, 54, 159, 0.1);
+}
+
+.owner-admin .owner-editable:hover {
+  box-shadow: 0 0 0 2px rgba(0, 54, 159, 0.2);
+}
+
+.owner-edit-handle {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  background: rgba(0, 54, 159, 0.88);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 2.3rem;
+  height: 2.3rem;
+  font-size: 1.05rem;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.28);
+}
+
+.owner-admin .owner-editable .owner-edit-handle {
+  display: inline-flex;
+}
+
+.owner-edit-handle:hover {
+  background: rgba(11, 103, 243, 0.92);
+}
+
+.owner-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.52);
+  backdrop-filter: blur(2px);
+  z-index: 1700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem;
+}
+
+.owner-modal__dialog {
+  background: #fff;
+  border-radius: 16px;
+  width: min(960px, 100%);
+  max-height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.28);
+}
+
+.owner-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  padding: 1.1rem 1.5rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.owner-modal__close {
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #475569;
+}
+
+.owner-modal__body {
+  padding: 1.25rem 1.5rem;
+  overflow-y: auto;
+}
+
+.owner-modal__footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.owner-input {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.16);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.owner-input:focus {
+  outline: none;
+  border-color: #0b67f3;
+  box-shadow: 0 0 0 3px rgba(11, 103, 243, 0.18);
+}
+
+.owner-textarea {
+  min-height: 160px;
+  font-family: 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', monospace;
+  resize: vertical;
+}
+
+.owner-textarea--large {
+  min-height: 220px;
+}
+
+.owner-button {
+  border: none;
+  border-radius: 10px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.owner-button--primary {
+  background: #0b67f3;
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(11, 103, 243, 0.25);
+}
+
+.owner-button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(11, 103, 243, 0.32);
+}
+
+.owner-button--ghost {
+  background: rgba(15, 23, 42, 0.05);
+  color: #1f2937;
+}
+
+.owner-button--ghost:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.owner-button--small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+}
+
+.owner-modal__help {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-bottom: 0.85rem;
+}
+
+.owner-toast {
+  position: fixed;
+  left: 1.5rem;
+  bottom: 1.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  padding: 0.65rem 1.15rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  opacity: 0;
+  transform: translateY(10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 2000;
+}
+
+.owner-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.owner-toast--error {
+  background: rgba(220, 38, 38, 0.92);
+}
+
+.owner-login__label {
+  display: block;
+  margin-bottom: 0.85rem;
+}
+
+.owner-login__hint {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-bottom: 0.65rem;
+}
+
+.owner-login__error {
+  font-size: 0.9rem;
+  color: #dc2626;
+  margin: 0;
+}
+
+.owner-pub-editor {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(320px, 1.5fr);
+  gap: 1.5rem;
+}
+
+.owner-pub-editor__list {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 14px;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.owner-pub-editor__list-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.owner-pub-editor__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.owner-pub-editor__item {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.owner-pub-editor__item.is-active {
+  border-color: rgba(11, 103, 243, 0.35);
+  box-shadow: 0 12px 28px rgba(11, 103, 243, 0.15);
+}
+
+.owner-pub-editor__summary {
+  border: none;
+  background: transparent;
+  text-align: left;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f2937;
+  cursor: pointer;
+}
+
+.owner-pub-editor__item-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.owner-pub-editor__form[hidden] {
+  display: none;
+}
+
+.owner-pub-editor__form-title {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+}
+
+.owner-pub-editor__field {
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.owner-pub-editor__field-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+  margin-bottom: 0.35rem;
+}
+
+.owner-pub-editor__form-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.owner-pub-editor__error {
+  color: #dc2626;
+  font-size: 0.88rem;
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+}
+
+.owner-pub-editor__empty {
+  font-size: 0.9rem;
+  color: #64748b;
+  text-align: center;
+  padding: 1rem 0.5rem;
+}
+
+@media (max-width: 960px) {
+  .owner-pub-editor {
+    grid-template-columns: 1fr;
+  }
+
+  .owner-pub-editor__list {
+    order: 2;
+  }
+
+  .owner-pub-editor__form {
+    order: 1;
+  }
+}
+
+body.owner-modal-open {
+  overflow: hidden;
+}

--- a/assets/js/admin-editor.js
+++ b/assets/js/admin-editor.js
@@ -1,0 +1,1114 @@
+(function () {
+  'use strict';
+
+  var win = window;
+  var doc = document;
+  var ownerConfig = win.__OWNER_CONFIG__ || {};
+  var passwordHash = (ownerConfig.password_hash || ownerConfig.passwordHash || '').toLowerCase();
+  var passwordHint = ownerConfig.password_hint || ownerConfig.passwordHint || '';
+  var storagePrefix = ownerConfig.storage_prefix || ownerConfig.storagePrefix || 'owner-edit';
+
+  var hasLocalStorage = false;
+  var hasSessionStorage = false;
+
+  try {
+    hasLocalStorage = !!win.localStorage;
+  } catch (error) {
+    hasLocalStorage = false;
+  }
+
+  try {
+    hasSessionStorage = !!win.sessionStorage;
+  } catch (error) {
+    hasSessionStorage = false;
+  }
+
+  var containers = Array.prototype.slice.call(doc.querySelectorAll('[data-editable-key]'));
+
+  if (!containers.length) {
+    return;
+  }
+
+  var originalContent = {};
+  var sessionKey = storagePrefix + ':auth';
+  var isAuthenticated = false;
+  var toolbar = null;
+  var toolbarButton = null;
+  var toolbarMenu = null;
+  var menuVisible = false;
+  var toast = null;
+  var toastTimer = null;
+  var activeModal = null;
+
+  function storageKey(key) {
+    return storagePrefix + ':section:' + key;
+  }
+
+  function cloneData(value) {
+    if (value === undefined || value === null) {
+      return value;
+    }
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      return value;
+    }
+  }
+
+  function resolveTarget(container) {
+    if (!container) {
+      return null;
+    }
+    var selector = container.getAttribute('data-editable-target');
+    if (!selector || selector === 'self' || selector === '@self') {
+      return container;
+    }
+    try {
+      var target = container.querySelector(selector);
+      return target || container;
+    } catch (error) {
+      return container;
+    }
+  }
+  function collectDataAttributes(element) {
+    var extras = {};
+    Array.prototype.slice.call(element.attributes || []).forEach(function (attr) {
+      if (attr && attr.name && attr.name.indexOf('data-') === 0) {
+        extras[attr.name] = attr.value;
+      }
+    });
+    return extras;
+  }
+
+  function serializePublicationItem(item) {
+    var attrs = collectDataAttributes(item);
+    var entry = {
+      type: item.getAttribute('data-type') || '',
+      year: item.getAttribute('data-year') || '',
+      date: item.getAttribute('data-date') || '',
+      plain: item.getAttribute('data-citation-plain') || '',
+      bib: item.getAttribute('data-citation-bibtex') || '',
+      html: item.innerHTML || '',
+      extras: {}
+    };
+
+    Object.keys(attrs).forEach(function (name) {
+      if (name === 'data-type' || name === 'data-year' || name === 'data-date' ||
+          name === 'data-citation-plain' || name === 'data-citation-bibtex') {
+        return;
+      }
+      entry.extras[name] = attrs[name];
+    });
+
+    return entry;
+  }
+
+  function serializeContainer(container) {
+    var type = container.getAttribute('data-editable-type') || 'richtext';
+    var target = resolveTarget(container);
+    if (!target) {
+      return { type: 'richtext', html: '' };
+    }
+
+    if (type === 'publication-list') {
+      var items = Array.prototype.slice.call(target.children).map(function (item) {
+        return serializePublicationItem(item);
+      });
+      return {
+        type: 'publication-list',
+        entries: items
+      };
+    }
+
+    return {
+      type: 'richtext',
+      html: target.innerHTML
+    };
+  }
+
+  function applyPublicationEntryAttributes(element, entry) {
+    if (!element || !entry) {
+      return;
+    }
+
+    function setAttr(name, value) {
+      if (value === undefined || value === null || value === '') {
+        element.removeAttribute(name);
+      } else {
+        element.setAttribute(name, value);
+      }
+    }
+
+    setAttr('data-type', entry.type || '');
+    setAttr('data-year', entry.year || '');
+    setAttr('data-date', entry.date || '');
+    setAttr('data-citation-plain', entry.plain || '');
+    setAttr('data-citation-bibtex', entry.bib || '');
+
+    if (entry.extras) {
+      Object.keys(entry.extras).forEach(function (name) {
+        var value = entry.extras[name];
+        if (value === undefined || value === null || value === '') {
+          element.removeAttribute(name);
+        } else {
+          element.setAttribute(name, value);
+        }
+      });
+    }
+  }
+
+  function createPublicationItem(entry) {
+    var li = doc.createElement('li');
+    applyPublicationEntryAttributes(li, entry);
+    li.innerHTML = entry && entry.html ? entry.html : '';
+    return li;
+  }
+
+  function applyDataToContainer(container, data) {
+    if (!container || !data) {
+      return;
+    }
+    var type = data.type || container.getAttribute('data-editable-type') || 'richtext';
+    var target = resolveTarget(container);
+    if (!target) {
+      return;
+    }
+
+    if (type === 'publication-list') {
+      target.innerHTML = '';
+      var entries = Array.isArray(data.entries) ? data.entries : [];
+      entries.forEach(function (entry) {
+        target.appendChild(createPublicationItem(entry));
+      });
+      return;
+    }
+
+    if (typeof data.html === 'string') {
+      target.innerHTML = data.html;
+    }
+  }
+
+  containers.forEach(function (container) {
+    var key = container.getAttribute('data-editable-key');
+    if (!key) {
+      return;
+    }
+    originalContent[key] = cloneData(serializeContainer(container));
+  });
+
+  if (hasLocalStorage) {
+    containers.forEach(function (container) {
+      var key = container.getAttribute('data-editable-key');
+      if (!key) {
+        return;
+      }
+      var stored = win.localStorage.getItem(storageKey(key));
+      if (!stored) {
+        return;
+      }
+      try {
+        var payload = JSON.parse(stored);
+        applyDataToContainer(container, payload);
+      } catch (error) {
+        console.warn('Failed to restore stored content for "' + key + '"', error);
+      }
+    });
+  }
+
+  var autoEnable = hasSessionStorage && win.sessionStorage.getItem(sessionKey) === '1';
+  createToolbar();
+  if (autoEnable) {
+    enableAdminMode(true);
+  }
+
+  function showToast(message, variant) {
+    if (!message) {
+      return;
+    }
+    if (!toast) {
+      toast = doc.createElement('div');
+      toast.className = 'owner-toast';
+      doc.body.appendChild(toast);
+    }
+    toast.textContent = message;
+    toast.classList.remove('owner-toast--error');
+    if (variant === 'error') {
+      toast.classList.add('owner-toast--error');
+    }
+    toast.classList.add('is-visible');
+    if (toastTimer) {
+      win.clearTimeout(toastTimer);
+    }
+    toastTimer = win.setTimeout(function () {
+      toast.classList.remove('is-visible');
+    }, 3200);
+  }
+
+  function getSectionTitle(container, fallback) {
+    return container.getAttribute('data-editable-title') || fallback || '';
+  }
+
+  function saveContainerData(container, data) {
+    if (!container || !hasLocalStorage) {
+      return;
+    }
+    var key = container.getAttribute('data-editable-key');
+    if (!key) {
+      return;
+    }
+    try {
+      var payload = data ? cloneData(data) : serializeContainer(container);
+      win.localStorage.setItem(storageKey(key), JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Failed to persist section "' + key + '"', error);
+    }
+  }
+
+  function clearContainerData(container) {
+    if (!container || !hasLocalStorage) {
+      return;
+    }
+    var key = container.getAttribute('data-editable-key');
+    if (!key) {
+      return;
+    }
+    win.localStorage.removeItem(storageKey(key));
+  }
+
+  function triggerSectionUpdated(container) {
+    if (!container) {
+      return;
+    }
+    var key = container.getAttribute('data-editable-key');
+    if (!key) {
+      return;
+    }
+    var detail = {
+      key: key,
+      type: container.getAttribute('data-editable-type') || 'richtext'
+    };
+    var event;
+    if (typeof win.CustomEvent === 'function') {
+      event = new win.CustomEvent('owner:section-updated', { detail: detail });
+    } else {
+      event = doc.createEvent('CustomEvent');
+      event.initCustomEvent('owner:section-updated', true, true, detail);
+    }
+    doc.dispatchEvent(event);
+  }
+
+  function refreshEditButton(container) {
+    if (!isAuthenticated) {
+      return;
+    }
+    removeEditButton(container);
+    ensureEditButton(container);
+  }
+
+  function resetContainer(container) {
+    if (!container) {
+      return;
+    }
+    var key = container.getAttribute('data-editable-key');
+    if (!key) {
+      return;
+    }
+    var original = originalContent[key];
+    if (!original) {
+      return;
+    }
+    applyDataToContainer(container, cloneData(original));
+    clearContainerData(container);
+    refreshEditButton(container);
+    triggerSectionUpdated(container);
+  }
+
+  function ensureEditButton(container) {
+    if (!container) {
+      return;
+    }
+    if (container.querySelector('.owner-edit-handle')) {
+      return;
+    }
+    var button = doc.createElement('button');
+    button.type = 'button';
+    button.className = 'owner-edit-handle';
+    button.setAttribute('aria-label', '编辑内容');
+    button.innerHTML = '✏️';
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      openEditor(container);
+    });
+    container.classList.add('owner-editable');
+    container.insertBefore(button, container.firstChild);
+  }
+
+  function removeEditButton(container) {
+    if (!container) {
+      return;
+    }
+    container.classList.remove('owner-editable');
+    var button = container.querySelector('.owner-edit-handle');
+    if (button && button.parentNode) {
+      button.parentNode.removeChild(button);
+    }
+  }
+
+  function createToolbar() {
+    toolbar = doc.createElement('div');
+    toolbar.className = 'owner-toolbar';
+
+    toolbarButton = doc.createElement('button');
+    toolbarButton.type = 'button';
+    toolbarButton.className = 'owner-toolbar__button';
+    toolbar.appendChild(toolbarButton);
+
+    toolbarMenu = doc.createElement('div');
+    toolbarMenu.className = 'owner-toolbar__menu';
+
+    var exportButton = doc.createElement('button');
+    exportButton.type = 'button';
+    exportButton.setAttribute('data-action', 'export');
+    exportButton.textContent = '导出修改';
+    toolbarMenu.appendChild(exportButton);
+
+    var clearButton = doc.createElement('button');
+    clearButton.type = 'button';
+    clearButton.setAttribute('data-action', 'clear');
+    clearButton.textContent = '清除全部修改';
+    toolbarMenu.appendChild(clearButton);
+
+    var logoutButton = doc.createElement('button');
+    logoutButton.type = 'button';
+    logoutButton.setAttribute('data-action', 'logout');
+    logoutButton.textContent = '退出编辑模式';
+    toolbarMenu.appendChild(logoutButton);
+
+    toolbar.appendChild(toolbarMenu);
+    doc.body.appendChild(toolbar);
+
+    toolbarButton.addEventListener('click', function () {
+      if (!isAuthenticated) {
+        openLoginModal();
+        return;
+      }
+      toggleMenu();
+    });
+
+    toolbarMenu.addEventListener('click', function (event) {
+      var button = event.target.closest('button[data-action]');
+      if (!button) {
+        return;
+      }
+      var action = button.getAttribute('data-action');
+      hideMenu();
+      if (action === 'export') {
+        exportChanges();
+      } else if (action === 'clear') {
+        clearAllChanges();
+      } else if (action === 'logout') {
+        disableAdminMode();
+        showToast('已退出编辑模式。');
+      }
+    });
+
+    doc.addEventListener('click', function (event) {
+      if (!menuVisible) {
+        return;
+      }
+      if (!toolbar.contains(event.target)) {
+        hideMenu();
+      }
+    });
+
+    updateToolbar();
+  }
+
+  function toggleMenu() {
+    menuVisible = !menuVisible;
+    toolbarMenu.classList.toggle('is-open', menuVisible);
+    toolbarButton.setAttribute('aria-expanded', menuVisible ? 'true' : 'false');
+  }
+
+  function hideMenu() {
+    menuVisible = false;
+    toolbarMenu.classList.remove('is-open');
+    toolbarButton.setAttribute('aria-expanded', 'false');
+  }
+
+  function updateToolbar() {
+    if (!toolbarButton) {
+      return;
+    }
+    toolbarButton.textContent = isAuthenticated ? '🔓 Owner' : '🔒 Owner';
+    toolbar.classList.toggle('owner-toolbar--active', isAuthenticated);
+    if (!isAuthenticated) {
+      hideMenu();
+    }
+  }
+
+  function enableAdminMode(skipToast) {
+    if (isAuthenticated) {
+      return;
+    }
+    isAuthenticated = true;
+    if (hasSessionStorage) {
+      win.sessionStorage.setItem(sessionKey, '1');
+    }
+    doc.body.classList.add('owner-admin');
+    containers.forEach(function (container) {
+      ensureEditButton(container);
+    });
+    updateToolbar();
+    if (!skipToast) {
+      showToast('已进入编辑模式。');
+    }
+  }
+
+  function disableAdminMode() {
+    if (!isAuthenticated) {
+      return;
+    }
+    isAuthenticated = false;
+    if (hasSessionStorage) {
+      win.sessionStorage.removeItem(sessionKey);
+    }
+    doc.body.classList.remove('owner-admin');
+    containers.forEach(function (container) {
+      removeEditButton(container);
+    });
+    if (activeModal && typeof activeModal.close === 'function') {
+      activeModal.close();
+    }
+    updateToolbar();
+  }
+
+  function hashString(value) {
+    if (win.crypto && win.crypto.subtle && win.TextEncoder) {
+      var encoder = new win.TextEncoder();
+      var data = encoder.encode(value);
+      return win.crypto.subtle.digest('SHA-256', data).then(function (buffer) {
+        return Array.prototype.map.call(new Uint8Array(buffer), function (byte) {
+          return ('00' + byte.toString(16)).slice(-2);
+        }).join('');
+      });
+    }
+    return Promise.resolve(value);
+  }
+
+  function createModal(options) {
+    if (activeModal && typeof activeModal.close === 'function') {
+      activeModal.close();
+    }
+    var overlay = doc.createElement('div');
+    overlay.className = 'owner-modal';
+
+    var dialog = doc.createElement('div');
+    dialog.className = 'owner-modal__dialog';
+    overlay.appendChild(dialog);
+
+    var header = doc.createElement('div');
+    header.className = 'owner-modal__header';
+    header.textContent = options && options.title ? options.title : '编辑内容';
+    dialog.appendChild(header);
+
+    var closeButton = doc.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'owner-modal__close';
+    closeButton.setAttribute('aria-label', '关闭弹窗');
+    closeButton.innerHTML = '&times;';
+    header.appendChild(closeButton);
+
+    var body = doc.createElement('div');
+    body.className = 'owner-modal__body';
+    dialog.appendChild(body);
+
+    var footer = doc.createElement('div');
+    footer.className = 'owner-modal__footer';
+    dialog.appendChild(footer);
+
+    function closeModal() {
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+      doc.body.classList.remove('owner-modal-open');
+      if (activeModal && activeModal.overlay === overlay) {
+        activeModal = null;
+      }
+    }
+
+    closeButton.addEventListener('click', closeModal);
+    overlay.addEventListener('click', function (event) {
+      if (event.target === overlay) {
+        closeModal();
+      }
+    });
+
+    doc.body.appendChild(overlay);
+    doc.body.classList.add('owner-modal-open');
+
+    activeModal = {
+      overlay: overlay,
+      dialog: dialog,
+      body: body,
+      footer: footer,
+      close: closeModal,
+      header: header
+    };
+
+    return activeModal;
+  }
+
+  function createActionButton(label, variant) {
+    var button = doc.createElement('button');
+    button.type = 'button';
+    button.className = 'owner-button';
+    if (variant) {
+      button.classList.add('owner-button--' + variant);
+    }
+    button.textContent = label;
+    return button;
+  }
+
+  function createSmallButton(label, variant) {
+    var button = createActionButton(label, variant);
+    button.classList.add('owner-button--small');
+    return button;
+  }
+
+  function openLoginModal() {
+    var modal = createModal({ title: '身份验证' });
+    var body = modal.body;
+    var footer = modal.footer;
+
+    var form = doc.createElement('form');
+    form.className = 'owner-login';
+
+    var label = doc.createElement('label');
+    label.className = 'owner-login__label';
+    label.textContent = '请输入管理员密码';
+    var input = doc.createElement('input');
+    input.type = 'password';
+    input.className = 'owner-input';
+    input.required = true;
+    label.appendChild(input);
+    form.appendChild(label);
+
+    if (passwordHint) {
+      var hint = doc.createElement('p');
+      hint.className = 'owner-login__hint';
+      hint.textContent = passwordHint;
+      form.appendChild(hint);
+    }
+
+    var error = doc.createElement('p');
+    error.className = 'owner-login__error';
+    error.setAttribute('hidden', 'hidden');
+    form.appendChild(error);
+
+    body.appendChild(form);
+
+    var submitButton = createActionButton('登录', 'primary');
+    var cancelButton = createActionButton('取消', 'ghost');
+    footer.appendChild(submitButton);
+    footer.appendChild(cancelButton);
+
+    cancelButton.addEventListener('click', function () {
+      modal.close();
+    });
+
+    function showError() {
+      error.textContent = '密码不正确，请重试。';
+      error.removeAttribute('hidden');
+      input.focus();
+      input.select();
+    }
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      submitButton.setAttribute('disabled', 'disabled');
+      hashString(input.value.trim()).then(function (hash) {
+        submitButton.removeAttribute('disabled');
+        if (!passwordHash) {
+          modal.close();
+          enableAdminMode();
+          showToast('已进入编辑模式。');
+          return;
+        }
+        if (hash && hash.toLowerCase() === passwordHash) {
+          modal.close();
+          enableAdminMode();
+          showToast('登录成功，已进入编辑模式。');
+        } else if (input.value && input.value === passwordHash) {
+          modal.close();
+          enableAdminMode();
+          showToast('登录成功，已进入编辑模式。');
+        } else {
+          showError();
+        }
+      }).catch(function () {
+        submitButton.removeAttribute('disabled');
+        showError();
+      });
+    });
+
+    submitButton.addEventListener('click', function () {
+      form.dispatchEvent(new Event('submit', { cancelable: true }));
+    });
+
+    setTimeout(function () {
+      input.focus();
+    }, 50);
+  }
+
+  function openEditor(container) {
+    var type = container.getAttribute('data-editable-type') || 'richtext';
+    if (type === 'publication-list') {
+      openPublicationEditor(container);
+    } else {
+      openRichtextEditor(container);
+    }
+  }
+
+  function openRichtextEditor(container) {
+    var title = getSectionTitle(container, '编辑内容');
+    var target = resolveTarget(container);
+    if (!target) {
+      return;
+    }
+    var modal = createModal({ title: title });
+    var body = modal.body;
+    var footer = modal.footer;
+
+    var description = doc.createElement('p');
+    description.className = 'owner-modal__help';
+    description.textContent = '可以直接编辑下方的 HTML 内容，保存后仅对当前浏览器生效，可通过“导出修改”进行备份。';
+    body.appendChild(description);
+
+    var textarea = doc.createElement('textarea');
+    textarea.className = 'owner-textarea';
+    textarea.value = target.innerHTML.trim();
+    body.appendChild(textarea);
+
+    var saveButton = createActionButton('保存', 'primary');
+    var resetButton = createActionButton('恢复默认', 'ghost');
+    var cancelButton = createActionButton('取消', 'ghost');
+    footer.appendChild(saveButton);
+    footer.appendChild(resetButton);
+    footer.appendChild(cancelButton);
+
+    saveButton.addEventListener('click', function () {
+      target.innerHTML = textarea.value;
+      saveContainerData(container, { type: 'richtext', html: textarea.value });
+      modal.close();
+      refreshEditButton(container);
+      triggerSectionUpdated(container);
+      showToast('已保存“' + title + '”的修改。');
+    });
+
+    resetButton.addEventListener('click', function () {
+      if (!win.confirm('确定要恢复“' + title + '”的默认内容吗？')) {
+        return;
+      }
+      resetContainer(container);
+      modal.close();
+      showToast('已恢复默认内容。');
+    });
+
+    cancelButton.addEventListener('click', function () {
+      modal.close();
+    });
+  }
+
+  function extractPublicationTitle(entry) {
+    if (!entry) {
+      return '';
+    }
+    var html = entry.html || '';
+    if (!html) {
+      return '';
+    }
+    var temp = doc.createElement('div');
+    temp.innerHTML = html;
+    var link = temp.querySelector('a');
+    if (link && link.textContent.trim()) {
+      return link.textContent.trim();
+    }
+    var paragraph = temp.querySelector('p');
+    if (paragraph && paragraph.textContent.trim()) {
+      return paragraph.textContent.trim();
+    }
+    return html.replace(/<[^>]+>/g, '').trim();
+  }
+
+  function formatPublicationSummary(entry, index) {
+    var year = entry.year || '—';
+    var title = extractPublicationTitle(entry) || '(未命名条目)';
+    return '[' + year + '] ' + title.replace(/\s+/g, ' ').trim();
+  }
+
+  function openPublicationEditor(container) {
+    var title = getSectionTitle(container, 'Publications');
+    var target = resolveTarget(container);
+    if (!target) {
+      return;
+    }
+
+    var entries = Array.prototype.slice.call(target.children).map(function (item) {
+      return serializePublicationItem(item);
+    });
+    var workingEntries = entries.map(function (entry) {
+      return cloneData(entry);
+    });
+    var activeIndex = null;
+
+    var modal = createModal({ title: title + ' - 编辑列表' });
+    var body = modal.body;
+    var footer = modal.footer;
+
+    var wrapper = doc.createElement('div');
+    wrapper.className = 'owner-pub-editor';
+    body.appendChild(wrapper);
+
+    var listSection = doc.createElement('div');
+    listSection.className = 'owner-pub-editor__list';
+    wrapper.appendChild(listSection);
+
+    var listHeader = doc.createElement('div');
+    listHeader.className = 'owner-pub-editor__list-header';
+    var addButton = createActionButton('新增条目', 'primary');
+    listHeader.appendChild(addButton);
+    listSection.appendChild(listHeader);
+
+    var itemsContainer = doc.createElement('ul');
+    itemsContainer.className = 'owner-pub-editor__items';
+    listSection.appendChild(itemsContainer);
+
+    var formSection = doc.createElement('div');
+    formSection.className = 'owner-pub-editor__form';
+    formSection.setAttribute('hidden', 'hidden');
+    wrapper.appendChild(formSection);
+
+    var formTitle = doc.createElement('h3');
+    formTitle.className = 'owner-pub-editor__form-title';
+    formSection.appendChild(formTitle);
+
+    var form = doc.createElement('form');
+    form.className = 'owner-pub-editor__details';
+    formSection.appendChild(form);
+
+    var errorMessage = doc.createElement('p');
+    errorMessage.className = 'owner-pub-editor__error';
+    errorMessage.setAttribute('hidden', 'hidden');
+    form.appendChild(errorMessage);
+
+    function createField(labelText, input) {
+      var field = doc.createElement('label');
+      field.className = 'owner-pub-editor__field';
+      var span = doc.createElement('span');
+      span.className = 'owner-pub-editor__field-label';
+      span.textContent = labelText;
+      field.appendChild(span);
+      input.classList.add('owner-input');
+      field.appendChild(input);
+      form.appendChild(field);
+      return input;
+    }
+
+    var typeInput = createField('类别 (如 journal/conference)', doc.createElement('input'));
+    var yearInput = createField('年份', doc.createElement('input'));
+    var dateInput = createField('日期 (YYYY 或 YYYY-MM)', doc.createElement('input'));
+    var plainTextarea = createField('Plain Citation (可选)', doc.createElement('textarea'));
+    plainTextarea.classList.add('owner-textarea');
+    var bibTextarea = createField('BibTeX (可选)', doc.createElement('textarea'));
+    bibTextarea.classList.add('owner-textarea');
+    var htmlTextarea = createField('展示内容（HTML）', doc.createElement('textarea'));
+    htmlTextarea.classList.add('owner-textarea', 'owner-textarea--large');
+
+    var extrasTextarea = createField('额外 data-* 属性 (JSON，可选)', doc.createElement('textarea'));
+    extrasTextarea.classList.add('owner-textarea');
+
+    var formButtons = doc.createElement('div');
+    formButtons.className = 'owner-pub-editor__form-actions';
+    var formSaveButton = createActionButton('更新条目', 'primary');
+    var formCancelButton = createActionButton('关闭编辑', 'ghost');
+    formButtons.appendChild(formSaveButton);
+    formButtons.appendChild(formCancelButton);
+    form.appendChild(formButtons);
+
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+      applyFormChanges();
+    });
+
+    formSaveButton.addEventListener('click', function () {
+      form.dispatchEvent(new Event('submit', { cancelable: true }));
+    });
+
+    formCancelButton.addEventListener('click', function () {
+      hideForm();
+    });
+
+    addButton.addEventListener('click', function () {
+      var newEntry = {
+        type: '',
+        year: new Date().getFullYear().toString(),
+        date: '',
+        plain: '',
+        bib: '',
+        html: '<p><strong>作者</strong>, “论文标题,” <em>期刊/会议</em>, 2025.</p>',
+        extras: {}
+      };
+      workingEntries.push(newEntry);
+      renderList();
+      openForm(workingEntries.length - 1);
+    });
+
+    function renderList() {
+      itemsContainer.innerHTML = '';
+      if (!workingEntries.length) {
+        var empty = doc.createElement('li');
+        empty.className = 'owner-pub-editor__empty';
+        empty.textContent = '暂无条目';
+        itemsContainer.appendChild(empty);
+        hideForm();
+        return;
+      }
+      workingEntries.forEach(function (entry, index) {
+        var item = doc.createElement('li');
+        item.className = 'owner-pub-editor__item';
+        if (index === activeIndex) {
+          item.classList.add('is-active');
+        }
+
+        var summaryButton = doc.createElement('button');
+        summaryButton.type = 'button';
+        summaryButton.className = 'owner-pub-editor__summary';
+        summaryButton.textContent = formatPublicationSummary(entry, index);
+        summaryButton.addEventListener('click', function () {
+          openForm(index);
+        });
+        item.appendChild(summaryButton);
+
+        var actions = doc.createElement('div');
+        actions.className = 'owner-pub-editor__item-actions';
+
+        var upButton = createSmallButton('上移', 'ghost');
+        upButton.disabled = index === 0;
+        upButton.addEventListener('click', function () {
+          moveEntry(index, index - 1);
+        });
+        actions.appendChild(upButton);
+
+        var downButton = createSmallButton('下移', 'ghost');
+        downButton.disabled = index === workingEntries.length - 1;
+        downButton.addEventListener('click', function () {
+          moveEntry(index, index + 1);
+        });
+        actions.appendChild(downButton);
+
+        var deleteButton = createSmallButton('删除', 'ghost');
+        deleteButton.addEventListener('click', function () {
+          removeEntry(index);
+        });
+        actions.appendChild(deleteButton);
+
+        item.appendChild(actions);
+        itemsContainer.appendChild(item);
+      });
+    }
+
+    function hideForm() {
+      activeIndex = null;
+      formSection.setAttribute('hidden', 'hidden');
+    }
+
+    function openForm(index) {
+      activeIndex = index;
+      var entry = workingEntries[index];
+      formSection.removeAttribute('hidden');
+      formTitle.textContent = '编辑条目 #' + (index + 1);
+      errorMessage.setAttribute('hidden', 'hidden');
+      typeInput.value = entry.type || '';
+      yearInput.value = entry.year || '';
+      dateInput.value = entry.date || '';
+      plainTextarea.value = entry.plain || '';
+      bibTextarea.value = entry.bib || '';
+      htmlTextarea.value = entry.html || '';
+      extrasTextarea.value = entry.extras ? JSON.stringify(entry.extras, null, 2) : '{}';
+      renderList();
+    }
+
+    function applyFormChanges(skipMessage) {
+      if (activeIndex === null) {
+        return false;
+      }
+      errorMessage.setAttribute('hidden', 'hidden');
+      var entry = workingEntries[activeIndex];
+      entry.type = typeInput.value.trim();
+      entry.year = yearInput.value.trim();
+      entry.date = dateInput.value.trim();
+      entry.plain = plainTextarea.value.trim();
+      entry.bib = bibTextarea.value.trim();
+      entry.html = htmlTextarea.value;
+      var extrasText = extrasTextarea.value.trim();
+      if (extrasText) {
+        try {
+          var extrasObj = extrasText ? JSON.parse(extrasText) : {};
+          entry.extras = extrasObj && typeof extrasObj === 'object' ? extrasObj : {};
+        } catch (error) {
+          errorMessage.textContent = '额外属性不是有效的 JSON 格式。';
+          errorMessage.removeAttribute('hidden');
+          return false;
+        }
+      } else {
+        entry.extras = {};
+      }
+      renderList();
+      if (!skipMessage) {
+        showToast('条目已更新（请记得保存全部修改）。');
+      }
+      return true;
+    }
+
+    function moveEntry(from, to) {
+      if (to < 0 || to >= workingEntries.length) {
+        return;
+      }
+      var item = workingEntries.splice(from, 1)[0];
+      workingEntries.splice(to, 0, item);
+      if (activeIndex === from) {
+        activeIndex = to;
+      } else if (activeIndex === to) {
+        activeIndex = from;
+      }
+      renderList();
+    }
+
+    function removeEntry(index) {
+      if (!win.confirm('确定要删除该条目吗？')) {
+        return;
+      }
+      workingEntries.splice(index, 1);
+      if (activeIndex === index) {
+        hideForm();
+      } else if (activeIndex > index) {
+        activeIndex -= 1;
+      }
+      renderList();
+    }
+
+    renderList();
+
+    var saveAllButton = createActionButton('保存修改', 'primary');
+    var resetButton = createActionButton('恢复默认', 'ghost');
+    var closeButton = createActionButton('完成', 'ghost');
+    footer.appendChild(saveAllButton);
+    footer.appendChild(resetButton);
+    footer.appendChild(closeButton);
+
+    saveAllButton.addEventListener('click', function () {
+      if (!applyFormChanges(true)) {
+        return;
+      }
+      var payload = {
+        type: 'publication-list',
+        entries: workingEntries.map(function (entry) {
+          return cloneData(entry);
+        })
+      };
+      applyDataToContainer(container, payload);
+      saveContainerData(container, payload);
+      modal.close();
+      refreshEditButton(container);
+      triggerSectionUpdated(container);
+      showToast('已更新论文列表。');
+    });
+
+    resetButton.addEventListener('click', function () {
+      if (!win.confirm('确定要恢复默认的论文列表吗？')) {
+        return;
+      }
+      resetContainer(container);
+      modal.close();
+      showToast('已恢复默认论文列表。');
+    });
+
+    closeButton.addEventListener('click', function () {
+      modal.close();
+    });
+  }
+
+  function exportChanges() {
+    if (!hasLocalStorage) {
+      showToast('当前浏览器不支持导出。', 'error');
+      return;
+    }
+    var sections = {};
+    containers.forEach(function (container) {
+      var key = container.getAttribute('data-editable-key');
+      if (!key) {
+        return;
+      }
+      var stored = win.localStorage.getItem(storageKey(key));
+      if (!stored) {
+        return;
+      }
+      try {
+        sections[key] = JSON.parse(stored);
+      } catch (error) {
+        console.warn('Skip invalid stored data for "' + key + '"', error);
+      }
+    });
+    var payload = {
+      generatedAt: new Date().toISOString(),
+      sections: sections
+    };
+    try {
+      var json = JSON.stringify(payload, null, 2);
+      var blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+      var link = doc.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'owner-content-' + Date.now() + '.json';
+      doc.body.appendChild(link);
+      link.click();
+      doc.body.removeChild(link);
+      setTimeout(function () {
+        URL.revokeObjectURL(link.href);
+      }, 0);
+      showToast('已导出当前修改。');
+    } catch (error) {
+      showToast('导出时出现问题。', 'error');
+    }
+  }
+
+  function clearAllChanges() {
+    if (!hasLocalStorage) {
+      showToast('当前浏览器不支持本地存储。', 'error');
+      return;
+    }
+    if (!win.confirm('确定要清除全部本地修改并恢复默认内容吗？')) {
+      return;
+    }
+    containers.forEach(function (container) {
+      clearContainerData(container);
+      var key = container.getAttribute('data-editable-key');
+      var original = originalContent[key];
+      if (original) {
+        applyDataToContainer(container, cloneData(original));
+        triggerSectionUpdated(container);
+      }
+      refreshEditButton(container);
+    });
+    showToast('已清除全部本地修改。');
+  }
+
+  doc.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape' && activeModal && typeof activeModal.close === 'function') {
+      activeModal.close();
+    }
+  });
+
+})();
+

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -60,55 +60,63 @@
       return replaced;
     }
 
-    var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
-      var year = parseInt(item.getAttribute('data-year'), 10);
-      var plainCitation = item.getAttribute('data-citation-plain') || '';
-      var bibCitation = item.getAttribute('data-citation-bibtex') || '';
-      var sanitized = sanitizeNode(item);
-      var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
-      var normalizedText = normalizeQuotes(textContent);
-      return {
-        type: item.getAttribute('data-type') || 'other',
-        year: isNaN(year) ? null : year,
-        date: item.getAttribute('data-date') || '',
-        content: item.innerHTML.trim(),
-        rawText: normalizedText,
-        searchText: normalizedText.toLowerCase(),
-        plainCitation: plainCitation,
-        bibCitation: bibCitation
-      };
-    });
+    var publications = [];
 
-    publications = publications.map(function (pub) {
-      pub.citations = generateCitations(pub);
-      return pub;
-    });
+    function readSourceItems() {
+      return Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
+        var year = parseInt(item.getAttribute('data-year'), 10);
+        var plainCitation = item.getAttribute('data-citation-plain') || '';
+        var bibCitation = item.getAttribute('data-citation-bibtex') || '';
+        var sanitized = sanitizeNode(item);
+        var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
+        var normalizedText = normalizeQuotes(textContent);
+        return {
+          type: item.getAttribute('data-type') || 'other',
+          year: isNaN(year) ? null : year,
+          date: item.getAttribute('data-date') || '',
+          content: item.innerHTML.trim(),
+          rawText: normalizedText,
+          searchText: normalizedText.toLowerCase(),
+          plainCitation: plainCitation,
+          bibCitation: bibCitation
+        };
+      }).map(function (pub) {
+        pub.citations = generateCitations(pub);
+        return pub;
+      });
+    }
 
-    var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
-      return pub.type;
-    }).filter(Boolean)));
-
-    var orderedOptions = typeOrder.map(function (type) {
-      return {
-        value: type,
-        label: typeLabels[type] || type
-      };
-    });
-
-    uniqueTypes.forEach(function (type) {
-      if (typeOrder.indexOf(type) === -1) {
-        orderedOptions.push({
+    function updateTypeOptions() {
+      var previous = typeSelect.value;
+      var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
+        return pub.type;
+      }).filter(Boolean)));
+      var orderedOptions = typeOrder.map(function (type) {
+        return {
           value: type,
           label: typeLabels[type] || type
-        });
+        };
+      });
+      uniqueTypes.forEach(function (type) {
+        if (typeOrder.indexOf(type) === -1) {
+          orderedOptions.push({
+            value: type,
+            label: typeLabels[type] || type
+          });
+        }
+      });
+      typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
+        return '<option value="' + type.value + '">' + type.label + '</option>';
+      }).join('');
+      if (typeSelect.querySelector('option[value="' + previous + '"]')) {
+        typeSelect.value = previous;
+      } else {
+        typeSelect.value = 'all';
       }
-    });
-
-    typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
-      return '<option value="' + type.value + '">' + type.label + '</option>';
-    }).join('');
+    }
 
     function updateYearOptions() {
+      var previous = yearSelect.value;
       var years = Array.from(new Set(publications.map(function (pub) {
         return pub.year;
       }).filter(Boolean)));
@@ -116,11 +124,21 @@
       yearSelect.innerHTML = '<option value="all">Date</option>' + years.map(function (year) {
         return '<option value="' + year + '">' + year + '</option>';
       }).join('');
+      if (yearSelect.querySelector('option[value="' + previous + '"]')) {
+        yearSelect.value = previous;
+      } else {
+        yearSelect.value = 'all';
+      }
     }
 
-    updateYearOptions();
-
     var sortOrder = 'desc';
+
+    function refreshData() {
+      publications = readSourceItems();
+      updateTypeOptions();
+      updateYearOptions();
+      render();
+    }
 
     function normalizeDate(dateStr, year) {
       if (!dateStr) {
@@ -706,6 +724,15 @@
       document.body.removeChild(textarea);
     }
 
-    render();
+    refreshData();
+
+    document.addEventListener('owner:section-updated', function (event) {
+      if (!event || !event.detail) {
+        return;
+      }
+      if (event.detail.key === 'publications') {
+        refreshData();
+      }
+    });
   });
 })();


### PR DESCRIPTION
## Summary
- add an owner-only editing overlay with a floating toolbar and modal editors backed by local storage
- wrap homepage sections with editable containers and document the new workflow in the README
- expose publication data refresh hooks so the list updates after owner edits

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed and bundler install blocked by network 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b3a000d0832da7c894f7b9a294b1