### PR TITLE
Add fallback rendering for author map

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -125,15 +125,28 @@
     {% if site.google_maps %}
       <div class="author__map author__map--location">
         {% if site.google_maps.api_key %}
+          {% assign map_lat = site.google_maps.location.lat | default: 0 %}
+          {% assign map_lng = site.google_maps.location.lng | default: 0 %}
+          {% assign map_zoom = site.google_maps.zoom | default: 14 %}
+          {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
           <div
             class="author-location-map"
             data-author-map
             data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-            data-lat="{{ site.google_maps.location.lat | default: 0 }}"
-            data-lng="{{ site.google_maps.location.lng | default: 0 }}"
-            data-zoom="{{ site.google_maps.zoom | default: 14 }}"
-            data-marker-title="{{ site.google_maps.location.title | default: author.location | default: 'Location' | escape }}"
-            aria-label="{{ site.google_maps.location.title | default: author.location | default: 'Location map' | escape }}">
+            data-lat="{{ map_lat }}"
+            data-lng="{{ map_lng }}"
+            data-zoom="{{ map_zoom }}"
+            data-marker-title="{{ map_title | escape }}"
+            aria-label="{{ map_title | escape }}">
+            <iframe
+              class="author-location-map__fallback"
+              data-author-map-fallback
+              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed"
+              title="{{ map_title | escape }}"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              allowfullscreen>
+            </iframe>
           </div>
         {% else %}
           <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -290,6 +290,12 @@
   overflow: hidden;
 }
 
+.author-location-map__fallback {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 @include breakpoint($large) {
   .author-location-map {
     height: 220px;

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -22,6 +22,12 @@
         map: map,
         title: title
       });
+
+      var fallback = mapContainer.querySelector('[data-author-map-fallback]');
+      if (fallback) {
+        fallback.style.display = 'none';
+        fallback.setAttribute('aria-hidden', 'true');
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- embed a Google Maps iframe fallback in the author profile card so the location map still renders when the JS API fails
- hide the fallback once the interactive Google Map loads successfully
- style the fallback iframe to fill the sidebar map container

## Testing
- Not run (bundle install fails with 403 from rubygems.org in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2b0f6f114832d896e45c1ff961fcd