### PR TITLE
Add cite buttons to About page publications

### DIFF
--- a/_includes/citation-modal.html
+++ b/_includes/citation-modal.html
@@ -1,0 +1,161 @@
+<div id="citation-modal" class="citation-modal" hidden>
+  <div class="citation-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="citation-modal-title" tabindex="-1">
+    <button type="button" class="citation-modal__close" aria-label="Close citation dialog">&times;</button>
+    <h4 id="citation-modal-title">Cite this publication</h4>
+    <div class="citation-modal__tabs" role="tablist">
+      <button type="button" class="citation-modal__tab is-active" data-format="plain" role="tab" aria-selected="true">Plain Text</button>
+      <button type="button" class="citation-modal__tab" data-format="bib" role="tab" aria-selected="false">BibTeX</button>
+    </div>
+    <pre class="citation-modal__content" id="citation-modal-content"></pre>
+    <div class="citation-modal__actions">
+      <div class="citation-modal__feedback" role="status" aria-live="polite" hidden></div>
+      <button type="button" class="citation-modal__action" data-action="copy">Copy</button>
+      <button type="button" class="citation-modal__action" data-action="download">Download</button>
+    </div>
+  </div>
+</div>
+
+<style>
+:root {
+  --citation-modal-accent: var(--publication-accent, #224b8d);
+  --citation-modal-accent-hover: var(--publication-accent-hover, #1a3a6d);
+  --citation-modal-accent-soft: var(--publication-accent-soft, rgba(34, 75, 141, 0.18));
+}
+
+.citation-modal[hidden] {
+  display: none;
+}
+
+.citation-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.citation-modal__dialog {
+  position: relative;
+  width: min(640px, 100%);
+  background: #fff;
+  border-radius: 0.85rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+}
+
+.citation-modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #57606a;
+}
+
+.citation-modal__tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.citation-modal__tab {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #c1c7d0;
+  background: #f6f8fa;
+  color: #24292f;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.citation-modal__tab.is-active {
+  background: var(--citation-modal-accent);
+  border-color: var(--citation-modal-accent);
+  color: #fff;
+}
+
+.citation-modal__content {
+  background: #f6f8fa;
+  border-radius: 0.65rem;
+  padding: 1rem;
+  max-height: 320px;
+  overflow: auto;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.citation-modal__actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.citation-modal__feedback {
+  margin-right: auto;
+  font-size: 0.85rem;
+  color: var(--citation-modal-accent);
+}
+
+.citation-modal__feedback[hidden] {
+  display: none;
+}
+
+.citation-modal__action {
+  padding: 0.45rem 1.1rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--citation-modal-accent);
+  background: var(--citation-modal-accent);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.citation-modal__action[data-action="copy"] {
+  background: #fff;
+  color: var(--citation-modal-accent);
+}
+
+.citation-modal__action[data-action="copy"]:hover {
+  background: var(--citation-modal-accent-soft);
+}
+
+.citation-modal__action[data-action="download"]:hover {
+  background: var(--citation-modal-accent-hover);
+}
+
+.citation-modal__action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--citation-modal-accent-soft);
+}
+
+.citation-badge-button {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  line-height: 0;
+}
+
+.citation-badge-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--citation-modal-accent-soft);
+  border-radius: 0.35rem;
+}
+
+.citation-badge-button img {
+  display: inline-block;
+  vertical-align: middle;
+}
+</style>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -29,7 +29,18 @@ Explore the full list of publications on the [Publications](/publications/) page
 [Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)\\
 **W. Wu**, D. Wu, Y. Zhang, S. Chen, and W. Zhang\\
 [**IEEE/CAA Journal of Automatica Sinica**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650) \\
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)   [![Video-Expa](https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4)  
+[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)   [![Video-Expa](https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video)](/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4)
+<button
+  type="button"
+  class="citation-badge-button"
+  data-citation-trigger="true"
+  data-citation-index="about-jas-2024"
+  data-citation-plain="W. Wu, D. Wu, Y. Zhang, S. Chen, and W. Zhang, “Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance,” IEEE/CAA Journal of Automatica Sinica, vol. 11, no. 9, pp. 2033–2035, Sept. 2024."
+  data-citation-bibtex="@ARTICLE{Wu2024Safety,&#10;  author={Wu, Wentao and Wu, Di and Zhang, Yibo and Chen, Shukang and Zhang, Weidong},&#10;  title={Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance},&#10;  journal={IEEE/CAA Journal of Automatica Sinica},&#10;  volume={11},&#10;  number={9},&#10;  pages={2033--2035},&#10;  year={2024}&#10;}"
+  aria-label="Cite this publication"
+>
+  <img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge">
+</button>
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ULOm3_A8WrAC'></span></strong>
 </div>
 </div>
@@ -42,6 +53,17 @@ Explore the full list of publications on the [Publications](/publications/) page
 **W. Wu**, Z. Peng, L. Liu, and D. Wang\\
 [**IEEE Transactions on Intelligent Vehicles**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)\\
 [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4)
+<button
+  type="button"
+  class="citation-badge-button"
+  data-citation-trigger="true"
+  data-citation-index="about-tiv-2022"
+  data-citation-plain="W. Wu, Z. Peng, L. Liu, and D. Wang, “A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train,” IEEE Transactions on Intelligent Vehicles, vol. 7, no. 3, pp. 627–637, Sept. 2022."
+  data-citation-bibtex="@ARTICLE{Wu2022Agener,&#10;  author={Wu, Wentao and Peng, Zhouhua and Liu, Lu and Wang, Dan},&#10;  title={A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train},&#10;  journal={IEEE Transactions on Intelligent Vehicles},&#10;  volume={7},&#10;  number={3},&#10;  pages={627--637},&#10;  year={2022}&#10;}"
+  aria-label="Cite this publication"
+>
+  <img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge">
+</button>
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:UeHWp8X0CEIC'></span></strong>
 </div>
 </div>
@@ -53,6 +75,17 @@ Explore the full list of publications on the [Publications](/publications/) page
 **W. Wu**, Z. Peng, D. Wang, L. Liu, Q.-L. Han\\
 [**IEEE Transactions on Cybernetics**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036) \\
 [![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
+<button
+  type="button"
+  class="citation-badge-button"
+  data-citation-trigger="true"
+  data-citation-index="about-tcyb-2021"
+  data-citation-plain="W. Wu, Z. Peng, D. Wang, L. Liu, and Q.-L. Han, “Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results,” IEEE Transactions on Cybernetics, vol. 52, no. 10, pp. 10937–10947, Oct. 2022."
+  data-citation-bibtex="@ARTICLE{Wu2022Networ,&#10;  author={Wu, Wentao and Peng, Zhouhua and Wang, Dan and Liu, Lu and Han, Qing-Long},&#10;  title={Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results},&#10;  journal={IEEE Transactions on Cybernetics},&#10;  volume={52},&#10;  number={10},&#10;  pages={10937--10947},&#10;  year={2022}&#10;}"
+  aria-label="Cite this publication"
+>
+  <img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge">
+</button>
 <strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:W7OEmFMy1HYC'></span></strong>
 
 </div>
@@ -101,4 +134,8 @@ Find the complete award record on the [Awards page](/awards/).
 ## 💻 Professional Services
 
 View detailed service activities on the [Professional Services page](/services/).
- -->
+-->
+
+{% include citation-modal.html %}
+
+<script src="{{ '/assets/js/publications.js' | relative_url }}"></script>

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -145,22 +145,7 @@
 
 
 
-<div id="citation-modal" class="citation-modal" hidden>
-  <div class="citation-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="citation-modal-title" tabindex="-1">
-    <button type="button" class="citation-modal__close" aria-label="Close citation dialog">&times;</button>
-    <h4 id="citation-modal-title">Cite this publication</h4>
-    <div class="citation-modal__tabs" role="tablist">
-      <button type="button" class="citation-modal__tab is-active" data-format="plain" role="tab" aria-selected="true">Plain Text</button>
-      <button type="button" class="citation-modal__tab" data-format="bib" role="tab" aria-selected="false">BibTeX</button>
-    </div>
-    <pre class="citation-modal__content" id="citation-modal-content"></pre>
-    <div class="citation-modal__actions">
-      <div class="citation-modal__feedback" role="status" aria-live="polite" hidden></div>
-      <button type="button" class="citation-modal__action" data-action="copy">Copy</button>
-      <button type="button" class="citation-modal__action" data-action="download">Download</button>
-    </div>
-  </div>
-</div>
+{% include citation-modal.html %}
 
 <style>
 :root {
@@ -395,124 +380,6 @@ mark.publication-highlight {
 
 .publication-source[hidden] {
   display: none !important;
-}
-
-.citation-modal[hidden] {
-  display: none;
-}
-
-.citation-modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1.5rem;
-}
-
-.citation-modal__dialog {
-  position: relative;
-  width: min(640px, 100%);
-  background: #fff;
-  border-radius: 0.85rem;
-  padding: 1.5rem;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
-}
-
-.citation-modal__close {
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  border: none;
-  background: transparent;
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-  color: #57606a;
-}
-
-.citation-modal__tabs {
-  display: inline-flex;
-  gap: 0.5rem;
-  margin: 1rem 0;
-}
-
-.citation-modal__tab {
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid #c1c7d0;
-  background: #f6f8fa;
-  color: #24292f;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.citation-modal__tab.is-active {
-  background: var(--publication-accent);
-  border-color: var(--publication-accent);
-  color: #fff;
-}
-
-.citation-modal__content {
-  background: #f6f8fa;
-  border-radius: 0.65rem;
-  padding: 1rem;
-  max-height: 320px;
-  overflow: auto;
-  font-size: 0.92rem;
-  line-height: 1.5;
-  white-space: pre-wrap;
-}
-
-.citation-modal__actions {
-  margin-top: 1rem;
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.citation-modal__feedback {
-  margin-right: auto;
-  font-size: 0.85rem;
-  color: var(--publication-accent);
-}
-
-.citation-modal__feedback[hidden] {
-  display: none;
-}
-
-.citation-modal__action {
-  padding: 0.45rem 1.1rem;
-  border-radius: 0.6rem;
-  border: 1px solid var(--publication-accent);
-  background: var(--publication-accent);
-  color: #fff;
-  cursor: pointer;
-  font-size: 0.95rem;
-  transition: background-color 0.2s ease, color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.citation-modal__action[data-action="copy"] {
-  background: #fff;
-  color: var(--publication-accent);
-}
-
-.citation-modal__action[data-action="copy"]:hover {
-  background: var(--publication-accent-soft);
-}
-
-.citation-modal__action[data-action="download"]:hover {
-  background: var(--publication-accent-hover);
-}
-
-.citation-modal__action:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--publication-accent-soft);
 }
 
 @media (max-width: 600px) {

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -20,134 +20,133 @@
     var citationClose = citationModal ? citationModal.querySelector('.citation-modal__close') : null;
     var citationActions = citationModal ? citationModal.querySelector('.citation-modal__actions') : null;
     var citationFeedback = citationModal ? citationModal.querySelector('.citation-modal__feedback') : null;
+    var hasPublicationList = sourceList && listEl && typeSelect && yearSelect && sortButton;
 
-    if (!sourceList || !listEl || !typeSelect || !yearSelect || !sortButton) {
-      return;
-    }
-
-    var typeLabels = {
-      journal: 'Journal Papers',
-      conference: 'Conference Papers',
-      review: 'Review Papers',
-      preprint: 'Preprints'
-    };
-
-    var typeOrder = ['journal', 'conference', 'review', 'preprint'];
-
-    var searchTerm = '';
     var activeCitationFormat = 'plain';
     var currentCitation = null;
     var copyFeedbackTimer = null;
 
-    function sanitizeNode(node) {
-      var clone = node.cloneNode(true);
-      Array.prototype.slice.call(clone.querySelectorAll('img, template')).forEach(function (el) {
-        el.remove();
-      });
-      return clone;
-    }
+    if (hasPublicationList) {
+      var typeLabels = {
+        journal: 'Journal Papers',
+        conference: 'Conference Papers',
+        review: 'Review Papers',
+        preprint: 'Preprints'
+      };
 
-    function normalizeQuotes(text) {
-      if (!text) {
-        return '';
+      var typeOrder = ['journal', 'conference', 'review', 'preprint'];
+
+      var searchTerm = '';
+
+      function sanitizeNode(node) {
+        var clone = node.cloneNode(true);
+        Array.prototype.slice.call(clone.querySelectorAll('img, template')).forEach(function (el) {
+          el.remove();
+        });
+        return clone;
       }
-      var replaced = text.replace(/''([^']+?)''/g, function (_, title) {
-        return '“' + title.trim().replace(/[\s,;:.]+$/, '') + '”';
+
+      function normalizeQuotes(text) {
+        if (!text) {
+          return '';
+        }
+        var replaced = text.replace(/''([^']+?)''/g, function (_, title) {
+          return '“' + title.trim().replace(/[\s,;:.]+$/, '') + '”';
+        });
+        replaced = replaced.replace(/"([^"]+?)"/g, function (_, title) {
+          return '“' + title.trim().replace(/[\s,;:.]+$/, '') + '”';
+        });
+        return replaced;
+      }
+
+      var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
+        var year = parseInt(item.getAttribute('data-year'), 10);
+        var plainCitation = item.getAttribute('data-citation-plain') || '';
+        var bibCitation = item.getAttribute('data-citation-bibtex') || '';
+        var sanitized = sanitizeNode(item);
+        var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
+        var normalizedText = normalizeQuotes(textContent);
+        return {
+          type: item.getAttribute('data-type') || 'other',
+          year: isNaN(year) ? null : year,
+          date: item.getAttribute('data-date') || '',
+          content: item.innerHTML.trim(),
+          rawText: normalizedText,
+          searchText: normalizedText.toLowerCase(),
+          plainCitation: plainCitation,
+          bibCitation: bibCitation
+        };
       });
-      replaced = replaced.replace(/"([^"]+?)"/g, function (_, title) {
-        return '“' + title.trim().replace(/[\s,;:.]+$/, '') + '”';
+
+      publications = publications.map(function (pub) {
+        pub.citations = generateCitations(pub);
+        return pub;
       });
-      return replaced;
-    }
 
-    var publications = Array.prototype.slice.call(sourceList.querySelectorAll('li')).map(function (item) {
-      var year = parseInt(item.getAttribute('data-year'), 10);
-      var plainCitation = item.getAttribute('data-citation-plain') || '';
-      var bibCitation = item.getAttribute('data-citation-bibtex') || '';
-      var sanitized = sanitizeNode(item);
-      var textContent = sanitized.textContent.replace(/\s+/g, ' ').trim();
-      var normalizedText = normalizeQuotes(textContent);
-      return {
-        type: item.getAttribute('data-type') || 'other',
-        year: isNaN(year) ? null : year,
-        date: item.getAttribute('data-date') || '',
-        content: item.innerHTML.trim(),
-        rawText: normalizedText,
-        searchText: normalizedText.toLowerCase(),
-        plainCitation: plainCitation,
-        bibCitation: bibCitation
-      };
-    });
+      var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
+        return pub.type;
+      }).filter(Boolean)));
 
-    publications = publications.map(function (pub) {
-      pub.citations = generateCitations(pub);
-      return pub;
-    });
-
-    var uniqueTypes = Array.from(new Set(publications.map(function (pub) {
-      return pub.type;
-    }).filter(Boolean)));
-
-    var orderedOptions = typeOrder.map(function (type) {
-      return {
-        value: type,
-        label: typeLabels[type] || type
-      };
-    });
-
-    uniqueTypes.forEach(function (type) {
-      if (typeOrder.indexOf(type) === -1) {
-        orderedOptions.push({
+      var orderedOptions = typeOrder.map(function (type) {
+        return {
           value: type,
           label: typeLabels[type] || type
-        });
-      }
-    });
+        };
+      });
 
-    typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
-      return '<option value="' + type.value + '">' + type.label + '</option>';
-    }).join('');
+      uniqueTypes.forEach(function (type) {
+        if (typeOrder.indexOf(type) === -1) {
+          orderedOptions.push({
+            value: type,
+            label: typeLabels[type] || type
+          });
+        }
+      });
 
-    function updateYearOptions() {
-      var years = Array.from(new Set(publications.map(function (pub) {
-        return pub.year;
-      }).filter(Boolean)));
-      years.sort(function (a, b) { return b - a; });
-      yearSelect.innerHTML = '<option value="all">Date</option>' + years.map(function (year) {
-        return '<option value="' + year + '">' + year + '</option>';
+      typeSelect.innerHTML = '<option value="all">Type</option>' + orderedOptions.map(function (type) {
+        return '<option value="' + type.value + '">' + type.label + '</option>';
       }).join('');
-    }
 
-    updateYearOptions();
-
-    var sortOrder = 'desc';
-
-    function normalizeDate(dateStr, year) {
-      if (!dateStr) {
-        return year ? String(year) + '-01-01' : '0000-01-01';
+      function updateYearOptions() {
+        var years = Array.from(new Set(publications.map(function (pub) {
+          return pub.year;
+        }).filter(Boolean)));
+        years.sort(function (a, b) { return b - a; });
+        yearSelect.innerHTML = '<option value="all">Date</option>' + years.map(function (year) {
+          return '<option value="' + year + '">' + year + '</option>';
+        }).join('');
       }
-      var normalized = dateStr.trim();
-      if (/^\d{4}$/.test(normalized)) {
-        return normalized + '-12-31';
-      }
-      if (/^\d{4}-\d{2}$/.test(normalized)) {
-        return normalized + '-01';
-      }
-      if (/^\d{4}\/\d{2}/.test(normalized)) {
-        var parts = normalized.split('/');
-        return parts[0] + '-' + parts[1] + '-01';
-      }
-      return normalized;
-    }
 
-    function render() {
-      var selectedType = typeSelect.value;
-      var selectedYear = yearSelect.value;
-      var highlightTerm = searchInput ? searchInput.value.trim() : '';
-      var normalizedSearch = searchTerm;
+      updateYearOptions();
 
-      var filtered = publications.filter(function (pub) {
-        if (selectedType !== 'all' && pub.type !== selectedType) {
+      var sortOrder = 'desc';
+
+      function normalizeDate(dateStr, year) {
+        if (!dateStr) {
+          return year ? String(year) + '-01-01' : '0000-01-01';
+        }
+        var normalized = dateStr.trim();
+        if (/^\d{4}$/.test(normalized)) {
+          return normalized + '-12-31';
+        }
+        if (/^\d{4}-\d{2}$/.test(normalized)) {
+          return normalized + '-01';
+        }
+        if (/^\d{4}\/\d{2}/.test(normalized)) {
+          var parts = normalized.split('/');
+          return parts[0] + '-' + parts[1] + '-01';
+        }
+        return normalized;
+      }
+
+      function render() {
+        var selectedType = typeSelect.value;
+        var selectedYear = yearSelect.value;
+        var highlightTerm = searchInput ? searchInput.value.trim() : '';
+        var normalizedSearch = searchTerm;
+
+        var filtered = publications.filter(function (pub) {
+          if (selectedType !== 'all' && pub.type !== selectedType) {
           return false;
         }
         if (selectedYear !== 'all' && String(pub.year) !== selectedYear) {
@@ -291,19 +290,22 @@
       });
     }
 
-    typeSelect.addEventListener('change', render);
-    yearSelect.addEventListener('change', render);
-    sortButton.addEventListener('click', function () {
-      sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
-      sortButton.textContent = sortOrder === 'desc' ? '⬇' : '⬆';
-      render();
-    });
-
-    if (searchInput) {
-      searchInput.addEventListener('input', function () {
-        searchTerm = this.value.trim().toLowerCase();
+      typeSelect.addEventListener('change', render);
+      yearSelect.addEventListener('change', render);
+      sortButton.addEventListener('click', function () {
+        sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
+        sortButton.textContent = sortOrder === 'desc' ? '⬇' : '⬆';
         render();
       });
+
+      if (searchInput) {
+        searchInput.addEventListener('input', function () {
+          searchTerm = this.value.trim().toLowerCase();
+          render();
+        });
+      }
+
+      render();
     }
 
     function enhanceDisplay(container) {
@@ -706,6 +708,44 @@
       document.body.removeChild(textarea);
     }
 
-    render();
+    function initializeManualCitationTriggers() {
+      if (!citationModal) {
+        return;
+      }
+      var triggers = Array.prototype.slice.call(document.querySelectorAll('[data-citation-trigger]'));
+      if (!triggers.length) {
+        return;
+      }
+      triggers.forEach(function (trigger, index) {
+        trigger.addEventListener('click', function (event) {
+          event.preventDefault();
+          var dataset = trigger.dataset || {};
+          var plain = dataset.citationPlain || '';
+          var bib = dataset.citationBibtex || '';
+          var targetId = dataset.citationTarget;
+          if ((!plain || !bib) && targetId) {
+            var source = document.getElementById(targetId);
+            if (source) {
+              if (!plain) {
+                plain = source.getAttribute('data-citation-plain') || plain;
+              }
+              if (!bib) {
+                bib = source.getAttribute('data-citation-bibtex') || bib;
+              }
+            }
+          }
+          if (!plain && !bib) {
+            return;
+          }
+          var citationIndex = dataset.citationIndex || String(index + 1);
+          openCitation(citationIndex, {
+            plain: plain,
+            bib: bib
+          });
+        });
+      });
+    }
+
+    initializeManualCitationTriggers();
   });
 })();


### PR DESCRIPTION
## Summary
- add cite buttons and shared citation modal include to the About page selected publications list
- extract reusable citation modal markup/styles and reuse it on the publications page
- update the publications script to handle manual citation triggers when the publication list UI is not present

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d21507f4e8832dba1ff750d8bda922