### PR TITLE
Align profile maps with layout orientation

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -119,41 +119,43 @@
         <li><a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i> Wikipedia</a></li>
 {% endif %}
     </ul>
-    <div class="author__map author__map--visitors">
-      <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
-    </div>
-    {% if site.google_maps %}
-      <div class="author__map author__map--location">
-        {% if site.google_maps.api_key %}
-          {% assign map_lat = site.google_maps.location.lat | default: 0 %}
-          {% assign map_lng = site.google_maps.location.lng | default: 0 %}
-          {% assign map_zoom = site.google_maps.zoom | default: 14 %}
-          {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
-          {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-          <div
-            class="author-location-map author-location-map--showing-fallback"
-            data-author-map
-            data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-            data-lat="{{ map_lat }}"
-            data-lng="{{ map_lng }}"
-            data-zoom="{{ map_zoom }}"
-            data-marker-title="{{ map_title | escape }}"
-            aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
-            <iframe
-              class="author-location-map__fallback"
-              data-author-map-fallback
-              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-              title="{{ map_title | escape }}"
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-              allowfullscreen>
-            </iframe>
-          </div>
-        {% else %}
-          <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
-        {% endif %}
+    <div class="author__maps">
+      <div class="author__map author__map--visitors">
+        <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
       </div>
-    {% endif %}
+      {% if site.google_maps %}
+        <div class="author__map author__map--location">
+          {% if site.google_maps.api_key %}
+            {% assign map_lat = site.google_maps.location.lat | default: 0 %}
+            {% assign map_lng = site.google_maps.location.lng | default: 0 %}
+            {% assign map_zoom = site.google_maps.zoom | default: 14 %}
+            {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
+            {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
+            <div
+              class="author-location-map author-location-map--showing-fallback"
+              data-author-map
+              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+              data-lat="{{ map_lat }}"
+              data-lng="{{ map_lng }}"
+              data-zoom="{{ map_zoom }}"
+              data-marker-title="{{ map_title | escape }}"
+              aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
+              <iframe
+                class="author-location-map__fallback"
+                data-author-map-fallback
+                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+                title="{{ map_title | escape }}"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                allowfullscreen>
+              </iframe>
+            </div>
+          {% else %}
+            <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
     <div class="author__urls_sm">
       {% if author.uri %}
         <a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i></a>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -269,8 +269,16 @@
   }
 }
 
-.author__map {
+.author__maps {
   margin-top: 1em;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 0.75em;
+}
+
+.author__map {
+  flex: 1 1 0;
 
   iframe {
     width: 100%;
@@ -278,7 +286,7 @@
 }
 
 .author__map--location {
-  margin-top: 0.75em;
+  margin-top: 0;
 }
 
 .author-location-map {
@@ -309,6 +317,10 @@
 }
 
 @include breakpoint($large) {
+  .author__maps {
+    flex-direction: column;
+  }
+
   .author-location-map {
     height: 220px;
   }


### PR DESCRIPTION
## Summary
- wrap the visitor and location map embeds in a shared container so they can be positioned together
- style the map container to switch between horizontal and vertical layouts in sync with the author profile orientation

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in environment)*
- `bundle install` *(fails: unable to download gems, rubygems.org returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f0a4a570832db3f5c5364bcc2d24