### PR TITLE
Add Google Maps embed to author profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,15 @@ author:
   youtube          :
   wikipedia        :
 
+google_maps:
+  api_key:
+  location:
+    lat: 22.3043
+    lng: 114.1795
+    title: "The Hong Kong Polytechnic University"
+  zoom: 16
+  placeholder: "Set your Google Maps API key in _config.yml to display the location map."
+
 
 # Reading Files
 include:

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -119,10 +119,28 @@
         <li><a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i> Wikipedia</a></li>
 {% endif %}
     </ul>
-    <div class="author__map">
+    <div class="author__map author__map--visitors">
       <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
     </div>
-      <div class="author__urls_sm">
+    {% if site.google_maps %}
+      <div class="author__map author__map--location">
+        {% if site.google_maps.api_key %}
+          <div
+            class="author-location-map"
+            data-author-map
+            data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+            data-lat="{{ site.google_maps.location.lat | default: 0 }}"
+            data-lng="{{ site.google_maps.location.lng | default: 0 }}"
+            data-zoom="{{ site.google_maps.zoom | default: 14 }}"
+            data-marker-title="{{ site.google_maps.location.title | default: author.location | default: 'Location' | escape }}"
+            aria-label="{{ site.google_maps.location.title | default: author.location | default: 'Location map' | escape }}">
+          </div>
+        {% else %}
+          <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
+        {% endif %}
+      </div>
+    {% endif %}
+    <div class="author__urls_sm">
       {% if author.uri %}
         <a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i></a>
       {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,6 +2,7 @@
 <script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -268,3 +268,40 @@
     display: none;
   }
 }
+
+.author__map {
+  margin-top: 1em;
+
+  iframe {
+    width: 100%;
+  }
+}
+
+.author__map--location {
+  margin-top: 0.75em;
+}
+
+.author-location-map {
+  width: 100%;
+  height: 200px;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+  background-color: $code-background-color;
+  overflow: hidden;
+}
+
+@include breakpoint($large) {
+  .author-location-map {
+    height: 220px;
+  }
+}
+
+.author-location-map__placeholder {
+  margin: 0;
+  padding: 0.5em 0.75em;
+  font-size: $type-size-6;
+  color: $gray;
+  background-color: $code-background-color;
+  border: 1px solid $border-color;
+  border-radius: $border-radius;
+}

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -1,0 +1,98 @@
+(function () {
+  'use strict';
+
+  function createInitializer(mapContainer, lat, lng, zoom, title) {
+    return function initializeMap() {
+      if (!window.google || !window.google.maps || !window.google.maps.Map) {
+        return;
+      }
+
+      var center = { lat: lat, lng: lng };
+      var map = new window.google.maps.Map(mapContainer, {
+        zoom: zoom,
+        center: center,
+        mapTypeControl: false,
+        streetViewControl: false,
+        fullscreenControl: false,
+        clickableIcons: false
+      });
+
+      new window.google.maps.Marker({
+        position: center,
+        map: map,
+        title: title
+      });
+    };
+  }
+
+  function loadMapScript(apiKey) {
+    var existingScript = document.querySelector('script[data-google-maps-api]');
+    if (existingScript) {
+      return existingScript;
+    }
+
+    var script = document.createElement('script');
+    script.src = 'https://maps.googleapis.com/maps/api/js?key=' + encodeURIComponent(apiKey) + '&callback=initAuthorLocationMap';
+    script.async = true;
+    script.defer = true;
+    script.setAttribute('data-google-maps-api', 'true');
+    document.head.appendChild(script);
+    return script;
+  }
+
+  function init() {
+    var mapContainer = document.querySelector('[data-author-map]');
+    if (!mapContainer) {
+      return;
+    }
+
+    var dataset = mapContainer.dataset || {};
+    var lat = parseFloat(dataset.lat);
+    var lng = parseFloat(dataset.lng);
+
+    if (isNaN(lat) || isNaN(lng)) {
+      return;
+    }
+
+    var zoom = parseInt(dataset.zoom, 10);
+    if (isNaN(zoom)) {
+      zoom = 14;
+    }
+
+    var title = dataset.markerTitle || '';
+    var apiKey = dataset.apiKey;
+    if (!apiKey) {
+      return;
+    }
+
+    var initializer = createInitializer(mapContainer, lat, lng, zoom, title);
+
+    window.__authorLocationMapCallbacks = window.__authorLocationMapCallbacks || [];
+    window.__authorLocationMapCallbacks.push(initializer);
+
+    if (window.google && window.google.maps && window.google.maps.Map) {
+      initializer();
+      return;
+    }
+
+    if (typeof window.initAuthorLocationMap !== 'function') {
+      window.initAuthorLocationMap = function initAuthorLocationMap() {
+        var callbacks = window.__authorLocationMapCallbacks || [];
+        while (callbacks.length > 0) {
+          var callback = callbacks.shift();
+          if (typeof callback === 'function') {
+            callback();
+          }
+        }
+      };
+    }
+
+    loadMapScript(apiKey);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- embed a configurable Google Maps location panel alongside the existing visitor map in the author sidebar
- add supporting configuration, JavaScript initialiser, and sidebar styles for the new map integration

## Testing
- bundle exec jekyll build *(fails: jekyll executable unavailable because bundle install could not download gems – HTTP 403)*


------
https://chatgpt.com/codex/tasks/task_e_68d29b5d8430832db0d56be92b47f885