### PR TITLE
Refine news section markup and styles

### DIFF
--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -14,29 +14,17 @@
   {% assign limit = news_count %}
 {% endif %}
 
-{% assign visible_count = include.visible_count %}
-{% if visible_count %}
-  {% assign visible_count = visible_count | plus: 0 %}
-{% else %}
-  {% assign visible_count = limit %}
-{% endif %}
-{% if visible_count < 1 %}
-  {% assign visible_count = 1 %}
-{% endif %}
-
 {% if limit > 0 %}
-<div class="news-window" data-news-window data-visible-count="{{ visible_count }}" tabindex="0" aria-label="Latest news" markdown="1">
 {% for item in news_items limit: limit %}
 - {{ item }}
 {% endfor %}
 {: .news-list}
-</div>
 {% else %}
 <p>No news items are available right now. Please check back later.</p>
 {% endif %}
 
 {% if include.show_button and limit < news_count %}
-<div class="news-window__actions">
+<p class="news-actions">
   <a class="btn" href="{{ '/news/' | relative_url }}">查看更多</a>
-</div>
+</p>
 {% endif %}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -111,42 +111,27 @@
     font-size: $type-size-6;
   }
 
-  .news-window {
-    --news-window-max-height: calc(5 * 3.5rem);
-    position: relative;
-    max-height: none;
-    overflow-y: auto;
+  .news-list {
     margin: 1rem 0;
-    padding: 0.75rem 1.25rem 0.75rem 1.5rem;
-    border: 1px solid $border-color;
-    border-radius: $border-radius;
-    background-color: rgba(#fff, 0.85);
-    box-shadow: 0 2px 6px rgba(#000, 0.06);
-    transition: box-shadow 0.2s ease;
+    padding-left: 1.25rem;
+    list-style-position: outside;
 
-    &:focus {
-      outline: 2px solid rgba($link-color, 0.55);
-      outline-offset: 2px;
-      box-shadow: 0 4px 12px rgba(#000, 0.12);
-    }
+    li {
+      margin-bottom: 0.75rem;
 
-    &.news-window--scroll {
-      max-height: var(--news-window-max-height);
-      padding-right: 1.75rem;
-    }
-
-    .news-list {
-      margin: 0;
-      padding-left: 0;
-      list-style-position: outside;
-
-      li {
-        margin-bottom: 0.75rem;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
+      &:last-child {
+        margin-bottom: 0;
       }
+    }
+  }
+
+  .news-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+
+    .btn {
+      margin-bottom: 0;
     }
   }
 
@@ -209,15 +194,6 @@
     }
   }
 
-  .news-window__actions {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 0.75rem;
-
-    .btn {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .page__hero-image {


### PR DESCRIPTION
## Summary
- render the news include directly as a markdown list and move the “查看更多” button below it
- replace the old `.news-window` and `.news-window__actions` styles with streamlined `.news-list` and `.news-actions` rules

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` executable missing because Bundler cannot fetch gems in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2eb840e58832d936b1fa3f3ae1fb7