### PR TITLE
Adjust author maps layout on small screens

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,6 +2,7 @@
 <script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/author-maps-placement.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
 
 {% include analytics.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -279,14 +279,32 @@
 
 .author__map {
   flex: 1 1 0;
+  min-height: 200px;
 
   iframe {
     width: 100%;
+    height: 100%;
   }
 }
 
 .author__map--location {
   margin-top: 0;
+}
+
+.author__maps--mobile {
+  width: 100%;
+  margin-top: 2em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+
+  .author__map {
+    flex: 0 0 auto;
+  }
+
+  .author-location-map {
+    height: 200px;
+  }
 }
 
 .author-location-map {

--- a/assets/js/author-maps-placement.js
+++ b/assets/js/author-maps-placement.js
@@ -1,0 +1,108 @@
+(function () {
+  'use strict';
+
+  var BREAKPOINT_MAX_WIDTH = 924;
+  var mapsContainer;
+  var placeholder;
+  var mainContainer;
+  var hasMoved = false;
+  var mediaQuery;
+
+  function ensurePlaceholder() {
+    if (!mapsContainer || !mapsContainer.parentNode) {
+      return;
+    }
+
+    if (!placeholder) {
+      placeholder = document.createComment('author__maps-placeholder');
+    }
+
+    if (!placeholder.parentNode) {
+      mapsContainer.parentNode.insertBefore(placeholder, mapsContainer.nextSibling);
+    }
+  }
+
+  function moveMapsToBottom() {
+    if (!mapsContainer || !mainContainer || hasMoved) {
+      return;
+    }
+
+    ensurePlaceholder();
+    mainContainer.appendChild(mapsContainer);
+    mapsContainer.classList.add('author__maps--mobile');
+    hasMoved = true;
+  }
+
+  function restoreMaps() {
+    if (!mapsContainer || !placeholder || !placeholder.parentNode || !hasMoved) {
+      return;
+    }
+
+    placeholder.parentNode.insertBefore(mapsContainer, placeholder);
+    mapsContainer.classList.remove('author__maps--mobile');
+    hasMoved = false;
+  }
+
+  function shouldUseMobileLayout() {
+    if (mediaQuery && typeof mediaQuery.matches === 'boolean') {
+      return mediaQuery.matches;
+    }
+
+    return window.innerWidth <= BREAKPOINT_MAX_WIDTH;
+  }
+
+  function handleLayoutChange() {
+    if (!mapsContainer || !mainContainer) {
+      return;
+    }
+
+    if (shouldUseMobileLayout()) {
+      moveMapsToBottom();
+    } else {
+      restoreMaps();
+    }
+  }
+
+  function registerListeners() {
+    if (mediaQuery) {
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleLayoutChange);
+        return;
+      }
+
+      if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(handleLayoutChange);
+        return;
+      }
+    }
+
+    window.addEventListener('resize', handleLayoutChange);
+  }
+
+  function init() {
+    var sidebar = document.querySelector('.sidebar');
+    mainContainer = document.getElementById('main');
+
+    if (!sidebar || !mainContainer) {
+      return;
+    }
+
+    mapsContainer = sidebar.querySelector('.author__maps');
+    if (!mapsContainer) {
+      return;
+    }
+
+    if (typeof window.matchMedia === 'function') {
+      mediaQuery = window.matchMedia('(max-width: ' + BREAKPOINT_MAX_WIDTH + 'px)');
+    }
+
+    handleLayoutChange();
+    registerListeners();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a script that relocates the author maps below the page content on narrow viewports
- tweak author map styles so the maps stack vertically with consistent sizing on mobile
- load the new placement script alongside existing sidebar assets

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3045d77c0832da57e1f0fc28df42c