### PR TITLE
Revamp homepage layout with landing blocks

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,118 +8,145 @@ redirect_from:
   - /about.html
 ---
 
-<span class='anchor' id='about-me'></span>
+<div class="landing landing--home">
 
-{% include_relative includes/intro.md %}
+<section class="landing-block landing-block--hero">
+  <span class="anchor" id="about-me"></span>
+  <div class="landing-block__inner">
+    <div class="landing-block__primary">
+      <p class="landing-eyebrow">Safety-Critical Control · Autonomous Systems · Marine Robotics</p>
+      <h1 class="landing-block__title">{{ site.author.name }}</h1>
+      <p class="landing-block__subtitle">{{ site.author.bio }}</p>
+      <p class="landing-block__summary">Currently with the Research Centre for Low Altitude Economy and the Department of Aeronautical and Aviation Engineering at The Hong Kong Polytechnic University.</p>
+      <div class="landing-block__cta">
+        <a class="btn btn--large" href="/publications/">📄 View Publications</a>
+        <a class="btn btn--inverse btn--large" href="mailto:wtwu95@gmail.com">✉️ Get in touch</a>
+      </div>
+    </div>
+    <div class="landing-block__secondary">
+      <div class="landing-stat-panel">
+        <h2 class="landing-stat-panel__title">Highlights</h2>
+        <ul class="landing-stat-list">
+          <li class="landing-stat">
+            <span class="landing-stat__label">Research interests</span>
+            <span class="landing-stat__value">Distributed &amp; safety-critical control, reinforcement learning, multi-agent systems</span>
+          </li>
+          <li class="landing-stat">
+            <span class="landing-stat__label">Recognition</span>
+            <span class="landing-stat__value">Doctoral Special Program of Young Elite Scientist Sponsorship Program · Outstanding Graduates of Shanghai 2025</span>
+          </li>
+          <li class="landing-stat">
+            <span class="landing-stat__label">Outputs</span>
+            <span class="landing-stat__value">30+ publications across IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, IEEE CDC</span>
+          </li>
+        </ul>
+      </div>
+      <div class="landing-quick-links" aria-label="Section shortcuts">
+        <a class="landing-quick-link" href="#about-me">About</a>
+        <a class="landing-quick-link" href="#news">News</a>
+        <a class="landing-quick-link" href="/awards/">Awards</a>
+        <a class="landing-quick-link" href="/services/">Professional Services</a>
+      </div>
+    </div>
+  </div>
+</section>
 
-{% include_relative includes/exp.md %}
+<section class="landing-block landing-block--content" markdown="1">
+  {% include_relative includes/intro.md %}
+</section>
 
-{% include_relative includes/edu.md %}
+<section class="landing-block landing-block--grid">
+  <div class="landing-grid landing-grid--two">
+    <div class="landing-card" markdown="1">
+      {% include_relative includes/exp.md %}
+    </div>
+    <div class="landing-card landing-card--accent" markdown="1">
+      {% include_relative includes/edu.md %}
+    </div>
+  </div>
+</section>
 
-{% include_relative includes/news.md %}
+<section class="landing-block landing-block--grid landing-block--news" id="news">
+  <div class="landing-grid landing-grid--two">
+    <div class="landing-card landing-card--stretch" markdown="1">
+      {% include_relative includes/news.md %}
+    </div>
+    <aside class="landing-card landing-card--highlight landing-card--stretch" markdown="1">
+      <h2 class="landing-card__title">Stay connected</h2>
+      <p class="landing-card__lead">Follow the latest updates and explore external profiles.</p>
+      {% include_relative includes/homepage.md %}
+      <ul class="landing-link-list">
+        <li><a href="/publications/">Publication archive</a></li>
+        <li><a href="/awards/">Awards &amp; honors</a></li>
+        <li><a href="/services/">Professional services</a></li>
+      </ul>
+    </aside>
+  </div>
+</section>
 
-<span class='anchor' id='-publications'></span>
-# 📚 Selected Publications
+<section class="landing-block landing-block--papers" markdown="1">
+  <span class="anchor" id="-publications"></span>
+  # 📚 Selected Publications
 
-Explore the full list of publications on the [Publications](/publications/) page.
+  Explore the full list of publications on the [Publications](/publications/) page.
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE CAA/JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
+  <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE CAA/JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
+  <div class='paper-box-text' markdown="1">
 
-[Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)<br />
-**W. Wu**, D. Wu, Y. Zhang, S. Chen, and W. Zhang<br />
-[**IEEE/CAA Journal of Automatica Sinica**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)<br />
-<div class="publication-actions">
-  <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="1" data-citation-plain="W. Wu, D. Wu, Y. Zhang, S. Chen, and W. Zhang, “Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance,” IEEE/CAA Journal of Automatica Sinica, vol. 11, no. 9, pp. 2033–2035, Sept. 2024." data-citation-bibtex="@ARTICLE{Wu2024Safety,&#10;  author={Wu, Wentao and Wu, Di and Zhang, Yibo and Chen, Shukang and Zhang, Weidong},&#10;  title={Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance},&#10;  journal={IEEE/CAA Journal of Automatica Sinica},&#10;  volume={11},&#10;  number={9},&#10;  pages={2033--2035},&#10;  year={2024}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
-  <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
-  <a class="publication-badge" href="/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video"></a>
+  [Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)<br />
+  **W. Wu**, D. Wu, Y. Zhang, S. Chen, and W. Zhang<br />
+  [**IEEE/CAA Journal of Automatica Sinica**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650)<br />
+  <div class="publication-actions">
+    <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="1" data-citation-plain="W. Wu, D. Wu, Y. Zhang, S. Chen, and W. Zhang, “Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance,” IEEE/CAA Journal of Automatica Sinica, vol. 11, no. 9, pp. 2033–2035, Sept. 2024." data-citation-bibtex="@ARTICLE{Wu2024Safety,&#10;  author={Wu, Wentao and Wu, Di and Zhang, Yibo and Chen, Shukang and Zhang, Weidong},&#10;  title={Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance},&#10;  journal={IEEE/CAA Journal of Automatica Sinica},&#10;  volume={11},&#10;  number={9},&#10;  pages={2033--2035},&#10;  year={2024}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
+    <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
+    <a class="publication-badge" href="/assets/Video/Video-Exp/WuWentao-2023-IEEE-JASa.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Expa--Demo-blue?label=Video"></a>
+  </div>
+  </div>
+  </div>
+
+
+  <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.gif' | relative_url }}' alt="sym" width="100%"></div></div>
+  <div class='paper-box-text' markdown="1">
+
+  [A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043)<br />
+  **W. Wu**, Z. Peng, L. Liu, and D. Wang<br />
+  [**IEEE Transactions on Intelligent Vehicles**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)<br />
+  <div class="publication-actions">
+    <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="2" data-citation-plain="W. Wu, Z. Peng, L. Liu, and D. Wang, “A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train,” IEEE Transactions on Intelligent Vehicles, vol. 7, no. 3, pp. 627–637, Sept. 2022." data-citation-bibtex="@ARTICLE{Wu2022Agener,&#10;  author={Wu, Wentao and Peng, Zhouhua and Liu, Lu and Wang, Dan},&#10;  title={A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train},&#10;  journal={IEEE Transactions on Intelligent Vehicles},&#10;  volume={7},&#10;  number={3},&#10;  pages={627--637},&#10;  year={2022}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
+    <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
+    <a class="publication-badge" href="/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video"></a>
+  </div>
+  </div>
+  </div>
+
+  <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='{{ '/assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' | relative_url }}' alt="sym" width="100%"></div></div>
+  <div class='paper-box-text' markdown="1">
+
+  [Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)<br />
+  **W. Wu**, Z. Peng, D. Wang, L. Liu, Q.-L. Han<br />
+  [**IEEE Transactions on Cybernetics**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)<br />
+  <div class="publication-actions">
+    <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="3" data-citation-plain="W. Wu, Z. Peng, D. Wang, L. Liu, and Q.-L. Han, “Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results,” IEEE Transactions on Cybernetics, vol. 52, no. 10, pp. 10937–10947, Oct. 2022." data-citation-bibtex="@ARTICLE{Wu2022Networ,&#10;  author={Wu, Wentao and Peng, Zhouhua and Wang, Dan and Liu, Lu and Han, Qing-Long},&#10;  title={Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results},&#10;  journal={IEEE Transactions on Cybernetics},&#10;  volume={52},&#10;  number={10},&#10;  pages={10937--10947},&#10;  year={2022}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
+    <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
+    <a class="publication-badge" href="/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video"></a>
+  </div>
+  </div>
+  </div>
+  {% include citation-modal.html %}
+</section>
+
+<section class="landing-block landing-block--misc" markdown="1">
+  # 😀 Miscellaneous
+
+  - [CloudConvert](https://cloudconvert.com/)
+  - [iLoveIMG](https://www.iloveimg.com/)
+  - [WordClouds](https://www.wordclouds.com/)
+  - [Color Hex](https://www.color-hex.com/color-palettes/)
+  - [Unsplash](https://unsplash.com/)
+  - [Pngtree](https://pngtree.com/)
+  - [How to write rebuttals](https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/)
+  - [How to write introduction](http://www-net.cs.umass.edu/kurose/writing/intro-style.html)
+  - [Emojipedia](https://emojipedia.org/)
+</section>
+
 </div>
-</div>
-</div>
-
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
-
-[A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043)<br />
-**W. Wu**, Z. Peng, L. Liu, and D. Wang<br />
-[**IEEE Transactions on Intelligent Vehicles**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857)<br />
-<div class="publication-actions">
-  <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="2" data-citation-plain="W. Wu, Z. Peng, L. Liu, and D. Wang, “A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train,” IEEE Transactions on Intelligent Vehicles, vol. 7, no. 3, pp. 627–637, Sept. 2022." data-citation-bibtex="@ARTICLE{Wu2022Agener,&#10;  author={Wu, Wentao and Peng, Zhouhua and Liu, Lu and Wang, Dan},&#10;  title={A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train},&#10;  journal={IEEE Transactions on Intelligent Vehicles},&#10;  volume={7},&#10;  number={3},&#10;  pages={627--637},&#10;  year={2022}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
-  <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2022-IEEE-TIV.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
-  <a class="publication-badge" href="/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video"></a>
-</div>
-</div>
-</div>
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='{{ '/assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
-
-[Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)<br />
-**W. Wu**, Z. Peng, D. Wang, L. Liu, Q.-L. Han<br />
-[**IEEE Transactions on Cybernetics**](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036)<br />
-<div class="publication-actions">
-  <button type="button" class="publication-cite" data-citation-modal-trigger="" data-citation-index="3" data-citation-plain="W. Wu, Z. Peng, D. Wang, L. Liu, and Q.-L. Han, “Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results,” IEEE Transactions on Cybernetics, vol. 52, no. 10, pp. 10937–10947, Oct. 2022." data-citation-bibtex="@ARTICLE{Wu2022Networ,&#10;  author={Wu, Wentao and Peng, Zhouhua and Wang, Dan and Liu, Lu and Han, Qing-Long},&#10;  title={Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results},&#10;  journal={IEEE Transactions on Cybernetics},&#10;  volume={52},&#10;  number={10},&#10;  pages={10937--10947},&#10;  year={2022}&#10;}"><img src="https://img.shields.io/badge/Link-Cite-0969da?labelColor=555" alt="Cite badge"></button>
-  <a class="publication-badge" href="/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf"><img alt="PDF badge" src="https://img.shields.io/badge/Link-PDF-gree"></a>
-  <a class="publication-badge" href="/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4"><img alt="Video badge" src="https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video"></a>
-</div>
-</div>
-</div>
-<!-- <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
-
-[Output-Feedback Finite-Time Safety-Critical Coordinated Control of Path-Guided Marine Surface Vehicles Based on Neurodynamic Optimization](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)
-
-**Wentao Wu**, Yibo Zhang, Weidong Zhang, Wei Xie
-
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ufrVoPGSRksC'></span></strong>
-
--
--
--
-</div>
-</div>
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
-
-[Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)
-
-**Wentao Wu**, Yibo Zhang, Zhenhua Li, Jun-Guo Lu, Weidong Zhang
-
-
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
--
--
--
-</div>
-</div>
- -->
-
-
-{% include citation-modal.html %}
-
-<!-- <span class='anchor' id='-awards'></span>
-# 🎖 Awards
-
-Find the complete award record on the [Awards page](/awards/).
-
-<span class='anchor' id='-professional-services'></span>
-# 📝 Professional Services
-
-View detailed service activities on the [Professional Services page](/services/). -->
-
-# 😀 Miscellaneous
-
-- [CloudConvert](https://cloudconvert.com/)
-- [iLoveIMG](https://www.iloveimg.com/)
-- [WordClouds](https://www.wordclouds.com/)
-- [Color Hex](https://www.color-hex.com/color-palettes/)
-- [Unsplash](https://unsplash.com/)
-- [Pngtree](https://pngtree.com/)
-- [How to write rebuttals](https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/)
-- [How to write introduction](http://www-net.cs.umass.edu/kurose/writing/intro-style.html)
-- [Emojipedia](https://emojipedia.org/)

--- a/_sass/_landing.scss
+++ b/_sass/_landing.scss
@@ -1,0 +1,349 @@
+/* ==========================================================================
+   Landing layout enhancements inspired by modular block design
+   ==========================================================================
+*/
+
+.landing {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.landing-block {
+  position: relative;
+  padding: 2.25rem 1.75rem;
+  border-radius: 1.75rem;
+  background: rgba($background-color, 0.96);
+  border: 1px solid rgba($border-color, 0.85);
+  box-shadow: 0 20px 45px rgba(#0f172a, 0.06);
+  overflow: hidden;
+
+  @include breakpoint($medium) {
+    padding: 2.75rem 3rem;
+  }
+}
+
+.landing-block--hero {
+  padding: 3rem 2.5rem;
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 45%, #312e81 100%);
+  border: none;
+  box-shadow: 0 35px 70px rgba(#0f172a, 0.35);
+  color: #f8fafc;
+
+  @include breakpoint($medium) {
+    padding: 3.5rem 3.5rem;
+  }
+
+  a {
+    color: #bfdbfe;
+    border-bottom: 1px solid rgba(#bfdbfe, 0.4);
+
+    &:hover,
+    &:focus {
+      color: #fff;
+      border-bottom-color: rgba(#fff, 0.85);
+    }
+  }
+
+  .landing-block__cta .btn {
+    border-radius: 999px;
+    padding: 0.85em 1.95em;
+    font-size: $type-size-5;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    box-shadow: 0 16px 30px rgba(#0f172a, 0.32);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-2px);
+      box-shadow: 0 20px 40px rgba(#0f172a, 0.4);
+    }
+  }
+
+  .landing-block__cta .btn.btn--inverse {
+    color: #f8fafc !important;
+    background: transparent;
+    border: 1px solid rgba(#bfdbfe, 0.7) !important;
+    box-shadow: none;
+
+    &:hover,
+    &:focus {
+      background: rgba(#bfdbfe, 0.15);
+    }
+  }
+
+  .landing-quick-links {
+    gap: 0.75rem;
+  }
+
+  .landing-quick-link {
+    background: rgba(#0f172a, 0.35);
+    color: #f1f5f9;
+
+    &:hover,
+    &:focus {
+      background: rgba(#0f172a, 0.6);
+    }
+  }
+}
+
+.landing-block--grid,
+.landing-block--news {
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.landing-block--papers {
+  background: linear-gradient(180deg, rgba(#1e3a8a, 0.08) 0%, rgba(#f8fafc, 0.95) 85%);
+  border: 1px solid rgba(#1e3a8a, 0.12);
+}
+
+.landing-block--misc {
+  background: rgba(#f8fafc, 0.95);
+}
+
+.landing-block__inner {
+  display: grid;
+  gap: 2.25rem;
+  align-items: center;
+
+  @include breakpoint($medium) {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+}
+
+.landing-block__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.landing-block__secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.landing-eyebrow {
+  display: inline-block;
+  font-size: $type-size-6;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(#bfdbfe, 0.9);
+}
+
+.landing-block__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.1;
+}
+
+.landing-block__subtitle {
+  font-size: $type-size-4;
+  margin: 0;
+}
+
+.landing-block__summary {
+  margin: 0;
+  font-size: $type-size-5;
+  max-width: 40ch;
+}
+
+.landing-block__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.landing-stat-panel {
+  background: rgba(#fff, 0.16);
+  border-radius: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(#bfdbfe, 0.2);
+}
+
+.landing-stat-panel__title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: $type-size-4;
+}
+
+.landing-stat-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.landing-stat {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.landing-stat__label {
+  font-size: $type-size-6;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.landing-stat__value {
+  font-size: $type-size-5;
+  line-height: 1.5;
+}
+
+.landing-quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.landing-quick-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba($link-color, 0.12);
+  color: $link-color;
+  font-size: $type-size-6;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  &:hover,
+  &:focus {
+    background: rgba($link-color, 0.2);
+    color: mix(#000, $link-color, 20%);
+  }
+}
+
+.landing-grid {
+  display: grid;
+  gap: 1.75rem;
+
+  &--two {
+    @include breakpoint($medium) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+}
+
+.landing-card {
+  height: 100%;
+  padding: 2.25rem 2rem;
+  border-radius: 1.5rem;
+  background: rgba(#fff, 0.94);
+  border: 1px solid rgba($border-color, 0.9);
+  box-shadow: 0 18px 38px rgba(#0f172a, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.landing-card--stretch {
+  justify-content: stretch;
+}
+
+.landing-card--accent {
+  background: linear-gradient(145deg, rgba(#bfdbfe, 0.3) 0%, rgba(#eff6ff, 0.95) 100%);
+  border: 1px solid rgba(#1e3a8a, 0.18);
+  box-shadow: 0 24px 48px rgba(#1e3a8a, 0.1);
+}
+
+.landing-card--highlight {
+  background: linear-gradient(155deg, rgba(#fef3c7, 0.85) 0%, rgba(#fde68a, 0.95) 100%);
+  border: 1px solid rgba(#f59e0b, 0.35);
+  box-shadow: 0 24px 48px rgba(#f59e0b, 0.15);
+}
+
+.landing-card__title {
+  margin: 0;
+  font-size: $type-size-3;
+}
+
+.landing-card__lead {
+  margin: 0;
+  font-size: $type-size-5;
+  color: mix(#000, $link-color, 25%);
+}
+
+.landing-card--highlight h1 {
+  font-size: $type-size-4;
+  margin-bottom: 0.75rem;
+}
+
+.landing-card--highlight ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.landing-link-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+
+  a {
+    font-weight: 600;
+    text-decoration: none;
+    color: mix(#000, $link-color, 10%);
+
+    &:hover,
+    &:focus {
+      color: $link-color;
+    }
+  }
+}
+
+.landing-card .news-window {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  max-height: 26rem;
+
+  &:focus {
+    outline: 2px solid rgba($link-color, 0.45);
+    box-shadow: none;
+  }
+
+  .news-list {
+    padding-left: 1.1rem;
+
+    li {
+      margin-bottom: 1rem;
+    }
+  }
+}
+
+.landing-card .news-window::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.landing-block--misc ul {
+  columns: 2;
+  column-gap: 1.5rem;
+
+  @include breakpoint($medium) {
+    columns: 3;
+  }
+}
+
+.landing-block--misc li {
+  break-inside: avoid;
+  padding: 0.2rem 0;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -31,6 +31,7 @@
 @import "forms";
 
 @import "page";
+@import "landing";
 @import "archive";
 @import "sidebar";
 


### PR DESCRIPTION
## Summary
- restructure the home page into modular "landing" sections with a hero banner, spotlight statistics, quick navigation chips, and dedicated cards for biography, experience, education, news, and external links
- wrap publication and miscellaneous sections with the new landing blocks while keeping existing content intact and enabling Markdown rendering inside each block
- introduce a dedicated `_landing.scss` stylesheet and import it into the build to provide gradient hero styling, card layouts, and updated news/miscellaneous presentation

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is unavailable in the environment)*
- bundle install *(fails: rubygems.org returns HTTP 403, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d2343c9f7c832d8c2062d3ed73567c