### PR TITLE
Align author maps side-by-side on narrow screens

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -279,14 +279,34 @@
 
 .author__map {
   flex: 1 1 0;
+  min-height: 200px;
 
   iframe {
     width: 100%;
+    height: 100%;
   }
 }
 
 .author__map--location {
   margin-top: 0;
+}
+
+.author__maps--mobile {
+  width: 100%;
+  margin-top: 2em;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 0.75em;
+
+  .author__map {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .author-location-map {
+    height: 200px;
+  }
 }
 
 .author-location-map {

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -1,6 +1,15 @@
 (function () {
   'use strict';
 
+  var BREAKPOINT_MAX_WIDTH = 924;
+  var mapsContainer = null;
+  var mapsPlaceholder = null;
+  var mapsOriginalParent = null;
+  var mainContainer = null;
+  var mapsMoved = false;
+  var layoutMediaQuery = null;
+  var layoutInitialized = false;
+
   function getFallback(mapContainer) {
     if (!mapContainer) {
       return null;
@@ -120,7 +129,6 @@
           showFallback(mapContainer);
         }
       }, 4000);
-      }
     };
   }
 
@@ -143,7 +151,110 @@
     return script;
   }
 
-  function init() {
+  function ensureMapsPlaceholder() {
+    if (!mapsContainer) {
+      return;
+    }
+
+    if (!mapsOriginalParent) {
+      mapsOriginalParent = mapsContainer.parentNode;
+    }
+
+    if (!mapsOriginalParent) {
+      return;
+    }
+
+    if (!mapsPlaceholder) {
+      mapsPlaceholder = document.createComment('author__maps-placeholder');
+    }
+
+    if (!mapsPlaceholder.parentNode) {
+      mapsOriginalParent.insertBefore(mapsPlaceholder, mapsContainer.nextSibling);
+    }
+  }
+
+  function moveMapsToMain() {
+    if (!mapsContainer || !mainContainer || mapsMoved) {
+      return;
+    }
+
+    ensureMapsPlaceholder();
+    mainContainer.appendChild(mapsContainer);
+    mapsContainer.classList.add('author__maps--mobile');
+    mapsMoved = true;
+  }
+
+  function restoreMapsToSidebar() {
+    if (!mapsContainer || !mapsPlaceholder || !mapsPlaceholder.parentNode || !mapsMoved) {
+      return;
+    }
+
+    mapsPlaceholder.parentNode.insertBefore(mapsContainer, mapsPlaceholder);
+    mapsContainer.classList.remove('author__maps--mobile');
+    mapsMoved = false;
+  }
+
+  function shouldUseMobileLayout() {
+    if (layoutMediaQuery && typeof layoutMediaQuery.matches === 'boolean') {
+      return layoutMediaQuery.matches;
+    }
+
+    return window.innerWidth <= BREAKPOINT_MAX_WIDTH;
+  }
+
+  function handleLayoutChange() {
+    if (!mapsContainer || !mainContainer) {
+      return;
+    }
+
+    if (shouldUseMobileLayout()) {
+      moveMapsToMain();
+    } else {
+      restoreMapsToSidebar();
+    }
+  }
+
+  function registerLayoutListeners() {
+    if (layoutMediaQuery) {
+      if (typeof layoutMediaQuery.addEventListener === 'function') {
+        layoutMediaQuery.addEventListener('change', handleLayoutChange);
+        return;
+      }
+
+      if (typeof layoutMediaQuery.addListener === 'function') {
+        layoutMediaQuery.addListener(handleLayoutChange);
+        return;
+      }
+    }
+
+    window.addEventListener('resize', handleLayoutChange);
+  }
+
+  function initAuthorMapsLayout() {
+    if (layoutInitialized) {
+      handleLayoutChange();
+      return;
+    }
+
+    mainContainer = document.getElementById('main');
+    mapsContainer = document.querySelector('.sidebar .author__maps');
+
+    if (!mainContainer || !mapsContainer || !mapsContainer.parentNode) {
+      return;
+    }
+
+    mapsOriginalParent = mapsContainer.parentNode;
+
+    if (typeof window.matchMedia === 'function') {
+      layoutMediaQuery = window.matchMedia('(max-width: ' + BREAKPOINT_MAX_WIDTH + 'px)');
+    }
+
+    handleLayoutChange();
+    registerLayoutListeners();
+    layoutInitialized = true;
+  }
+
+  function initAuthorLocationMap() {
     var mapContainer = document.querySelector('[data-author-map]');
     if (!mapContainer) {
       return;
@@ -192,6 +303,11 @@
     }
 
     loadMapScript(apiKey, language);
+  }
+
+  function init() {
+    initAuthorMapsLayout();
+    initAuthorLocationMap();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- keep the relocated author map section in a horizontal row on narrow screens so the two maps stay side-by-side with matching dimensions when moved beneath the main content
- fix the author map initializer so the relocation and fallback handling run correctly on load

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3045d77c0832da57e1f0fc28df42c