### PR TITLE
Create dedicated pages for publications, awards, and services

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,10 +13,10 @@ main:
     url: "/#-news"
 
   - title: "Publications"
-    url: "/#-publications"
+    url: "/publications/"
 
   - title: "Awards"
-    url: "/#-awards"
+    url: "/awards/"
 
   - title: "Services"
-    url: "/#-professional-services"
+    url: "/services/"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ permalink: /
 title: ""
 excerpt: ""
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
@@ -18,8 +18,17 @@ redirect_from:
 
 {% include_relative includes/news.md %}
 
-{% include_relative includes/pub.md %}
+<span class='anchor' id='-publications'></span>
+## 📚 Publications
 
-{% include_relative includes/award.md %}
+Explore the full list of publications on the [Publications page](/publications/).
 
-{% include_relative includes/serv.md %}
+<span class='anchor' id='-awards'></span>
+## 🎖 Awards
+
+Find the complete award record on the [Awards page](/awards/).
+
+<span class='anchor' id='-professional-services'></span>
+## 💻 Professional Services
+
+View detailed service activities on the [Professional Services page](/services/).

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -1,0 +1,7 @@
+---
+permalink: /awards/
+title: ""
+author_profile: true
+---
+
+{% include_relative includes/award.md %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,9 @@
+---
+permalink: /publications/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-publications'></span>
+
+{% include_relative includes/pub.md %}

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -1,0 +1,9 @@
+---
+permalink: /services/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-professional-services'></span>
+
+{% include_relative includes/serv.md %}


### PR DESCRIPTION
## Summary
- add standalone pages for publications, awards, and professional services by reusing the existing include content
- shorten the homepage by replacing the large sections with pointers to the new pages while preserving anchor IDs
- update the primary navigation links to target the dedicated pages for quicker access

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb89d3a8832dbc650a95d1bd626b