### PR TITLE
Refine typography and interface styling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,11 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
+<!-- Font loading -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -13,7 +13,12 @@ body {
   padding-bottom: 0em;
   color: $text-color;
   font-family: $global-font-family;
-  line-height: 1.5;
+  line-height: 1.7;
+  font-weight: 400;
+  background-color: $body-color;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 
   &.overflow--hidden {
     /* when primary navigation is visible, the content in the background won't scroll */
@@ -22,28 +27,29 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin: 1em 0 0.5em;
-  line-height: 1.2;
+  margin: 1.2em 0 0.6em;
+  line-height: 1.15;
   font-family: $header-font-family;
-  font-weight: bold;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 h1 {
   // margin: 4em 0 0.5em;
-  margin-top: 1em;
-  font-size: $type-size-3;
+  margin-top: 0.75em;
+  font-size: $type-size-2;
 }
 
 h2 {
-  font-size: $type-size-4;
+  font-size: $type-size-3;
 }
 
 h3 {
-  font-size: $type-size-5;
+  font-size: $type-size-4;
 }
 
 h4 {
-  font-size: $type-size-6;
+  font-size: $type-size-5;
 }
 
 h5 {
@@ -59,7 +65,13 @@ small, .small {
 }
 
 p {
-  margin-bottom: 0.5em;
+  margin-bottom: 1em;
+}
+
+.page__content {
+  max-width: 74ch;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 u,
@@ -73,7 +85,7 @@ ins {
 
 ul {
   padding-inline-start: 2em;
-  margin-block-start: 0.5em;
+  margin-block-start: 0.8em;
 }
 
 del a {
@@ -103,7 +115,9 @@ blockquote {
   padding-left: 1em;
   padding-right: 1em;
   font-style: italic;
-  border-left: 0.25em solid $primary-color;
+  border-left: 0.25em solid rgba($primary-color, 0.6);
+  background: rgba($primary-color, 0.06);
+  border-radius: 0.5em;
 
   cite {
     font-style: italic;
@@ -141,7 +155,7 @@ a {
   &:focus {
     color: $link-color-hover;
     background-color: rgba($link-color, 0.12);
-    box-shadow: 0 0 0 1px rgba($link-color, 0.15);
+    box-shadow: 0 6px 18px -12px rgba($link-color, 0.6);
     text-decoration: none;
     outline: none;
   }
@@ -180,7 +194,7 @@ td > code {
 
 hr {
   display: block;
-  margin: 1em 0;
+  margin: 2em 0;
   border: 0;
   border-top: 1px solid $border-color;
 }
@@ -189,12 +203,23 @@ hr {
 
 ul li,
 ol li {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.6em;
 }
 
 li ul,
 li ol {
-  margin-top: 0.5em;
+  margin-top: 0.6em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /*

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -10,20 +10,35 @@
   /* default button */
   display: inline-block;
   margin-bottom: 0.25em;
-  padding: 0.5em 1em;
+  padding: 0.65em 1.4em;
   color: #fff !important;
   font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: bold;
+  font-size: $type-size-5;
+  font-weight: 600;
+  letter-spacing: 0.02em;
   text-align: center;
   text-decoration: none;
-  background-color: $primary-color;
+  background-image: linear-gradient(135deg, lighten($primary-color, 10%), $primary-color);
   border: 0 !important;
-  border-radius: $border-radius;
+  border-radius: 999px;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-position 0.2s ease;
+  box-shadow: 0 14px 24px -18px rgba($primary-color, 0.65);
 
   &:hover {
-    background-color: mix(white, #000, 20%);
+    transform: translateY(-1px);
+    box-shadow: 0 18px 28px -16px rgba($primary-color, 0.75);
+    background-image: linear-gradient(135deg, lighten($primary-color, 18%), darken($primary-color, 3%));
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 10px 20px -14px rgba($primary-color, 0.7);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba($primary-color, 0.3);
+    outline-offset: 4px;
   }
 
   .icon {
@@ -54,7 +69,8 @@
 
     &:hover {
       color: #fff !important;
-      border-color: $gray;
+      border-color: transparent;
+      background-image: linear-gradient(135deg, lighten($primary-color, 14%), $primary-color);
     }
   }
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -6,16 +6,16 @@
    Typography
    ========================================================================== */
 
-$doc-font-size              : 16;
+$doc-font-size              : 17;
 
 /* paragraph indention */
 $paragraph-indent           : false; // true, false (default)
 $indent-var                 : 0.5em;
 
 /* system typefaces */
-$serif                      : Georgia, Times, serif;
+$serif                      : "Playfair Display", "Times New Roman", Times, serif;
 // $sans-serif                 : "Trebuchet MS", Helvetica, sans-serif;
-$sans-serif                 : Georgia, "Times New Roman", Times, serif;
+$sans-serif                 : "Inter var", "Inter", "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
 // $sans-serif                 : Georgia, serif, sans-serif;
 
 // $sans-serif                 : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
@@ -33,8 +33,8 @@ $calisto                    : "Calisto MT", serif;
 $garamond                   : Garamond, serif;
 
 $global-font-family         : $sans-serif;
-$header-font-family         : $sans-serif;
-$caption-font-family        : $serif;
+$header-font-family         : $serif;
+$caption-font-family        : $sans-serif;
 
 /* type scale */
 $type-size-1                : 2.441em;  // ~39.056px
@@ -51,24 +51,24 @@ $type-size-8                : 0.625em;  // ~10px
    Colors
    ========================================================================== */
 
-$gray                       : #7a8288;
-$dark-gray                  : mix(#000, $gray, 40%);
-$darker-gray                : mix(#000, $gray, 60%);
-$light-gray                 : mix(#fff, $gray, 50%);
+$gray                       : #4f5b66;
+$dark-gray                  : mix(#000, $gray, 38%);
+$darker-gray                : mix(#000, $gray, 58%);
+$light-gray                 : mix(#fff, $gray, 55%);
 $lighter-gray               : mix(#fff, $gray, 90%);
 
-$body-color                 : #fff;
-$background-color           : #fff;
-$code-background-color      : #fafafa;
-$code-background-color-dark : $light-gray;
-$text-color                 : $dark-gray;
-$border-color               : $lighter-gray;
+$body-color                 : #f6f8fc;
+$background-color           : #ffffff;
+$code-background-color      : #eef2fb;
+$code-background-color-dark : lighten($gray, 32%);
+$text-color                 : #1f2937;
+$border-color               : mix(#fff, $gray, 82%);
 
-$primary-color              : #7a8288;
+$primary-color              : #274690;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
-$info-color                 : #224b8d;
+$info-color                 : #3d5af1;
 // $info-color                 : #52adc8;
 
 /* brands */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -46,9 +46,15 @@
     align-items: flex-start;
     flex-direction: row;
     flex-wrap: wrap;
-    border-bottom: 1px #efefef solid;
-    padding: 2em 0 2em 0;
-    
+    gap: 1.5rem;
+    border: 1px solid rgba(39, 70, 144, 0.08);
+    padding: 2.25em 2em;
+    margin-bottom: 2.25em;
+    border-radius: 1.4rem;
+    background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(238, 242, 255, 0.92));
+    box-shadow: 0 26px 48px -32px rgba(39, 70, 144, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+
 
     .paper-box-image{
         justify-content: center;
@@ -57,16 +63,18 @@
         order: 2;
         img {
             max-width: 400px;
-            box-shadow: 3px 3px 6px #888;
+            box-shadow: 0 20px 30px -28px rgba(39, 70, 144, 0.6);
+            border-radius: 1rem;
             object-fit: cover;
         }
     }
-    
+
     .paper-box-text{
         max-width: 100%;
         order: 1;
+        transition: color 0.2s ease;
     }
-    
+
     @include breakpoint($medium) {
         .paper-box-image{
             justify-content: left;
@@ -74,10 +82,10 @@
             max-width: 40%;
             order: 1;
         }
-        
+
         .paper-box-text{
             justify-content: left;
-            padding-left: 2em;
+            padding-left: 2.25em;
             max-width: 60%;
             order: 2;
         }
@@ -85,6 +93,10 @@
     }
 
 
+    &:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 30px 54px -30px rgba(39, 70, 144, 0.45);
+    }
 }
 
 $scroll_offset : 2em;
@@ -121,17 +133,17 @@ h1:before, .anchor:before {
   align-items: baseline;
 }
 
-.cv-main { font-size: 15.5px; line-height: 1.5; color: #222; }
+.cv-main { font-size: 16px; line-height: 1.65; color: #1f2937; }
 .cv-role, .cv-degree { font-weight: 600; }
-.cv-date { font-size: 13px; color: #666; white-space: nowrap; }
+.cv-date { font-size: 13.5px; color: #64748b; white-space: nowrap; }
 
 .cv-sub {
   margin-top: 2px;
-  font-size: 13.5px; line-height: 1.45; color: #6a6a6a;
+  font-size: 14px; line-height: 1.5; color: #6b7280;
 }
 
 /* 更紧凑的标题与段距 */
-h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
+h1,h2,h3 { margin-top: 0.6em; margin-bottom: 0.75em; }
 #experiences + h1, #educations + h1 { margin-top: 0; }
 
 /* 移动端收紧布局：日期换行到下一行 */
@@ -140,11 +152,12 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   .cv-date { order: 2; }
 }
 :root {
-  --publication-control-height: 2.5rem;
-  --publication-highlight: #fff3b0;
-  --publication-accent: #224b8d;
-  --publication-accent-hover: #1a3a6d;
-  --publication-accent-soft: rgba(34, 75, 141, 0.18);
+  --publication-control-height: 2.6rem;
+  --publication-highlight: #eef2ff;
+  --publication-accent: #3d5af1;
+  --publication-accent-hover: #2a4bd6;
+  --publication-accent-soft: rgba(61, 90, 241, 0.2);
+  --surface-elevated: rgba(255, 255, 255, 0.85);
 }
 
 .publication-controls {
@@ -152,23 +165,30 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   flex-wrap: wrap;
   gap: 0.85rem;
   align-items: stretch;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(39, 70, 144, 0.08);
+  background: var(--surface-elevated);
+  box-shadow: 0 24px 48px -32px rgba(39, 70, 144, 0.35);
+  backdrop-filter: blur(12px);
 }
 
 .publication-controls select,
 .publication-controls button,
 .publication-search {
-  padding: 0 0.85rem;
-  border-radius: 0.45rem;
-  border: 1px solid #c1c7d0;
-  background-color: #fff;
-  font-size: 0.95rem;
+  padding: 0 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(61, 90, 241, 0.18);
+  background-color: rgba(255, 255, 255, 0.92);
+  font-size: 1rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, color 0.2s ease;
   height: var(--publication-control-height);
   min-height: var(--publication-control-height);
   box-sizing: border-box;
   outline: none;
+  color: #1f2937;
 }
 
 .publication-search {
@@ -188,12 +208,13 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 .publication-controls button {
   cursor: pointer;
-  background-color: #e0e0e0;
-  color: #494e52;
-  border-color: #e0e0e0;
+  background-image: linear-gradient(135deg, rgba(61, 90, 241, 0.85), rgba(39, 70, 144, 0.95));
+  color: #fff;
+  border-color: transparent;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-shadow: 0 16px 30px -24px rgba(39, 70, 144, 0.8);
 }
 
 .publication-search::-webkit-search-decoration,
@@ -202,13 +223,12 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls button:hover {
-  background-color: #d5d5d5;
-  border-color: #d5d5d5;
+  background-image: linear-gradient(135deg, rgba(61, 90, 241, 0.95), rgba(39, 70, 144, 1));
+  box-shadow: 0 20px 36px -24px rgba(39, 70, 144, 0.85);
 }
 
 .publication-controls button:active {
-  background-color: #cbcbcb;
-  border-color: #cbcbcb;
+  background-image: linear-gradient(135deg, rgba(61, 90, 241, 0.8), rgba(39, 70, 144, 0.9));
 }
 
 .publication-controls select:hover,
@@ -242,7 +262,7 @@ ol.publication-list > li:last-child {
 
 .publication-index {
   /*font-weight: 600;*/
-  color: #57606a;
+  color: #475569;
   min-width: 3rem;
   text-align: right;
   font-variant-numeric: tabular-nums;
@@ -527,7 +547,25 @@ mark.publication-highlight {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --publication-highlight: rgba(148, 163, 184, 0.35);
+    --publication-highlight: rgba(61, 90, 241, 0.25);
+    --surface-elevated: rgba(15, 23, 42, 0.78);
+  }
+
+  .publication-controls select,
+  .publication-controls button,
+  .publication-search {
+    background-color: rgba(15, 23, 42, 0.72);
+    border-color: rgba(61, 90, 241, 0.35);
+    color: #e2e8f0;
+  }
+
+  .publication-controls button {
+    background-image: linear-gradient(135deg, rgba(99, 125, 255, 0.85), rgba(39, 70, 144, 0.95));
+    box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.85);
+  }
+
+  .publication-controls button:hover {
+    background-image: linear-gradient(135deg, rgba(124, 149, 255, 0.9), rgba(39, 70, 144, 1));
   }
 }
 
@@ -545,10 +583,10 @@ mark.publication-highlight {
 }
 
 .contact-card {
-  background: #f8f9fb;
-  border-left: 4px solid var(--publication-accent, #224b8d);
-  border-radius: 0.75rem;
-  box-shadow: 0 18px 40px -24px rgba(34, 75, 141, 0.65);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(238, 242, 255, 0.9));
+  border-left: 4px solid var(--publication-accent, #3d5af1);
+  border-radius: 0.9rem;
+  box-shadow: 0 22px 46px -28px rgba(39, 70, 144, 0.55);
   padding: 1.35rem 1.5rem;
   line-height: 1.6;
 }
@@ -558,20 +596,20 @@ mark.publication-highlight {
 }
 
 .contact-card a {
-  color: var(--publication-accent, #224b8d);
+  color: var(--publication-accent, #3d5af1);
   font-weight: 600;
 }
 
 .contact-card a:hover,
 .contact-card a:focus {
-  color: var(--publication-accent-hover, #1a3a6d);
+  color: var(--publication-accent-hover, #2a4bd6);
 }
 
 .contact-map-container {
   min-height: 260px;
   border-radius: 0.75rem;
   overflow: hidden;
-  box-shadow: 0 20px 45px -28px rgba(34, 75, 141, 0.6);
+  box-shadow: 0 20px 45px -28px rgba(39, 70, 144, 0.6);
   background: #e8eef9;
 }
 


### PR DESCRIPTION
## Summary
- load Inter and Playfair Display from Google Fonts and refresh typography tokens for a lighter, higher-contrast palette
- relax body spacing, limit content width, and modernize buttons, cards, and quote styling for a more refined presentation
- refresh publication filters and contact modules with elevated surfaces, gradients, and dark-mode aware accents

## Testing
- bundle exec jekyll build *(fails: jekyll not installed in environment)*
- bundle install *(fails: rubygems.org returned 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d39831d800832da801192beb802ec9