### PR TITLE
Add bilingual and theme toggles to homepage

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,14 +5,24 @@
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
-            <a href="{{ '/' | relative_url }}#about-me" target="_self">Homepage</a>
+            <a href="{{ '/' | relative_url }}#about-me" target="_self" data-i18n-key="nav-home">Homepage</a>
           </li>
           {% for link in site.data.navigation.main %}
+            {% assign translation_key = link.title | slugify: 'ascii' %}
             <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}" target="_self">{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}" target="_self" data-i18n-key="nav-{{ translation_key }}">{{ link.title }}</a>
             </li>
           {% endfor %}
         </ul>
+        <div class="masthead__toggles">
+          <button class="masthead__toggle" id="language-toggle" type="button" aria-label="Toggle language">
+            <span class="masthead__toggle-icon" aria-hidden="true">🌐</span>
+            <span class="masthead__toggle-label" id="language-toggle-label">中文</span>
+          </button>
+          <button class="masthead__toggle" id="theme-toggle" type="button" aria-label="Toggle color mode">
+            <span class="masthead__toggle-icon" aria-hidden="true">🌓</span>
+          </button>
+        </div>
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,6 +3,7 @@
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/site-toggles.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -20,6 +20,7 @@ redirect_from:
 
 <span class='anchor' id='-publications'></span>
 # 📚 Selected Publications
+{: data-i18n-key="heading-publications" }
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -101,40 +102,43 @@ redirect_from:
 Explore the full list of publications on the [Publications](/publications/) page.
  -->
 <p class="news-actions">
-  <a class="btn" href="{{ '/publications/' | relative_url }}">Show Full List</a>
+  <a class="btn" href="{{ '/publications/' | relative_url }}" data-i18n-key="publications-show-all">Show Full List</a>
 </p>
 {% include citation-modal.html %}
 
 <span class='anchor' id='-awards'></span>
 # 🎖 Selected Awards
+{: data-i18n-key="heading-awards" }
 
-- 2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**
-- 2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**
-- 2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC
-- 2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province
+<ul class="awards-list">
+  <li data-i18n-key="award-2025">2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**</li>
+  <li data-i18n-key="award-2024">2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**</li>
+  <li data-i18n-key="award-2023-best-paper">2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC</li>
+  <li data-i18n-key="award-2022">2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province</li>
+</ul>
 
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/awards/' | relative_url }}">View All Awards</a>
+  <a class="btn" href="{{ '/awards/' | relative_url }}" data-i18n-key="awards-view-all">View All Awards</a>
 </p>
 
 <span class='anchor' id='-professional-services'></span>
 # ⚙️ Professional Services
+{: data-i18n-key="heading-services" }
 
-
-- **Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)
-
-- **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
-
-- **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
-
-- **Reviewer** for international journals and conferences
+<ul class="services-list">
+  <li data-i18n-key="service-editor">**Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)</li>
+  <li data-i18n-key="service-organizer">**Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)</li>
+  <li data-i18n-key="service-ta">**Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)</li>
+  <li data-i18n-key="service-reviewer">**Reviewer** for international journals and conferences</li>
+</ul>
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/services/' | relative_url }}">Explore All Services</a>
+  <a class="btn" href="{{ '/services/' | relative_url }}" data-i18n-key="services-view-all">Explore All Services</a>
 </p>
 
 # 😀 Miscellaneous
+{: data-i18n-key="heading-misc" }
 
 - [CloudConvert](https://cloudconvert.com/)
 - [iLoveIMG](https://www.iloveimg.com/)

--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -1,7 +1,8 @@
 # 🎓 Educations
+{: data-i18n-key="heading-educations" }
 
 <ul class="cv-list">
-  <li class="cv-item">
+  <li class="cv-item" data-i18n-key="education-phd">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
@@ -13,7 +14,7 @@
     <div class="cv-sub">Supervisors: Chair Professor <a href="https://automation.sjtu.edu.cn/wdzhang"><b>Weidong Zhang (张卫东)</b></a> and Professor <a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>Junguo Lu (卢俊国)</b></a></div>
   </li>
 
-  <li class="cv-item">
+  <li class="cv-item" data-i18n-key="education-master">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
@@ -25,7 +26,7 @@
     <div class="cv-sub">Supervisors: Professor <a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>Dan Wang (王丹)</b></a> and Professor <a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>Zhouhua Peng (彭周华)</b></a></div>
   </li>
 
-  <li class="cv-item">
+  <li class="cv-item" data-i18n-key="education-bachelor">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -1,6 +1,7 @@
 # 📖 Experiences
+{: data-i18n-key="heading-experiences" }
 <ul class="cv-list">
-  <li class="cv-item">
+  <li class="cv-item" data-i18n-key="experience-postdoc">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Postdoctoral Fellow</span> in
@@ -13,7 +14,7 @@
     <div class="cv-sub">Supervisor: Chair Professor <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>Wen-Hua Chen (陈文华)</b></a> (Fellow of IEEE, IMechE, IET, HEA)</div>
   </li>
 
-  <li class="cv-item">
+  <li class="cv-item" data-i18n-key="experience-visiting">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Visiting Scholar</span> in

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,11 +1,14 @@
 # 👨🏻‍🎓 Biography
+{: data-i18n-key="heading-biography" }
 
 I am currently a Postdoctoral Fellow in [Research Centre for Low Altitude Economy](https://www.polyu.edu.hk/rclae/), [Department of Aeronautical and Aviation Engineering](https://www.polyu.edu.hk/aae/), [The Hong Kong Polytechnic University](https://www.polyu.edu.hk/), under the supervision of Prof. [Wen-Hua Chen](https://scholar.google.com/citations?user=UfIb9GkAAAAJ).
+{: data-i18n-key="bio-paragraph-1" }
 
 I am a Youth Editorial Board Member of the [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS). I am also an organizer for Special Session 2 of the 2025 10th ACIRS. I was selected for the inaugural **Doctoral Special Program of Young Elite Scientist Sponsorship Program** by China Association for Science and Technology (CAST) in 2025. I obtained **National Scholarships** for Graduate Students (Top 1%) in 2020, 2023, and 2024. My master's thesis received the **Excellent Master Dissertation Award** of Liaoning Province!
+{: data-i18n-key="bio-paragraph-2" }
 
-My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. 
-I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a>
-in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a> in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+{: data-i18n-key="bio-paragraph-3" }
 
 Welcome to contact me for academic collaboration! Please feel free to email me at [wtwu95@gmail.com](mailto:wtwu95@gmail.com) or [wen-tao.wu@polyu.edu.hk](mailto:wen-tao.wu@polyu.edu.hk).
+{: data-i18n-key="bio-paragraph-4" }

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,4 +1,5 @@
 # 💬 News
+{: data-i18n-key="heading-news" }
 
 {% assign news_items = site.data.news | default: [] %}
 {% assign news_count = news_items | size %}
@@ -20,11 +21,11 @@
 {% endfor %}
 {: .news-list}
 {% else %}
-<p>No news items are available right now. Please check back later.</p>
+<p data-i18n-key="news-empty">No news items are available right now. Please check back later.</p>
 {% endif %}
 
 {% if include.show_button and limit < news_count %}
 <p class="news-actions">
-  <a class="btn" href="{{ '/news/' | relative_url }}">Read More News</a>
+  <a class="btn" href="{{ '/news/' | relative_url }}" data-i18n-key="news-read-more">Read More News</a>
 </p>
 {% endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -623,3 +623,177 @@ mark.publication-highlight {
     border-left-color: #f87171;
   }
 }
+
+.masthead__toggles {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 1rem;
+}
+
+.masthead__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: #ffffff;
+  color: #1f2937;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.masthead__toggle:hover,
+.masthead__toggle:focus {
+  border-color: #2563eb;
+  color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.masthead__toggle-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+@media (max-width: 850px) {
+  .masthead__toggles {
+    margin-left: 0;
+    margin-top: 0.75rem;
+  }
+
+  .masthead__menu {
+    flex-wrap: wrap;
+  }
+}
+
+body.theme-dark {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body.theme-dark .masthead,
+body.theme-dark .greedy-nav,
+body.theme-dark .greedy-nav .visible-links,
+body.theme-dark .masthead__toggle {
+  background-color: #111c34;
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+body.theme-dark .masthead__toggle:hover,
+body.theme-dark .masthead__toggle:focus {
+  color: #93c5fd;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+body.theme-dark .masthead__toggle-label {
+  color: inherit;
+}
+
+body.theme-dark .page,
+body.theme-dark .page__inner-wrap,
+body.theme-dark #main,
+body.theme-dark .sidebar,
+body.theme-dark .site-nav {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body.theme-dark .page__content,
+body.theme-dark .page__content p,
+body.theme-dark .page__content li,
+body.theme-dark .page__content h1,
+body.theme-dark .page__content h2,
+body.theme-dark .page__content h3,
+body.theme-dark .page__content h4,
+body.theme-dark .page__content h5,
+body.theme-dark .page__content h6 {
+  color: #e2e8f0;
+}
+
+body.theme-dark a {
+  color: #93c5fd;
+}
+
+body.theme-dark a:hover,
+body.theme-dark a:focus {
+  color: #bfdbfe;
+}
+
+body.theme-dark .btn,
+body.theme-dark .publication-badge img,
+body.theme-dark .publication-actions .publication-cite {
+  background: rgba(37, 99, 235, 0.15);
+  color: #bfdbfe;
+  border-color: rgba(147, 197, 253, 0.4);
+}
+
+body.theme-dark .btn:hover,
+body.theme-dark .btn:focus {
+  background: rgba(37, 99, 235, 0.25);
+  color: #e0f2fe;
+}
+
+body.theme-dark .paper-box {
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+body.theme-dark .cv-item {
+  border-bottom-color: rgba(148, 163, 184, 0.25);
+}
+
+body.theme-dark .cv-date {
+  color: #cbd5f5;
+}
+
+body.theme-dark .cv-sub {
+  color: #c7d2fe;
+}
+
+body.theme-dark .contact-card {
+  background: rgba(30, 41, 59, 0.85);
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.95);
+}
+
+body.theme-dark .map-api-warning {
+  background: rgba(127, 29, 29, 0.35);
+  color: #fecaca;
+}
+
+body.theme-dark .masthead__menu-item a,
+body.theme-dark .masthead__menu-item a:visited {
+  color: inherit;
+}
+
+body.theme-dark .masthead__menu-item a:hover,
+body.theme-dark .masthead__menu-item a:focus {
+  color: #93c5fd;
+}
+
+body.theme-dark .news-actions .btn {
+  background: rgba(30, 64, 175, 0.3);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+body.theme-dark .news-actions .btn:hover,
+body.theme-dark .news-actions .btn:focus {
+  background: rgba(59, 130, 246, 0.35);
+  color: #f0f9ff;
+}
+
+.awards-list,
+.services-list {
+  margin: 0 0 1rem 0;
+  padding-left: 1.25rem;
+}
+
+.awards-list li,
+.services-list li {
+  margin-bottom: 0.35rem;
+  list-style: disc outside;
+}

--- a/assets/js/site-toggles.js
+++ b/assets/js/site-toggles.js
@@ -1,0 +1,176 @@
+(function () {
+  const LANGUAGE_KEY = 'site-language';
+  const THEME_KEY = 'site-theme';
+  const body = document.body;
+  const html = document.documentElement;
+  const languageToggle = document.getElementById('language-toggle');
+  const languageLabel = document.getElementById('language-toggle-label');
+  const themeToggle = document.getElementById('theme-toggle');
+
+  const translations = {
+    zh: {
+      'nav-home': '主页',
+      'nav-biography': '个人简介',
+      'nav-news': '最新动态',
+      'nav-publications': '代表性论文',
+      'nav-awards': '所获荣誉',
+      'nav-services': '学术服务',
+      'heading-biography': '👨🏻‍🎓 个人简介',
+      'bio-paragraph-1': '我目前在<a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心</a>、<a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系</a>担任博士后研究员，由<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ">陈文华教授</a>指导。',
+      'bio-paragraph-2': '我是<a href="http://www.coscipress.com/journal/JAICS">《人工智能与控制系统期刊》</a>青年编委，同时担任2025年第十届ACIRS第二分会“机器人系统的分布式优化与控制”组织者。2025年入选中国科协“青年人才托举工程博士专项计划”，并于2020、2023、2024年获得研究生国家奖学金，我的硕士论文荣获辽宁省优秀硕士学位论文。',
+      'bio-paragraph-3': '我的研究兴趣包括分布式控制、安全关键控制、强化学习、博弈优化及其在自主车辆和多智能体系统中的应用。我已在IEEE T-CYB、IEEE/CAA JAS、IEEE T-ITS、IEEE T-FS、IEEE CDC等国际顶级期刊与会议发表30余篇论文<a href="https://scholar.google.com/citations?user=e2ban1wAAAAJ"> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations" alt="Google Scholar 引用数"></a>。',
+      'bio-paragraph-4': '欢迎与我交流科研合作事宜，可通过邮箱 <a href="mailto:wtwu95@gmail.com">wtwu95@gmail.com</a> 或 <a href="mailto:wen-tao.wu@polyu.edu.hk">wen-tao.wu@polyu.edu.hk</a> 与我联系。',
+      'heading-experiences': '📖 工作与访学经历',
+      'experience-postdoc': '\n    <div class="cv-row">\n      <div class="cv-main">\n        <span class="cv-role">博士后研究员</span>，就职于\n        <a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心 (RCLAE)</a>、\n        <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系 (AAE)</a>，\n        <a href="https://www.polyu.edu.hk/">香港理工大学 (PolyU)</a>，香港，中国\n      </div>\n      <div class="cv-date">2025/04–至今</div>\n    </div>\n    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>陈文华</b></a>教授（IEEE、IMechE、IET、HEA 会士）</div>\n  ',
+      'experience-visiting': '\n    <div class="cv-row">\n      <div class="cv-main">\n        <span class="cv-role">访问学者</span>，在\n        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">维多利亚大学机械工程系 (ME)</a>，\n        <a href="https://www.uvic.ca/">维多利亚大学 (UVic)</a>，加拿大维多利亚\n      </div>\n      <div class="cv-date">2024/01–2024/11</div>\n    </div>\n    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>施阳</b></a>教授（RSC、CAE、EIC、IEEE、ASME、CSME 会士）</div>\n  ',
+      'heading-educations': '🎓 教育背景',
+      'education-phd': '\n    <div class="cv-row">\n      <div class="cv-main">\n        <span class="cv-degree">博士 (Ph.D.)</span>，电子信息工程，\n        <a href="https://sais.sjtu.edu.cn/">上海交通大学自动化与人工智能研究院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>）、<a href="https://www.sjtu.edu.cn/">上海交通大学 (SJTU)</a>，中国上海\n      </div>\n      <div class="cv-date">2021/09–2025/03</div>\n    </div>\n    <div class="cv-sub">导师：<a href="https://automation.sjtu.edu.cn/wdzhang"><b>张卫东</b></a>教授、<a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>卢俊国</b></a>教授</div>\n  ',
+      'education-master': '\n    <div class="cv-row">\n      <div class="cv-main">\n        <span class="cv-degree">硕士 (M.E.)</span>，电气工程，\n        <a href="https://cbdq.dlmu.edu.cn/index.htm">大连海事大学海洋电气工程学院</a>、<a href="https://www.dlmu.edu.cn/">大连海事大学 (DMU)</a>，中国大连\n      </div>\n      <div class="cv-date">2018/09–2021/06</div>\n    </div>\n    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>王丹</b></a>教授、<a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>彭周华</b></a>教授</div>\n  ',
+      'education-bachelor': '\n    <div class="cv-row">\n      <div class="cv-main">\n        <span class="cv-degree">学士 (B.E.)</span>，电气工程及其自动化，\n        <a href="https://www.seiee.sjtu.edu.cn/">电气与电子工程学院</a>、<a href="http://www.hrbust.edu.cn/">哈尔滨理工大学 (HUST)</a>，中国哈尔滨\n      </div>\n      <div class="cv-date">2014/09–2018/06</div>\n    </div>\n  ',
+      'heading-news': '💬 最新动态',
+      'news-empty': '暂无新闻更新，欢迎稍后再来查看。',
+      'news-read-more': '查看更多新闻',
+      'heading-publications': '📚 代表性论文',
+      'publications-show-all': '查看全部论文',
+      'heading-awards': '🎖 所获荣誉',
+      'award-2025': '2025 年：**<span style="color:red">青年人才托举工程博士专项计划（首批）</span>**',
+      'award-2024': '2024 · 2023 · 2020 年：**<span style="color:red">研究生国家奖学金</span>**',
+      'award-2023-best-paper': '2023 年：第七届CCSICC **<span style="color:red">最佳学生论文提名奖</span>**',
+      'award-2022': '2022 年：**<span style="color:red">辽宁省优秀硕士学位论文奖</span>**',
+      'awards-view-all': '查看全部奖项',
+      'heading-services': '⚙️ 学术服务',
+      'service-editor': '**青年编委**：<a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence &amp; Control Systems</a>（2025 至今）',
+      'service-organizer': '**会议组织者**：2025 第十届 ACIRS “机器人系统的分布式优化与控制”专题',
+      'service-ta': '**课程助教**：香港理工大学《动力系统与控制》（2025 年 9 月至今）',
+      'service-reviewer': '**审稿人**：多家国际期刊与会议',
+      'services-view-all': '查看全部服务',
+      'heading-misc': '😀 其他资源'
+    }
+  };
+
+  const elementsByKey = {};
+
+  function captureElements() {
+    Object.keys(elementsByKey).forEach((key) => {
+      elementsByKey[key] = [];
+    });
+
+    document.querySelectorAll('[data-i18n-key]').forEach((element) => {
+      const key = element.getAttribute('data-i18n-key');
+      if (!key) {
+        return;
+      }
+      if (!elementsByKey[key]) {
+        elementsByKey[key] = [];
+      }
+      elementsByKey[key].push(element);
+      if (!element.dataset.i18nEn) {
+        element.dataset.i18nEn = element.innerHTML;
+      }
+    });
+  }
+
+  function applyLanguage(lang) {
+    const target = lang === 'zh' ? 'zh' : 'en';
+    body.setAttribute('data-language', target);
+    html.setAttribute('lang', target === 'zh' ? 'zh-Hans' : 'en');
+
+    Object.keys(elementsByKey).forEach((key) => {
+      const elements = elementsByKey[key];
+      const translation = translations.zh[key];
+      elements.forEach((element) => {
+        if (!element.dataset.i18nEn) {
+          element.dataset.i18nEn = element.innerHTML;
+        }
+        if (target === 'zh' && translation) {
+          element.innerHTML = translation;
+        } else {
+          element.innerHTML = element.dataset.i18nEn;
+        }
+      });
+    });
+
+    if (languageLabel) {
+      languageLabel.textContent = target === 'zh' ? 'EN' : '中文';
+    }
+
+    if (languageToggle) {
+      languageToggle.setAttribute('aria-pressed', target === 'zh');
+    }
+
+    try {
+      localStorage.setItem(LANGUAGE_KEY, target);
+    } catch (error) {
+      /* localStorage might be unavailable */
+    }
+  }
+
+  function applyTheme(theme) {
+    const mode = theme === 'dark' ? 'dark' : 'light';
+    body.setAttribute('data-theme', mode);
+    if (mode === 'dark') {
+      body.classList.add('theme-dark');
+      if (themeToggle) {
+        themeToggle.setAttribute('aria-pressed', 'true');
+      }
+    } else {
+      body.classList.remove('theme-dark');
+      if (themeToggle) {
+        themeToggle.setAttribute('aria-pressed', 'false');
+      }
+    }
+    try {
+      localStorage.setItem(THEME_KEY, mode);
+    } catch (error) {
+      /* localStorage might be unavailable */
+    }
+  }
+
+  function initialLanguage() {
+    try {
+      const stored = localStorage.getItem(LANGUAGE_KEY);
+      if (stored === 'zh' || stored === 'en') {
+        return stored;
+      }
+    } catch (error) {
+      /* ignore */
+    }
+    return 'en';
+  }
+
+  function initialTheme() {
+    try {
+      const stored = localStorage.getItem(THEME_KEY);
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+    } catch (error) {
+      /* ignore */
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    captureElements();
+    applyLanguage(initialLanguage());
+    applyTheme(initialTheme());
+
+    if (languageToggle) {
+      languageToggle.addEventListener('click', function () {
+        const current = body.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
+        const next = current === 'zh' ? 'en' : 'zh';
+        applyLanguage(next);
+      });
+    }
+
+    if (themeToggle) {
+      themeToggle.addEventListener('click', function () {
+        const next = body.classList.contains('theme-dark') ? 'light' : 'dark';
+        applyTheme(next);
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add language and theme toggle controls to the masthead
- tag homepage content for translation and provide Simplified Chinese copy
- implement dark-mode styling and persistence logic via new toggle script

## Testing
- `bundle exec jekyll build` *(fails: jekyll gem not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6902fd360832dbd598955df85db3b