### PR TITLE
Update home page call-to-action labels

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -101,7 +101,7 @@ redirect_from:
 Explore the full list of publications on the [Publications](/publications/) page.
  -->
 <p class="news-actions">
-  <a class="btn" href="{{ '/publications/' | relative_url }}">Explore Full List</a>
+  <a class="btn" href="{{ '/publications/' | relative_url }}">浏览全部论文 →</a>
 </p>
 {% include citation-modal.html %}
 
@@ -115,7 +115,7 @@ Explore the full list of publications on the [Publications](/publications/) page
 
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/awards/' | relative_url }}">View All</a>
+  <a class="btn" href="{{ '/awards/' | relative_url }}">查看全部奖项 →</a>
 </p>
 
 <!-- <span class='anchor' id='-professional-services'></span> -->
@@ -131,7 +131,7 @@ Explore the full list of publications on the [Publications](/publications/) page
 - **Reviewer** for international journals and conferences
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/services/' | relative_url }}">View All</a>
+  <a class="btn" href="{{ '/services/' | relative_url }}">查看全部服务 →</a>
 </p>
 
 # 😀 Miscellaneous

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -25,6 +25,6 @@
 
 {% if include.show_button and limit < news_count %}
 <p class="news-actions">
-  <a class="btn" href="{{ '/news/' | relative_url }}">Read More</a>
+  <a class="btn" href="{{ '/news/' | relative_url }}">更多新闻 →</a>
 </p>
 {% endif %}

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -51,3 +51,24 @@
     display: table;
   }
 }
+
+@mixin cta-button {
+  margin-bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.85rem;
+  height: var(--publication-control-height);
+  min-height: var(--publication-control-height);
+  border-radius: 0.45rem;
+  border: 1px solid $cta-button-border !important;
+  background-color: $cta-button-background;
+  color: $cta-button-text !important;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease, color 0.2s ease;
+  text-decoration: none;
+  box-shadow: none;
+}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -131,35 +131,18 @@
     margin-top: 0.75rem;
 
     .btn {
-      margin-bottom: 0;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0 0.85rem;
-      height: var(--publication-control-height);
-      min-height: var(--publication-control-height);
-      border-radius: 0.45rem;
-      border: 1px solid #c1c7d0 !important;
-      background-color: #e0e0e0;
-      color: #494e52 !important;
-      font-size: 0.95rem;
-      font-weight: 600;
-      line-height: 1.2;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease,
-        background-color 0.2s ease, color 0.2s ease;
-      text-decoration: none;
-      box-shadow: none;
+      @include cta-button;
     }
 
     .btn:hover {
-      background-color: #d5d5d5;
-      border-color: #d5d5d5 !important;
+      background-color: $cta-button-background-hover;
+      border-color: $cta-button-background-hover !important;
       text-decoration: none;
     }
 
     .btn:active {
-      background-color: #cbcbcb;
-      border-color: #cbcbcb !important;
+      background-color: $cta-button-background-active;
+      border-color: $cta-button-background-active !important;
     }
 
     .btn:hover,

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -71,6 +71,13 @@ $danger-color               : #ee5f5b;
 $info-color                 : #224b8d;
 // $info-color                 : #52adc8;
 
+/* call-to-action buttons */
+$cta-button-background      : #e0e0e0;
+$cta-button-background-hover: #d5d5d5;
+$cta-button-background-active: #cbcbcb;
+$cta-button-border          : #c1c7d0;
+$cta-button-text            : #494e52;
+
 /* brands */
 $behance-color              : #1769FF;
 $dribbble-color             : #ea4c89;


### PR DESCRIPTION
## Summary
- localize the publications, awards, and services call-to-action buttons on the homepage
- adjust the news "Read More" button copy to match the new style
- extract the homepage call-to-action button styling into reusable variables and a mixin for future reuse

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d3d102dbdc832d951d48c273f6a980