### PR TITLE
Restyle site with Apple-inspired minimal aesthetic

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -13,7 +13,19 @@ body {
   padding-bottom: 0em;
   color: $text-color;
   font-family: $global-font-family;
-  line-height: 1.5;
+  line-height: 1.68;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  background-color: $body-color;
+  background-image: linear-gradient(180deg, #fbfbfd 0%, $body-color 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "kern", "liga", "clig", "calt";
+
+  @supports (-webkit-backdrop-filter: blur(0)) {
+    background-image: linear-gradient(180deg, rgba(251, 251, 253, 0.92) 0%, rgba(245, 245, 247, 0.98) 72%, $body-color 100%);
+  }
 
   &.overflow--hidden {
     /* when primary navigation is visible, the content in the background won't scroll */
@@ -22,36 +34,41 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin: 1em 0 0.5em;
-  line-height: 1.2;
+  margin: 1.1em 0 0.55em;
+  line-height: 1.12;
   font-family: $header-font-family;
-  font-weight: bold;
+  font-weight: 600;
+  letter-spacing: -0.015em;
 }
 
 h1 {
-  // margin: 4em 0 0.5em;
-  margin-top: 1em;
-  font-size: $type-size-3;
+  margin-top: 0.6em;
+  font-size: clamp(2.5rem, 4vw, 3.35rem);
+  letter-spacing: -0.02em;
 }
 
 h2 {
-  font-size: $type-size-4;
+  font-size: clamp(1.95rem, 3.2vw, 2.6rem);
+  letter-spacing: -0.015em;
 }
 
 h3 {
-  font-size: $type-size-5;
+  font-size: clamp(1.55rem, 2.6vw, 1.95rem);
+  letter-spacing: -0.01em;
 }
 
 h4 {
-  font-size: $type-size-6;
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
 }
 
 h5 {
-  font-size: $type-size-6;
+  font-size: clamp(1.1rem, 1.8vw, 1.35rem);
 }
 
 h6 {
-  font-size: $type-size-6;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 small, .small {
@@ -59,7 +76,14 @@ small, .small {
 }
 
 p {
-  margin-bottom: 0.5em;
+  margin-bottom: 1.25em;
+}
+
+.page__content {
+  max-width: 72ch;
+  margin-left: auto;
+  margin-right: auto;
+  padding: clamp(2rem, 6vw, 4rem) 0;
 }
 
 u,
@@ -73,7 +97,7 @@ ins {
 
 ul {
   padding-inline-start: 2em;
-  margin-block-start: 0.5em;
+  margin-block-start: 0.8em;
 }
 
 del a {
@@ -99,14 +123,20 @@ abbr[data-original-title] {
 /* blockquotes */
 
 blockquote {
-  margin: 2em 1em 2em 0;
-  padding-left: 1em;
-  padding-right: 1em;
-  font-style: italic;
-  border-left: 0.25em solid $primary-color;
+  margin: 2.5em auto;
+  padding: 1.2em 1.5em;
+  font-style: normal;
+  border-left: 4px solid rgba($primary-color, 0.2);
+  background: rgba(#fff, 0.6);
+  border-radius: 1.1em;
+  box-shadow: 0 30px 60px -48px rgba(15, 23, 42, 0.18);
 
   cite {
-    font-style: italic;
+    display: block;
+    margin-top: 0.8em;
+    font-style: normal;
+    font-weight: 500;
+    color: rgba($text-color, 0.7);
 
     &:before {
       content: "\2014";
@@ -135,13 +165,15 @@ a {
 .page__content a {
   display: inline;
   border-radius: 0.25em;
-  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 
   &:hover,
   &:focus {
     color: $link-color-hover;
-    background-color: rgba($link-color, 0.12);
-    box-shadow: 0 0 0 1px rgba($link-color, 0.15);
+    background-color: rgba($link-color, 0.08);
+    box-shadow: 0 14px 36px -28px rgba($link-color, 0.45);
+    border-bottom-color: rgba($link-color, 0.35);
     text-decoration: none;
     outline: none;
   }
@@ -180,21 +212,33 @@ td > code {
 
 hr {
   display: block;
-  margin: 1em 0;
+  margin: 2.5em 0;
   border: 0;
-  border-top: 1px solid $border-color;
+  height: 1px;
+  background: linear-gradient(90deg, rgba($border-color, 0) 0%, rgba($border-color, 0.8) 40%, rgba($border-color, 0.8) 60%, rgba($border-color, 0) 100%);
 }
 
 /* lists */
 
 ul li,
 ol li {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.6em;
 }
 
 li ul,
 li ol {
-  margin-top: 0.5em;
+  margin-top: 0.6em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /*

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -9,21 +9,38 @@
 .btn {
   /* default button */
   display: inline-block;
-  margin-bottom: 0.25em;
-  padding: 0.5em 1em;
+  margin-bottom: 0.35em;
+  padding: 0.75em 1.9em;
   color: #fff !important;
   font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: bold;
+  font-size: $type-size-5;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   text-align: center;
   text-decoration: none;
-  background-color: $primary-color;
+  background-image: linear-gradient(180deg, lighten($primary-color, 12%), $primary-color);
+  background-size: 100% 100%;
   border: 0 !important;
-  border-radius: $border-radius;
+  border-radius: 999px;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-image 0.25s ease;
+  box-shadow: 0 18px 36px -22px rgba($primary-color, 0.55);
 
   &:hover {
-    background-color: mix(white, #000, 20%);
+    transform: translateY(-2px);
+    box-shadow: 0 26px 42px -24px rgba($primary-color, 0.65);
+    background-image: linear-gradient(180deg, lighten($primary-color, 18%), darken($primary-color, 4%));
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 14px 26px -18px rgba($primary-color, 0.6);
+    background-image: linear-gradient(180deg, lighten($primary-color, 8%), darken($primary-color, 6%));
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba($primary-color, 0.45);
+    outline-offset: 3px;
   }
 
   .icon {
@@ -48,13 +65,16 @@
   /* for dark backgrounds */
 
   &--inverse {
-    color: $gray !important;
-    border: 1px solid $light-gray !important; /* override*/
-    background-color: #fff;
+    color: $masthead-link-color !important;
+    border: 1px solid rgba($text-color, 0.08) !important; /* override*/
+    background-color: rgba(#fff, 0.88);
+    box-shadow: 0 14px 32px -24px rgba($text-color, 0.18);
 
     &:hover {
-      color: #fff !important;
-      border-color: $gray;
+      color: $link-color-hover !important;
+      border-color: rgba($text-color, 0.1);
+      background-color: #fff;
+      box-shadow: 0 22px 40px -26px rgba($text-color, 0.22);
     }
   }
 

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -5,19 +5,32 @@
 .masthead {
   position: sticky;
   top: 0;
-  background-color: white;
-  border-bottom: 1px solid $border-color;
+  background-color: rgba(245, 245, 247, 0.9);
+  border-bottom: 1px solid rgba($text-color, 0.08);
+  backdrop-filter: saturate(180%) blur(18px);
+  -webkit-backdrop-filter: saturate(180%) blur(18px);
+  box-shadow: 0 1px 0 rgba(#fff, 0.4) inset;
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
   -webkit-animation: intro 0.3s both;
           animation: intro 0.3s both;
   -webkit-animation-delay: 0.15s;
           animation-delay: 0.15s;
   z-index: 20;
 
+  @supports not ((-webkit-backdrop-filter: blur(0))) {
+    background-color: rgba(245, 245, 247, 0.97);
+  }
+
   &__inner-wrap {
     @include container;
     @include clearfix;
-    padding: .5em;
+    padding: 0.35em 1.25em;
     font-family: $sans-serif-narrow;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
 
     @include breakpoint($x-large) {
       max-width: $x-large;
@@ -29,6 +42,17 @@
 
     a {
       text-decoration: none;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      padding: 0.4rem 0.65rem;
+      border-radius: 999px;
+      transition: color 0.2s ease, background-color 0.2s ease;
+
+      &:hover,
+      &:focus {
+        background-color: rgba($text-color, 0.06);
+        color: $masthead-link-color-hover;
+      }
     }
   }
 }

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -175,17 +175,22 @@
 .greedy-nav {
   position: relative;
   min-width: 250px;
-  background: $background-color;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 
   a {
     display: block;
-    margin: 0 1rem;
-    padding: 0.5rem 0;
+    margin: 0 0.75rem;
+    padding: 0.4rem 0.1rem;
     color: $masthead-link-color;
     text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease;
 
     &:hover {
       color: $masthead-link-color-hover;
+      background-color: rgba($masthead-link-color-hover, 0.08);
     }
   }
 
@@ -193,12 +198,23 @@
     position: absolute;
     height: 100%;
     right: 0;
-    padding: 0 0.5rem;
-    border: 0;
+    padding: 0 0.65rem;
+    border: 1px solid rgba($masthead-link-color, 0.08);
     outline: none;
-    background-color: $primary-color;
-    color: #fff;
+    background-color: rgba(255, 255, 255, 0.65);
+    color: $masthead-link-color;
+    border-radius: 999px;
     cursor: pointer;
+    backdrop-filter: saturate(180%) blur(18px);
+    -webkit-backdrop-filter: saturate(180%) blur(18px);
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+
+    &:hover,
+    &:focus {
+      color: $primary-color;
+      border-color: rgba($primary-color, 0.35);
+      background-color: rgba(255, 255, 255, 0.85);
+    }
   }
 
   .visible-links {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -6,18 +6,18 @@
    Typography
    ========================================================================== */
 
-$doc-font-size              : 16;
+$doc-font-size              : 18;
 
 /* paragraph indention */
 $paragraph-indent           : false; // true, false (default)
 $indent-var                 : 0.5em;
 
 /* system typefaces */
-$serif                      : Georgia, Times, serif;
-// $sans-serif                 : "Trebuchet MS", Helvetica, sans-serif;
-$sans-serif                 : Georgia, "Times New Roman", Times, serif;
-// $sans-serif                 : Georgia, serif, sans-serif;
+$serif                      : "SF Pro Display", "SF Pro Text", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", "Helvetica", sans-serif;
+$sans-serif                 : "SF Pro Text", "SF Pro Display", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", "Helvetica", Arial, sans-serif;
 
+// $sans-serif                 : "Trebuchet MS", Helvetica, sans-serif;
+// $sans-serif                 : Georgia, serif, sans-serif;
 // $sans-serif                 : -apple-system, ".SFNSText-Regular", "San Francisco", "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
 $monospace                  : Monaco, Consolas, "Lucida Console", monospace;
 
@@ -33,42 +33,42 @@ $calisto                    : "Calisto MT", serif;
 $garamond                   : Garamond, serif;
 
 $global-font-family         : $sans-serif;
-$header-font-family         : $sans-serif;
-$caption-font-family        : $serif;
+$header-font-family         : "SF Pro Display", "SF Pro Text", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", "Helvetica", sans-serif;
+$caption-font-family        : $sans-serif;
 
 /* type scale */
-$type-size-1                : 2.441em;  // ~39.056px
-$type-size-2                : 1.953em;  // ~31.248px
-$type-size-3                : 1.4em;  // ~25.008px
-$type-size-4                : 1.2em;   // ~20px
-$type-size-5                : 1em;      // ~16px
-$type-size-6                : 1em;   // ~12px
-$type-size-7                : 0.6875em; // ~11px
-$type-size-8                : 0.625em;  // ~10px
+$type-size-1                : 3.052em;  // ~55px
+$type-size-2                : 2.441em;  // ~44px
+$type-size-3                : 1.953em;  // ~35px
+$type-size-4                : 1.563em;  // ~28px
+$type-size-5                : 1.125em;  // ~20px
+$type-size-6                : 1em;      // ~18px
+$type-size-7                : 0.875em;  // ~16px
+$type-size-8                : 0.75em;   // ~14px
 
 
 /*
    Colors
    ========================================================================== */
 
-$gray                       : #7a8288;
-$dark-gray                  : mix(#000, $gray, 40%);
-$darker-gray                : mix(#000, $gray, 60%);
-$light-gray                 : mix(#fff, $gray, 50%);
+$gray                       : #6e6e73;
+$dark-gray                  : mix(#000, $gray, 38%);
+$darker-gray                : mix(#000, $gray, 58%);
+$light-gray                 : mix(#fff, $gray, 55%);
 $lighter-gray               : mix(#fff, $gray, 90%);
 
-$body-color                 : #fff;
-$background-color           : #fff;
-$code-background-color      : #fafafa;
-$code-background-color-dark : $light-gray;
-$text-color                 : $dark-gray;
-$border-color               : $lighter-gray;
+$body-color                 : #f5f5f7;
+$background-color           : #ffffff;
+$code-background-color      : #eef1f9;
+$code-background-color-dark : lighten($gray, 32%);
+$text-color                 : #1d1d1f;
+$border-color               : rgba(#1d1d1f, 0.12);
 
-$primary-color              : #7a8288;
+$primary-color              : #0071e3;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
-$info-color                 : #224b8d;
+$info-color                 : #0071e3;
 // $info-color                 : #52adc8;
 
 /* brands */
@@ -96,10 +96,10 @@ $xing-color                 : #006567;
 
 /* links */
 $link-color                 : $info-color;
-$link-color-hover           : mix(#000, $link-color, 25%);
-$link-color-visited         : mix(#fff, $link-color, 25%);
-$masthead-link-color        : $primary-color;
-$masthead-link-color-hover  : mix(#000, $primary-color, 25%);
+$link-color-hover           : darken($link-color, 8%);
+$link-color-visited         : mix(#fff, $link-color, 20%);
+$masthead-link-color        : #1d1d1f;
+$masthead-link-color-hover  : darken(#1d1d1f, 12%);
 
 
 /*

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -42,42 +42,53 @@
 
 .paper-box {
     display: flex;
-    justify-content: left;
-    align-items: flex-start;
     flex-direction: row;
     flex-wrap: wrap;
-    border-bottom: 1px #efefef solid;
-    padding: 2em 0 2em 0;
-    
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(1.5rem, 4vw, 2.75rem);
+    border: 1px solid var(--border-soft);
+    padding: clamp(2rem, 5vw, 3rem);
+    margin-bottom: 2.5em;
+    border-radius: 1.75rem;
+    background: var(--surface-elevated);
+    backdrop-filter: saturate(180%) blur(24px);
+    -webkit-backdrop-filter: saturate(180%) blur(24px);
+    box-shadow: 0 40px 90px -60px rgba(15, 23, 42, 0.25);
+    transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+
 
     .paper-box-image{
-        justify-content: center;
         display: flex;
+        justify-content: center;
         width: 100%;
         order: 2;
+
         img {
-            max-width: 400px;
-            box-shadow: 3px 3px 6px #888;
+            max-width: 420px;
+            width: 100%;
+            box-shadow: 0 30px 60px -38px rgba(15, 23, 42, 0.35);
+            border-radius: 1.25rem;
             object-fit: cover;
         }
     }
-    
+
     .paper-box-text{
         max-width: 100%;
         order: 1;
+        transition: color 0.3s ease;
     }
-    
+
     @include breakpoint($medium) {
         .paper-box-image{
-            justify-content: left;
-            min-width: 200px;
-            max-width: 40%;
+            justify-content: flex-start;
+            min-width: 240px;
+            max-width: 38%;
             order: 1;
         }
-        
+
         .paper-box-text{
-            justify-content: left;
-            padding-left: 2em;
+            padding-left: clamp(1.75rem, 3vw, 2.75rem);
             max-width: 60%;
             order: 2;
         }
@@ -85,6 +96,11 @@
     }
 
 
+    &:hover {
+        transform: translateY(-8px);
+        border-color: rgba(0, 113, 227, 0.18);
+        box-shadow: 0 48px 100px -64px rgba(15, 23, 42, 0.32);
+    }
 }
 
 $scroll_offset : 2em;
@@ -121,17 +137,17 @@ h1:before, .anchor:before {
   align-items: baseline;
 }
 
-.cv-main { font-size: 15.5px; line-height: 1.5; color: #222; }
+.cv-main { font-size: 16px; line-height: 1.65; color: #1f2937; }
 .cv-role, .cv-degree { font-weight: 600; }
-.cv-date { font-size: 13px; color: #666; white-space: nowrap; }
+.cv-date { font-size: 13.5px; color: #64748b; white-space: nowrap; }
 
 .cv-sub {
   margin-top: 2px;
-  font-size: 13.5px; line-height: 1.45; color: #6a6a6a;
+  font-size: 14px; line-height: 1.5; color: #6b7280;
 }
 
 /* 更紧凑的标题与段距 */
-h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
+h1,h2,h3 { margin-top: 0.6em; margin-bottom: 0.75em; }
 #experiences + h1, #educations + h1 { margin-top: 0; }
 
 /* 移动端收紧布局：日期换行到下一行 */
@@ -140,35 +156,49 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   .cv-date { order: 2; }
 }
 :root {
-  --publication-control-height: 2.5rem;
-  --publication-highlight: #fff3b0;
-  --publication-accent: #224b8d;
-  --publication-accent-hover: #1a3a6d;
-  --publication-accent-soft: rgba(34, 75, 141, 0.18);
+  --canvas: #f5f5f7;
+  --ink: #1d1d1f;
+  --border-soft: rgba(17, 17, 31, 0.08);
+  --surface-elevated: rgba(255, 255, 255, 0.82);
+  --surface-glass: rgba(255, 255, 255, 0.68);
+  --publication-control-height: 2.75rem;
+  --publication-highlight: rgba(0, 113, 227, 0.12);
+  --publication-accent: #0071e3;
+  --publication-accent-hover: #0360c6;
+  --publication-accent-soft: rgba(0, 113, 227, 0.18);
 }
 
 .publication-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
+  gap: 1rem;
   align-items: stretch;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  padding: 1.1rem 1.4rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-glass);
+  box-shadow: 0 36px 80px -60px rgba(15, 23, 42, 0.28);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
 }
 
 .publication-controls select,
 .publication-controls button,
 .publication-search {
-  padding: 0 0.85rem;
-  border-radius: 0.45rem;
-  border: 1px solid #c1c7d0;
-  background-color: #fff;
-  font-size: 0.95rem;
+  padding: 0 1.1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 113, 227, 0.16);
+  background-color: rgba(255, 255, 255, 0.92);
+  font-size: 1rem;
+  letter-spacing: -0.01em;
   transition: border-color 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, color 0.2s ease;
   height: var(--publication-control-height);
   min-height: var(--publication-control-height);
   box-sizing: border-box;
   outline: none;
+  color: var(--ink);
 }
 
 .publication-search {
@@ -188,12 +218,15 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 .publication-controls button {
   cursor: pointer;
-  background-color: #e0e0e0;
-  color: #494e52;
-  border-color: #e0e0e0;
+  background-image: linear-gradient(180deg, rgba(41, 151, 255, 0.95), var(--publication-accent));
+  color: #fff;
+  border-color: transparent;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: 0 24px 46px -28px rgba(0, 113, 227, 0.5);
 }
 
 .publication-search::-webkit-search-decoration,
@@ -202,13 +235,12 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls button:hover {
-  background-color: #d5d5d5;
-  border-color: #d5d5d5;
+  background-image: linear-gradient(180deg, rgba(66, 168, 255, 0.98), var(--publication-accent));
+  box-shadow: 0 32px 56px -30px rgba(0, 113, 227, 0.55);
 }
 
 .publication-controls button:active {
-  background-color: #cbcbcb;
-  border-color: #cbcbcb;
+  background-image: linear-gradient(180deg, rgba(41, 151, 255, 0.92), rgba(0, 113, 227, 0.92));
 }
 
 .publication-controls select:hover,
@@ -231,18 +263,30 @@ ol.publication-list > li {
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: 1rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 1.15rem 1.4rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 28px 60px -52px rgba(15, 23, 42, 0.22);
   line-height: 1.65;
   align-items: flex-start;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 ol.publication-list > li:last-child {
   margin-bottom: 0;
 }
 
+ol.publication-list > li:hover {
+  transform: translateY(-4px);
+  border-color: rgba(0, 113, 227, 0.16);
+  box-shadow: 0 36px 70px -56px rgba(15, 23, 42, 0.28);
+}
+
 .publication-index {
   /*font-weight: 600;*/
-  color: #57606a;
+  color: rgba(17, 17, 31, 0.45);
   min-width: 3rem;
   text-align: right;
   font-variant-numeric: tabular-nums;
@@ -296,7 +340,7 @@ ol.publication-list > li:last-child {
   border: none;
   background: transparent;
   /*font-weight: 600;*/
-  color: #57606a;
+  color: rgba(17, 17, 31, 0.55);
   font-variant-numeric: tabular-nums;
   line-height: 1.2;
 }
@@ -527,7 +571,55 @@ mark.publication-highlight {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --publication-highlight: rgba(148, 163, 184, 0.35);
+    --canvas: #0d1017;
+    --ink: #f5f5f7;
+    --border-soft: rgba(255, 255, 255, 0.08);
+    --surface-elevated: rgba(22, 28, 38, 0.82);
+    --surface-glass: rgba(22, 28, 38, 0.72);
+    --publication-highlight: rgba(0, 113, 227, 0.32);
+  }
+
+  .paper-box {
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(24, 31, 45, 0.86);
+    box-shadow: 0 40px 90px -60px rgba(0, 0, 0, 0.55);
+  }
+
+  .paper-box:hover {
+    border-color: rgba(0, 122, 255, 0.32);
+    box-shadow: 0 52px 110px -64px rgba(0, 0, 0, 0.6);
+  }
+
+  .paper-box .paper-box-image img {
+    box-shadow: 0 36px 70px -40px rgba(0, 0, 0, 0.6);
+  }
+
+  .publication-controls select,
+  .publication-controls button,
+  .publication-search {
+    background-color: rgba(18, 24, 36, 0.78);
+    border-color: rgba(0, 113, 227, 0.35);
+    color: #e5ecfb;
+  }
+
+  .publication-controls button {
+    background-image: linear-gradient(180deg, rgba(66, 168, 255, 0.95), rgba(0, 113, 227, 0.92));
+    box-shadow: 0 32px 56px -34px rgba(0, 0, 0, 0.55);
+  }
+
+  .publication-controls button:hover {
+    background-image: linear-gradient(180deg, rgba(82, 180, 255, 1), rgba(0, 113, 227, 0.95));
+  }
+
+  ol.publication-list > li {
+    background: rgba(20, 26, 38, 0.82);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 28px 60px -50px rgba(0, 0, 0, 0.55);
+  }
+
+  ol.publication-list > li:hover {
+    border-color: rgba(0, 122, 255, 0.3);
+    box-shadow: 0 36px 72px -52px rgba(0, 0, 0, 0.62);
   }
 }
 
@@ -545,12 +637,15 @@ mark.publication-highlight {
 }
 
 .contact-card {
-  background: #f8f9fb;
-  border-left: 4px solid var(--publication-accent, #224b8d);
-  border-radius: 0.75rem;
-  box-shadow: 0 18px 40px -24px rgba(34, 75, 141, 0.65);
-  padding: 1.35rem 1.5rem;
-  line-height: 1.6;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-soft);
+  border-left: 4px solid var(--publication-accent, #0071e3);
+  border-radius: 1.1rem;
+  box-shadow: 0 34px 70px -50px rgba(15, 23, 42, 0.3);
+  padding: 1.5rem 1.65rem;
+  line-height: 1.65;
+  backdrop-filter: saturate(180%) blur(18px);
+  -webkit-backdrop-filter: saturate(180%) blur(18px);
 }
 
 .contact-card p {
@@ -558,21 +653,22 @@ mark.publication-highlight {
 }
 
 .contact-card a {
-  color: var(--publication-accent, #224b8d);
+  color: var(--publication-accent, #0071e3);
   font-weight: 600;
 }
 
 .contact-card a:hover,
 .contact-card a:focus {
-  color: var(--publication-accent-hover, #1a3a6d);
+  color: var(--publication-accent-hover, #2a4bd6);
 }
 
 .contact-map-container {
   min-height: 260px;
-  border-radius: 0.75rem;
+  border-radius: 1.1rem;
   overflow: hidden;
-  box-shadow: 0 20px 45px -28px rgba(34, 75, 141, 0.6);
-  background: #e8eef9;
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 30px 72px -54px rgba(15, 23, 42, 0.28);
+  background: rgba(0, 0, 0, 0.03);
 }
 
 #contact-map {
@@ -604,17 +700,19 @@ mark.publication-highlight {
 
 @media (prefers-color-scheme: dark) {
   .contact-card {
-    background: rgba(15, 23, 42, 0.6);
-    box-shadow: 0 16px 35px -25px rgba(15, 23, 42, 0.8);
+    background: rgba(24, 31, 45, 0.82);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 34px 70px -52px rgba(0, 0, 0, 0.6);
   }
 
   .contact-map-container {
-    background: rgba(30, 41, 59, 0.7);
-    box-shadow: 0 16px 35px -25px rgba(15, 23, 42, 0.9);
+    background: rgba(18, 24, 36, 0.82);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 34px 70px -52px rgba(0, 0, 0, 0.65);
   }
 
   .map-noscript {
-    color: #e2e8f0;
+    color: rgba(229, 236, 251, 0.8);
   }
 
   .map-api-warning {


### PR DESCRIPTION
## Summary
- replace Google Fonts usage with a system-focused SF Pro stack and refreshed typography/color tokens for an Apple-like baseline
- refresh core base styles, masthead, navigation, and buttons with translucent surfaces, refined spacing, and glassmorphism cues
- restyle publication listings and contact modules with elevated cards, responsive spacing, and dark-mode aware treatments

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in container)*
- bundle install *(fails: rubygems.org requests returned 403 responses in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d39831d800832da801192beb802ec9