### PR TITLE
Ensure dedicated pages render with the standard layout

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,10 +13,10 @@ main:
     url: "/#-news"
 
   - title: "Publications"
-    url: "/#-publications"
+    url: "/publications/"
 
   - title: "Awards"
-    url: "/#-awards"
+    url: "/awards/"
 
   - title: "Services"
-    url: "/#-professional-services"
+    url: "/services/"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -4,9 +4,13 @@
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
-          <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item"><a href="#about-me">Homepage</a></li>
+          <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
+            <a href="{{ '/' | relative_url }}#about-me" target="_self">Homepage</a>
+          </li>
           {% for link in site.data.navigation.main %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item">
+              <a href="{{ link.url | relative_url }}" target="_self">{{ link.title }}</a>
+            </li>
           {% endfor %}
         </ul>
         <ul class="hidden-links hidden"></ul>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ permalink: /
 title: ""
 excerpt: ""
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
@@ -18,8 +18,17 @@ redirect_from:
 
 {% include_relative includes/news.md %}
 
-{% include_relative includes/pub.md %}
+<span class='anchor' id='-publications'></span>
+## 📚 Publications
 
-{% include_relative includes/award.md %}
+Explore the full list of publications on the [Publications page](/publications/).
 
-{% include_relative includes/serv.md %}
+<span class='anchor' id='-awards'></span>
+## 🎖 Awards
+
+Find the complete award record on the [Awards page](/awards/).
+
+<span class='anchor' id='-professional-services'></span>
+## 💻 Professional Services
+
+View detailed service activities on the [Professional Services page](/services/).

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -1,0 +1,8 @@
+---
+layout: default
+permalink: /awards/
+title: ""
+author_profile: true
+---
+
+{% include_relative includes/award.md %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,10 @@
+---
+layout: default
+permalink: /publications/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-publications'></span>
+
+{% include_relative includes/pub.md %}

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -1,0 +1,10 @@
+---
+layout: default
+permalink: /services/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-professional-services'></span>
+
+{% include_relative includes/serv.md %}


### PR DESCRIPTION
## Summary
- make the navigation menu use relative URLs that open in the same tab so dedicated pages no longer spawn a new window
- explicitly set the default layout on the publications, awards, and services pages to ensure the masthead and sidebar render consistently

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable unavailable; bundle install requires network access which returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb89d3a8832dbc650a95d1bd626b