### PR TITLE
Align Google Maps language with site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ title                    : "Wentao Wu (吴文涛)"
 description              : ""
 repository               : "wtwu95/wtwu95.github.io"
 google_scholar_stats_use_cdn : true
+lang                     : en
 
 # google analytics
 google_analytics_id      : # "https://analytics.google.com/analytics/e2ban1wAAAAJ"
@@ -68,6 +69,7 @@ google_maps:
     lng: 114.1795
     title: "The Hong Kong Polytechnic University"
   zoom: 16
+  language: en
   placeholder: "Set your Google Maps API key in _config.yml to display the location map."
 
 

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -129,6 +129,7 @@
           {% assign map_lng = site.google_maps.location.lng | default: 0 %}
           {% assign map_zoom = site.google_maps.zoom | default: 14 %}
           {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
+          {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
           <div
             class="author-location-map author-location-map--showing-fallback"
             data-author-map
@@ -137,11 +138,11 @@
             data-lng="{{ map_lng }}"
             data-zoom="{{ map_zoom }}"
             data-marker-title="{{ map_title | escape }}"
-            aria-label="{{ map_title | escape }}">
+            aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
             <iframe
               class="author-location-map__fallback"
               data-author-map-fallback
-              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed"
+              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
               title="{{ map_title | escape }}"
               loading="lazy"
               referrerpolicy="no-referrer-when-downgrade"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,8 @@ layout: compress
 ---
 
 <!doctype html>
-<html lang="en" class="no-js">
+{% assign page_language = page.lang | default: site.lang | default: site.locale | default: 'en' %}
+<html lang="{{ page_language }}" class="no-js">
   <head>
     {% include head.html %}
     {% include head/custom.html %}

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -124,14 +124,18 @@
     };
   }
 
-  function loadMapScript(apiKey) {
+  function loadMapScript(apiKey, language) {
     var existingScript = document.querySelector('script[data-google-maps-api]');
     if (existingScript) {
       return existingScript;
     }
 
     var script = document.createElement('script');
-    script.src = 'https://maps.googleapis.com/maps/api/js?key=' + encodeURIComponent(apiKey) + '&callback=initAuthorLocationMap';
+    var scriptSrc = 'https://maps.googleapis.com/maps/api/js?key=' + encodeURIComponent(apiKey) + '&callback=initAuthorLocationMap';
+    if (language) {
+      scriptSrc += '&language=' + encodeURIComponent(language);
+    }
+    script.src = scriptSrc;
     script.async = true;
     script.defer = true;
     script.setAttribute('data-google-maps-api', 'true');
@@ -160,6 +164,7 @@
 
     var title = dataset.markerTitle || '';
     var apiKey = dataset.apiKey;
+    var language = dataset.language;
     if (!apiKey) {
       return;
     }
@@ -186,7 +191,7 @@
       };
     }
 
-    loadMapScript(apiKey);
+    loadMapScript(apiKey, language);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- add configurable site language and reuse it for Google Maps
- pass the preferred language to the author location map script and iframe fallback
- derive the HTML document language from configurable settings for consistency

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed)*
- bundle install *(fails: rubygems.org responded 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c1ace1cc832da1c1ae6722d2b58e