### PR TITLE
Limit homepage news and add archive

### DIFF
--- a/_data/news.json
+++ b/_data/news.json
@@ -1,0 +1,126 @@
+[
+    {
+        "date": "08/2025",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/11164660))!"
+    },
+    {
+        "date": "08/2025",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-IE** ([Link](10.1109/TIE.2025.3600515))!"
+    },
+    {
+        "date": "06/2025",
+        "content": "\ud83d\udc4f I was awarded the **Outstanding Graduates of Shanghai**!"
+    },
+    {
+        "date": "01/2025",
+        "content": "\ud83d\udc4f\ud83c\udf89 I obtained **Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program** by CAST!"
+    },
+    {
+        "date": "09/2024",
+        "content": "\ud83d\udc4f\ud83d\udc4f I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
+    },
+    {
+        "date": "08/2024",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!"
+    },
+    {
+        "date": "07/2024",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by IEEE **CDC** ([Link]())!"
+    },
+    {
+        "date": "07/2024",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-FS** ([Link](10.1109/TFUZZ.2024.3434711))!"
+    },
+    {
+        "date": "03/2024",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/10549852))!"
+    },
+    {
+        "date": "02/2024",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/document/10462491))!"
+    },
+    {
+        "date": "02/2024",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/10449447))!"
+    },
+    {
+        "date": "12/2023",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/document/10416809))!"
+    },
+    {
+        "date": "12/2023",
+        "content": "\ud83d\udc4f I obtained the **Scientific Research Talens Graduate Student Scholarship** awarded by Sanya Yazhou Bay Science and Technology City!"
+    },
+    {
+        "date": "12/2023",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/document/10414035))!"
+    },
+    {
+        "date": "12/2023",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
+    },
+    {
+        "date": "11/2023",
+        "content": "\ud83d\udc4f My conference paper was awarded the **Best Student Paper Nomination Award** at 2023 7th CCSICC!"
+    },
+    {
+        "date": "11/2023",
+        "content": "\ud83d\udc4f I won the **National third prize** of the First Air Force Aviation Innovation Challenge in 2023!"
+    },
+    {
+        "date": "11/2023",
+        "content": "\ud83d\udc4f I obtained the **First-class Scholarship** for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!"
+    },
+    {
+        "date": "09/2023",
+        "content": "\ud83d\udc4f\ud83d\udc4f I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
+    },
+    {
+        "date": "09/2023",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-ITS** ([Link](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979))!"
+    },
+    {
+        "date": "08/2023",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE CAA/JAS** ([Link](https://www.ieee-jas.net/indexen.html))!"
+    },
+    {
+        "date": "07/2023",
+        "content": "\ud83d\udc4f I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!"
+    },
+    {
+        "date": "02/2023",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/abstract/document/10059139))!"
+    },
+    {
+        "date": "12/2022",
+        "content": "\ud83c\udf89 I won the **First Prize** in the Hainan Free Trade Port Entrepreneurship Competition!"
+    },
+    {
+        "date": "10/2022",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by IEEE **T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9950329))!"
+    },
+    {
+        "date": "10/2022",
+        "content": "\ud83c\udf89 One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
+    },
+    {
+        "date": "09/2022",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/abstract/document/9900363))!"
+    },
+    {
+        "date": "06/2022",
+        "content": "\ud83c\udf89 One co-author's paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9878245))!"
+    },
+    {
+        "date": "04/2022",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!"
+    },
+    {
+        "date": "01/2022",
+        "content": "\ud83c\udf89 One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!"
+    },
+    {
+        "date": "04/2021",
+        "content": "\ud83c\udf89 One paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!"
+    }
+]

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,6 +3,9 @@ permalink: /
 title: ""
 excerpt: ""
 author_profile: true
+news_limit: 10
+news_enable_scroll: false
+news_more_link: /news/
 redirect_from:
   - /about/
   - /about.html

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,38 +1,27 @@
 # 💬 News
 
-<div class="news-window" data-news-window data-visible-count="5" tabindex="0" aria-label="Latest news" markdown="1">
+{% assign news_items = site.data.news %}
+{% if page.news_limit %}
+  {% assign news_items = news_items | slice: 0, page.news_limit %}
+{% endif %}
+{% assign enable_scroll = page.news_enable_scroll %}
+{% if enable_scroll == nil %}
+  {% assign enable_scroll = true %}
+{% endif %}
+{% assign visible_count = page.news_visible_count | default: 5 %}
+{% assign aria_label = page.news_aria_label | default: 'Latest news' %}
 
-- *08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/11164660))!
-- *08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-IE** ([Link](10.1109/TIE.2025.3600515))!
-- *06/2025* &nbsp;👏 I was awarded the **Outstanding Graduates of Shanghai**!
-- *01/2025* &nbsp;👏🎉 I obtained **Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program** by CAST!
-- *09/2024* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!
-- *08/2024* &nbsp;🎉 One paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!
-- *07/2024* &nbsp;🎉  One co-author's paper was accepted by IEEE **CDC** ([Link]())!
-- *07/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](10.1109/TFUZZ.2024.3434711))!
-- *03/2024* &nbsp;🎉 One  paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/10549852))!
-- *02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/document/10462491))!
-- *02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/10449447))!
-- *12/2023* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/document/10416809))!
-- *12/2023* &nbsp;👏 I obtained the **Scientific Research Talens Graduate Student Scholarship** awarded by Sanya Yazhou Bay Science and Technology City!
-- *12/2023* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/document/10414035))!
-- *12/2023* &nbsp;🎉 One co-author's paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!
-- *11/2023* &nbsp;👏  My conference paper was awarded the **Best Student Paper Nomination Award** at 2023 7th CCSICC!
-- *11/2023* &nbsp;👏  I won the **National third prize** of the First Air Force Aviation Innovation Challenge in 2023!
-- *11/2023* &nbsp;👏  I obtained the **First-class Scholarship** for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!
-- *09/2023* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!
-- *09/2023* &nbsp;🎉  One paper was accepted by **IEEE T-ITS** ([Link](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979))!
-- *08/2023* &nbsp;🎉  One paper was accepted by **IEEE CAA/JAS** ([Link](https://www.ieee-jas.net/indexen.html))!
-- *07/2023* &nbsp;👏  I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!
-- *02/2023* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/abstract/document/10059139))!
-- *12/2022* &nbsp;🎉  I won the **First Prize** in the Hainan Free Trade Port Entrepreneurship Competition!
-- *10/2022* &nbsp;🎉  One co-author's paper was accepted by IEEE **T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9950329))!
-- *10/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!
-- *09/2022* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/abstract/document/9900363))!
-- *06/2022* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9878245))!
-- *04/2022* &nbsp;🎉  One paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!
-- *01/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!
-- *04/2021* &nbsp;🎉  One paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!
-{: .news-list}
-
+<div class="news-window{% unless enable_scroll %} news-window--full{% endunless %}"{% if enable_scroll %} data-news-window data-visible-count="{{ visible_count }}" tabindex="0"{% endif %} aria-label="{{ aria_label }}">
+  <ul class="news-list">
+    {% for item in news_items %}
+      {% capture item_content %}{{ item.content | markdownify }}{% endcapture %}
+      {% assign item_content = item_content | replace: '<p>', '' | replace: '</p>', '' | strip %}
+      <li><em>{{ item.date }}</em>&nbsp;{{ item_content }}</li>
+    {% endfor %}
+  </ul>
+  {% if page.news_more_link %}
+  <div class="news-more">
+    <a class="btn" href="{{ page.news_more_link | relative_url }}">查看更多</a>
+  </div>
+  {% endif %}
 </div>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -1,0 +1,8 @@
+---
+permalink: /news/
+title: "News"
+author_profile: true
+news_enable_scroll: false
+---
+
+{% include_relative includes/news.md %}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -124,6 +124,11 @@
     box-shadow: 0 2px 6px rgba(#000, 0.06);
     transition: box-shadow 0.2s ease;
 
+    &.news-window--full {
+      max-height: none;
+      overflow: visible;
+    }
+
     &:focus {
       outline: 2px solid rgba($link-color, 0.55);
       outline-offset: 2px;
@@ -145,6 +150,15 @@
         &:last-child {
           margin-bottom: 0;
         }
+      }
+    }
+
+    .news-more {
+      margin-top: 1rem;
+      text-align: right;
+
+      .btn {
+        margin-bottom: 0;
       }
     }
   }

--- a/github_myprofile_updater/update.py
+++ b/github_myprofile_updater/update.py
@@ -1,10 +1,31 @@
+import json
+
+
+def load_markdown(path):
+    with open(path, encoding='utf-8') as handle:
+        return handle.read().strip()
+
+
+def build_news_section(data_path):
+    with open(data_path, encoding='utf-8') as handle:
+        news_items = json.load(handle)
+
+    lines = ['# 💬 News', '']
+
+    for item in news_items:
+        lines.append(f"- *{item['date']}* &nbsp;{item['content']}")
+
+    return '\n'.join(lines)
+
+
 if __name__ == '__main__':
     _header = '## Hi there 👋'
     base_dir = '../_pages/includes/'
-    _intro = open(f'{base_dir}/intro.md').read().strip()
-    _homepage = open(f'{base_dir}/homepage.md').read().strip()
-    _pub = open(f'{base_dir}/pub.md').read().strip()
-    _news = open(f'{base_dir}/news.md').read().strip()
+    data_dir = '../_data/'
+    _intro = load_markdown(f'{base_dir}/intro.md')
+    _homepage = load_markdown(f'{base_dir}/homepage.md')
+    _pub = load_markdown(f'{base_dir}/pub.md')
+    _news = build_news_section(f'{data_dir}/news.json')
     with open('README.md', 'w') as f:
         f.write(_header)
         f.write('\n\n')


### PR DESCRIPTION
## Summary
- limit the homepage news section to the newest ten items and append a matching “查看更多” button that links to the full archive
- move the news entries into a shared data file that powers both the homepage include and a new `/news/` archive page
- add supporting styles and update the profile README generator so it renders the news from the new data source

## Testing
- bundle exec jekyll build *(fails: bundler could not find `jekyll` because required gems are unavailable in the environment)*
- bundle install *(fails: rubygems.org responds with HTTP 403 so dependencies cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de9c6d38832d99aec97ccf5e6489