### PR TITLE
Add interactive map contact section on homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,10 @@ repository               : "wtwu95/wtwu95.github.io"
 google_scholar_stats_use_cdn : true
 
 # google analytics
-google_analytics_id      : # "https://analytics.google.com/analytics/e2ban1wAAAAJ" 
+google_analytics_id      : # "https://analytics.google.com/analytics/e2ban1wAAAAJ"
+
+# Google Maps
+google_maps_api_key      : # "YOUR_GOOGLE_MAPS_JAVASCRIPT_API_KEY"
 
 # SEO Related
 google_site_verification :  # get google_site_verification from https://search.google.com/search-console/about

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -112,6 +112,65 @@ Find the complete award record on the [Awards page](/awards/).
 
 View detailed service activities on the [Professional Services page](/services/). -->
 
+# 📍 Contact & Location
+
+<div class="contact-location">
+  <div class="contact-card" markdown="1">
+**Wentao Wu (吴文涛)**<br />
+Postdoctoral Fellow in RCLAE & AAE, PolyU<br />
+Hong Kong, China
+
+- ✉️ Email: [wtwu95@gmail.com](mailto:wtwu95@gmail.com)
+- 🔗 [ResearchGate](https://www.researchgate.net/profile/Wu-Wentao-5)
+- 🔍 [Google Scholar](https://scholar.google.com/citations?user=e2ban1wAAAAJ)
+- 🆔 [ORCID](https://orcid.org/0000-0002-3740-598X)
+  </div>
+  <div class="contact-map-container">
+    <div id="contact-map" role="region" aria-label="Map showing the Hong Kong Polytechnic University campus"></div>
+    <noscript class="map-noscript">Enable JavaScript to view the interactive map.</noscript>
+  </div>
+</div>
+
+{% assign maps_key = site.google_maps_api_key | default: '' %}
+<script>
+  window.initMap = function() {
+    const polyuCampus = { lat: 22.3045, lng: 114.1796 };
+    const mapElement = document.getElementById('contact-map');
+    if (!mapElement || typeof google === 'undefined' || !google.maps) {
+      return;
+    }
+
+    const map = new google.maps.Map(mapElement, {
+      center: polyuCampus,
+      zoom: 16,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: false
+    });
+
+    const marker = new google.maps.Marker({
+      position: polyuCampus,
+      map: map,
+      title: 'Wentao Wu (吴文涛)'
+    });
+
+    const infoWindow = new google.maps.InfoWindow({
+      content: '<div class="map-info-window"><strong>Wentao Wu (吴文涛)</strong><br/>Postdoctoral Fellow<br/>The Hong Kong Polytechnic University</div>'
+    });
+
+    marker.addListener('click', function() {
+      infoWindow.open(map, marker);
+    });
+
+    infoWindow.open(map, marker);
+  };
+</script>
+{% if maps_key != '' %}
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ maps_key }}&callback=initMap"></script>
+{% else %}
+<div class="map-api-warning">Set <code>google_maps_api_key</code> in <code>_config.yml</code> to enable the interactive map.</div>
+{% endif %}
+
 # 😀 Miscellaneous
 
 - [CloudConvert](https://cloudconvert.com/)

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -530,3 +530,96 @@ mark.publication-highlight {
     --publication-highlight: rgba(148, 163, 184, 0.35);
   }
 }
+
+.contact-location {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+@include breakpoint($medium) {
+  .contact-location {
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    align-items: stretch;
+  }
+}
+
+.contact-card {
+  background: #f8f9fb;
+  border-left: 4px solid var(--publication-accent, #224b8d);
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px -24px rgba(34, 75, 141, 0.65);
+  padding: 1.35rem 1.5rem;
+  line-height: 1.6;
+}
+
+.contact-card p {
+  margin-bottom: 0.8rem;
+}
+
+.contact-card a {
+  color: var(--publication-accent, #224b8d);
+  font-weight: 600;
+}
+
+.contact-card a:hover,
+.contact-card a:focus {
+  color: var(--publication-accent-hover, #1a3a6d);
+}
+
+.contact-map-container {
+  min-height: 260px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 20px 45px -28px rgba(34, 75, 141, 0.6);
+  background: #e8eef9;
+}
+
+#contact-map {
+  width: 100%;
+  min-height: 260px;
+}
+
+.map-info-window {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.map-noscript {
+  display: block;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  color: #444;
+}
+
+.map-api-warning {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-left: 4px solid #d9534f;
+  background: #fff4f4;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  color: #a94442;
+}
+
+@media (prefers-color-scheme: dark) {
+  .contact-card {
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: 0 16px 35px -25px rgba(15, 23, 42, 0.8);
+  }
+
+  .contact-map-container {
+    background: rgba(30, 41, 59, 0.7);
+    box-shadow: 0 16px 35px -25px rgba(15, 23, 42, 0.9);
+  }
+
+  .map-noscript {
+    color: #e2e8f0;
+  }
+
+  .map-api-warning {
+    background: rgba(127, 29, 29, 0.25);
+    color: #fecaca;
+    border-left-color: #f87171;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Contact & Location section to the homepage with key profile links and a map container
- integrate the Google Maps JavaScript API using a configurable API key and graceful fallback messaging
- style the new contact card and map embed for light and dark themes

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available before bundle install)*
- bundle install *(fails: rubygems.org returned HTTP 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a450f914832d8d7639c8f6f93b87