### PR TITLE
Restore styling assets for standalone pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,10 +13,10 @@ main:
     url: "/#-news"
 
   - title: "Publications"
-    url: "/#-publications"
+    url: "/publications/"
 
   - title: "Awards"
-    url: "/#-awards"
+    url: "/awards/"
 
   - title: "Services"
-    url: "/#-professional-services"
+    url: "/services/"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,9 +11,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="assets/css/main.css">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
 <meta http-equiv="cleartype" content="on">
-<head>
-  <base target="_blank">
-</head>
+

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,13 +1,13 @@
-<link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png">
-<link rel="manifest" href="images/site.webmanifest">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ '/images/apple-touch-icon.png' | relative_url }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/favicon-32x32.png' | relative_url }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ '/images/favicon-16x16.png' | relative_url }}">
+<link rel="manifest" href="{{ '/images/site.webmanifest' | relative_url }}">
 
 <meta name="msapplication-TileColor" content="#000000">
-<meta name="msapplication-TileImage" content="images/mstile-144x144.png?v=M44lzPylqQ">
-<meta name="msapplication-config" content="images/browserconfig.xml?v=M44lzPylqQ">
+<meta name="msapplication-TileImage" content="{{ '/images/mstile-144x144.png?v=M44lzPylqQ' | relative_url }}">
+<meta name="msapplication-config" content="{{ '/images/browserconfig.xml?v=M44lzPylqQ' | relative_url }}">
 <meta name="theme-color" content="#ffffff">
-<link rel="stylesheet" href="assets/css/academicons.css"/>
+<link rel="stylesheet" href="{{ '/assets/css/academicons.css' | relative_url }}"/>
 
 <script type="text/x-mathjax-config"> MathJax.Hub.Config({ TeX: { equationNumbers: { autoNumber: "all" } } }); </script>
 <script type="text/x-mathjax-config">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -4,9 +4,13 @@
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
-          <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item"><a href="#about-me">Homepage</a></li>
+          <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
+            <a href="{{ '/' | relative_url }}#about-me" target="_self">Homepage</a>
+          </li>
           {% for link in site.data.navigation.main %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item">
+              <a href="{{ link.url | relative_url }}" target="_self">{{ link.title }}</a>
+            </li>
           {% endfor %}
         </ul>
         <ul class="hidden-links hidden"></ul>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
-<script src="assets/js/main.min.js"></script>
-<script src="assets/js/news-window.js"></script>
+<script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}
+

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,7 +3,7 @@ permalink: /
 title: ""
 excerpt: ""
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
@@ -18,8 +18,17 @@ redirect_from:
 
 {% include_relative includes/news.md %}
 
-{% include_relative includes/pub.md %}
+<span class='anchor' id='-publications'></span>
+## 📚 Publications
 
-{% include_relative includes/award.md %}
+Explore the full list of publications on the [Publications page](/publications/).
 
-{% include_relative includes/serv.md %}
+<span class='anchor' id='-awards'></span>
+## 🎖 Awards
+
+Find the complete award record on the [Awards page](/awards/).
+
+<span class='anchor' id='-professional-services'></span>
+## 💻 Professional Services
+
+View detailed service activities on the [Professional Services page](/services/).

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -1,0 +1,8 @@
+---
+layout: default
+permalink: /awards/
+title: ""
+author_profile: true
+---
+
+{% include_relative includes/award.md %}

--- a/_pages/includes/col.md
+++ b/_pages/includes/col.md
@@ -5,12 +5,12 @@
         <div style="display: flex; justify-content: space-between;">
             <div>
                 <div class="badge">IEEE T-SMCA 2023</div>
-                <img src='assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' alt="sym" width="50%">
+                <img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="50%">
                 <p>介绍第一个人物</p>
             </div>
             <div>
                 <div class="badge">IEEE T-SMCA 2023</div>
-                <img src='assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' alt="sym" width="50%">
+                <img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="50%">
                 <p>介绍第二个人物</p>
             </div>
         </div>

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -2,7 +2,7 @@
 
 ### Selected Papers
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE CAA/JAS 2023</div><img src='assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE CAA/JAS 2023</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)\\
@@ -15,7 +15,7 @@
 </div>
 
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><img src='assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.gif' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043) \\
@@ -26,7 +26,7 @@
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='{{ '/assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)\\
@@ -40,7 +40,7 @@
 
 
 
-<!-- <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2022</div><img src='assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.gif' alt="sym" width="100%"></div></div>
+<!-- <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Output-Feedback Finite-Time Safety-Critical Coordinated Control of Path-Guided Marine Surface Vehicles Based on Neurodynamic Optimization](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)
@@ -56,7 +56,7 @@
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,10 @@
+---
+layout: default
+permalink: /publications/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-publications'></span>
+
+{% include_relative includes/pub.md %}

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -1,0 +1,10 @@
+---
+layout: default
+permalink: /services/
+title: ""
+author_profile: true
+---
+
+<span class='anchor' id='-professional-services'></span>
+
+{% include_relative includes/serv.md %}


### PR DESCRIPTION
## Summary
- update the shared head include to remove the `_blank` base tag and load CSS/icon assets with `relative_url` so nested pages keep the default layout styling
- load shared JavaScript through `relative_url` so functionality works on dedicated section pages
- point collaborator and publication include images to site-relative asset URLs so media renders correctly on standalone views

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb89d3a8832dbc650a95d1bd626b