### PR TITLE
Customize homepage awards and services content

### DIFF
--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -1,6 +1,22 @@
 # 🎖 Awards
 
-{% assign awards = site.data.awards | default: [] %}
+{% assign awards = "" | split: "" %}
+{% assign awards = awards | push: "2025&nbsp; <strong><span style='color:red'>Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span></strong>" %}
+{% assign awards = awards | push: "2025&nbsp; Outstanding Graduate of Shanghai" %}
+{% assign awards = awards | push: "2024 · 2023 · 2020&nbsp; <strong><span style='color:red'>National Scholarships for Graduate Students</span></strong>" %}
+{% assign awards = awards | push: "2023&nbsp; State-Sponsored Postgraduate Program for National Construction of High-Level Universities" %}
+{% assign awards = awards | push: "2023&nbsp; <strong><span style='color:red'>Best Student Paper Nomination Award</span></strong> of the 7th CCSICC" %}
+{% assign awards = awards | push: "2023&nbsp; First-Level Scholarship for Doctoral Students" %}
+{% assign awards = awards | push: "2023&nbsp; Scientific Research Talents Graduate Student Scholarship" %}
+{% assign awards = awards | push: "2023&nbsp; Third Award of the First Aviation Innovation Challenge of the PLA Air Force" %}
+{% assign awards = awards | push: "2022&nbsp; <strong><span style='color:red'>Excellent Master Dissertation Award</span></strong> of Liaoning Province" %}
+{% assign awards = awards | push: "2022&nbsp; Top 10 High-Impact Papers of <em>Chinese Journal of Ship Research</em> — selected from articles published in 2019–2021" %}
+{% assign awards = awards | push: "2022&nbsp; First Prize of Hainan Free Trade Port Innovation and Entrepreneurship Contest" %}
+{% assign awards = awards | push: "2021&nbsp; Excellent Master Dissertation Award of Dalian Maritime University" %}
+{% assign awards = awards | push: "2020&nbsp; Outstanding Graduate of Dalian" %}
+{% assign awards = awards | push: "2020&nbsp; First Prize of Liaoning Provincial Graduate Electronic Design Contest" %}
+{% assign awards = awards | push: "2019 · 2020&nbsp; First Prizes of National Graduate Electronic Design Contest in Northeast Division" %}
+
 {% assign awards_count = awards | size %}
 {% assign limit = include.limit %}
 {% if limit %}
@@ -15,10 +31,11 @@
 {% endif %}
 
 {% if limit > 0 and awards_count > 0 %}
-{% for award in awards limit: limit %}
-- {{ award }}
-{% endfor %}
-{: .awards-list}
+<ul class="awards-list">
+  {% for award in awards limit: limit %}
+  <li>{{ award }}</li>
+  {% endfor %}
+</ul>
 {% else %}
 <p>No awards are available at this time. Please check back later.</p>
 {% endif %}

--- a/_pages/includes/serv.md
+++ b/_pages/includes/serv.md
@@ -1,12 +1,33 @@
 # 🧩  Professional Services
 
-{% assign services = site.data.services | default: [] %}
-{% assign total_items = 0 %}
-{% for section in services %}
-  {% assign section_items = section.items | default: [] %}
-  {% assign section_count = section_items | size %}
-  {% assign total_items = total_items | plus: section_count %}
-{% endfor %}
+{% assign services = "" | split: "" %}
+{% assign services = services | push: "Journal Editorial Boards||<strong>Young Editorial Board Member</strong>: <a href='http://www.coscipress.com/journal/JAICS'>Journal of Artificial Intelligence &amp; Control Systems</a> (2025–present)" %}
+{% assign services = services | push: "Conference Program Committee and Editorial||<strong>Organizer</strong> for “Special Session 2. Distributed Optimization and Control for Robot Systems” at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)" %}
+{% assign services = services | push: "Teaching||<strong>Teaching Assistant</strong> for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025–present)" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9'>IEEE Transactions on Automatic Control</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673'>IEEE Control Systems Letters</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221036'>IEEE Transactions on Cybernetics</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8254253'>IEEE Transactions on Industrial Cyber-Physical Systems</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=25'>IEEE Transactions on Vehicular Technology</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6687312'>IEEE Transactions on Transportation Electrification</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=8782712'>IEEE Open Journal of the Industrial Electronics Society</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6570650'>IEEE/CAA Journal of Automatica Sinica</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=41'>IEEE Transactions on Industrial Electronics</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7274857'>IEEE Transactions on Intelligent Vehicles</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6221021'>IEEE Transactions on Systems, Man, and Cybernetics: Systems</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6488907'>IEEE Internet of Things Journal</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://www.sciencedirect.com/journal/ocean-engineering'>Ocean Engineering</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://www.sciencedirect.com/journal/isa-transactions'>ISA Transactions</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://link.springer.com/journal/34'>Circuits, Systems, and Signal Processing</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://onlinelibrary.wiley.com/journal/10991239'>International Journal of Robust and Nonlinear Control</a>" %}
+{% assign services = services | push: "Journal Reviewer||<a href='https://link.springer.com/journal/11071'>Nonlinear Dynamics</a>" %}
+{% assign services = services | push: "Conference Reviewer||IEEE Conference on Decision and Control (CDC)" %}
+{% assign services = services | push: "Conference Reviewer||American Control Conference (ACC)" %}
+{% assign services = services | push: "Conference Reviewer||Annual Conference of the IEEE Industrial Electronics Society (IECON)" %}
+{% assign services = services | push: "Conference Reviewer||Chinese Control Conference (CCC)" %}
+{% assign services = services | push: "Conference Reviewer||Chinese Control and Decision Conference (CCDC)" %}
+
+{% assign total_items = services | size %}
 {% assign limit = include.limit %}
 {% if limit %}
   {% assign limit = limit | plus: 0 %}
@@ -23,37 +44,30 @@
 <p>No professional service activities are available at this time. Please check back later.</p>
 {% else %}
   {% assign displayed = 0 %}
-  {% assign limited = false %}
-  {% if limit < total_items %}
-    {% assign limited = true %}
-  {% endif %}
-  {% for section in services %}
-    {% assign section_items = section.items | default: [] %}
-    {% assign section_count = section_items | size %}
-    {% if section_count == 0 %}
-      {% continue %}
-    {% endif %}
-    {% assign remaining = limit | minus: displayed %}
-    {% if remaining <= 0 %}
-      {% break %}
-    {% endif %}
-    {% assign items_to_show = section_count %}
-    {% if limited and remaining < items_to_show %}
-      {% assign items_to_show = remaining %}
-    {% endif %}
+  {% assign current_title = '' %}
+  {% for entry in services %}
+    {% assign parts = entry | split: '||' %}
+    {% assign title = parts[0] | strip %}
+    {% assign item = parts[1] | strip %}
+    {% if title != current_title %}
+      {% if current_title != '' %}
+</ul>
 
-## {{ section.title }}
-
-{% for item in section_items limit: items_to_show %}
-- {{ item }}
-{% endfor %}
-{: .services-list}
-
-    {% assign displayed = displayed | plus: items_to_show %}
+      {% endif %}
+## {{ title }}
+<ul class="services-list">
+      {% assign current_title = title %}
+    {% endif %}
+    <li>{{ item }}</li>
+    {% assign displayed = displayed | plus: 1 %}
     {% if displayed >= limit %}
       {% break %}
     {% endif %}
   {% endfor %}
+  {% if current_title != '' %}
+</ul>
+
+  {% endif %}
 {% endif %}
 
 {% if include.show_button and limit < total_items %}


### PR DESCRIPTION
## Summary
- define the awards include with inline custom entries so the homepage no longer relies on `_data` while retaining limit and button behavior
- rework the services include to use handcrafted grouped content with flattened iteration logic that still honors the limit and "More" link controls

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable missing because gems are not installed in the container)*
- `bundle install` *(fails: unable to fetch gems; received 403 Forbidden responses from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f6793018832daf02b8c8bf3dd2ad