### PR TITLE
Polish toggle controls and dark theme readability

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,7 @@
 # main links links
 main:
   - title: "Biography"
+    title_zh: "个人简介"
     url: "/#about-me"
 
   # - title: "Experiences"
@@ -10,13 +11,17 @@ main:
   #   url: "/#-educations"
 
   - title: "News"
+    title_zh: "最新动态"
     url: "/#-news"
 
   - title: "Publications"
+    title_zh: "代表性论文"
     url: "/#-publications"
 
   - title: "Awards"
+    title_zh: "所获荣誉"
     url: "/#-awards"
 
   - title: "Services"
+    title_zh: "学术服务"
     url: "/#-professional-services"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,14 +5,45 @@
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
-            <a href="{{ '/' | relative_url }}#about-me" target="_self">Homepage</a>
+            <a href="{{ '/' | relative_url }}#about-me" target="_self">
+              <span data-lang="en">Homepage</span>
+              <span data-lang="zh" hidden>主页</span>
+            </a>
           </li>
           {% for link in site.data.navigation.main %}
+            {% assign zh_label = link.title_zh | default: link.title %}
             <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}" target="_self">{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}" target="_self">
+                <span data-lang="en">{{ link.title }}</span>
+                <span data-lang="zh" hidden>{{ zh_label }}</span>
+              </a>
             </li>
           {% endfor %}
         </ul>
+        <div class="masthead__toggles" role="group" aria-label="Site display preferences">
+          <button
+            class="masthead__toggle"
+            id="language-toggle"
+            type="button"
+            aria-label="Switch to Chinese / 切换到中文"
+            title="Switch to Chinese / 切换到中文"
+            aria-pressed="false"
+          >
+            <span class="masthead__toggle-icon" aria-hidden="true">🌐</span>
+            <span class="masthead__toggle-label" id="language-toggle-label" aria-hidden="true">EN</span>
+          </button>
+          <button
+            class="masthead__toggle masthead__toggle--theme"
+            id="theme-toggle"
+            type="button"
+            aria-label="Switch to dark mode / 切换到深色模式"
+            title="Switch to dark mode / 切换到深色模式"
+            aria-pressed="false"
+          >
+            <span class="masthead__toggle-icon" id="theme-toggle-icon" aria-hidden="true">🌙</span>
+            <span class="masthead__toggle-label" id="theme-toggle-label" aria-hidden="true">Light</span>
+          </button>
+        </div>
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,6 +3,7 @@
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/site-toggles.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -19,7 +19,7 @@ redirect_from:
 {% include_relative includes/news.md limit=5 show_button=true %}
 
 <span class='anchor' id='-publications'></span>
-# 📚 Selected Publications
+# <span data-lang="en">📚 Selected Publications</span><span data-lang="zh" hidden>📚 代表性论文</span>
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -63,85 +63,85 @@ redirect_from:
 </div>
 </div>
 </div>
-<!-- <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
 
-[Output-Feedback Finite-Time Safety-Critical Coordinated Control of Path-Guided Marine Surface Vehicles Based on Neurodynamic Optimization](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)
-
-**Wentao Wu**, Yibo Zhang, Weidong Zhang, Wei Xie
-
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2022-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2022-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:ufrVoPGSRksC'></span></strong>
-
--
--
--
-</div>
-</div>
-
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
-<div class='paper-box-text' markdown="1">
-
-[Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)
-
-**Wentao Wu**, Yibo Zhang, Zhenhua Li, Jun-Guo Lu, Weidong Zhang
-
-
-[![PDF](https://img.shields.io/badge/Link-PDF-gree)](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)  [![Video](https://img.shields.io/badge/%F0%9F%A4%97%20Sim--Demo-blue?label=Video)](/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.mp4)
-<strong><span class='show_paper_citations' data='WGp4lBIAAAAJ:_kc_bZDykSQC'></span></strong>
-
--
--
--
-</div>
-</div>
- -->
-
-<!--
-Explore the full list of publications on the [Publications](/publications/) page.
- -->
 <p class="news-actions">
-  <a class="btn" href="{{ '/publications/' | relative_url }}">Show Full List</a>
+  <a class="btn" href="{{ '/publications/' | relative_url }}">
+    <span data-lang="en">Show Full List</span>
+    <span data-lang="zh" hidden>查看全部论文</span>
+  </a>
 </p>
 {% include citation-modal.html %}
 
 <span class='anchor' id='-awards'></span>
-# 🎖 Selected Awards
+# <span data-lang="en">🎖 Selected Awards</span><span data-lang="zh" hidden>🎖 所获荣誉</span>
 
-- 2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**
-- 2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**
-- 2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC
-- 2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province
+<ul class="awards-list" data-lang="en">
+  <li>2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**</li>
+  <li>2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**</li>
+  <li>2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC</li>
+  <li>2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province</li>
+</ul>
 
+<ul class="awards-list" data-lang="zh" hidden>
+  <li>2025 年：**<span style="color:red">青年人才托举工程博士专项计划（首批）</span>**</li>
+  <li>2024 · 2023 · 2020 年：**<span style="color:red">研究生国家奖学金</span>**</li>
+  <li>2023 年：第七届 CCSICC **<span style="color:red">最佳学生论文提名奖</span>**</li>
+  <li>2022 年：**<span style="color:red">辽宁省优秀硕士学位论文奖</span>**</li>
+</ul>
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/awards/' | relative_url }}">View All Awards</a>
+  <a class="btn" href="{{ '/awards/' | relative_url }}">
+    <span data-lang="en">View All Awards</span>
+    <span data-lang="zh" hidden>查看全部奖项</span>
+  </a>
 </p>
 
 <span class='anchor' id='-professional-services'></span>
-# ⚙️ Professional Services
+# <span data-lang="en">⚙️ Professional Services</span><span data-lang="zh" hidden>⚙️ 学术服务</span>
 
+<ul class="services-list" data-lang="en">
+  <li><strong>Young Editorial Board Member</strong>: <a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence &amp; Control Systems</a> (2025-present)</li>
+  <li><strong>Organizer</strong> for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)</li>
+  <li><strong>Teaching Assistant</strong> for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)</li>
+  <li><strong>Reviewer</strong> for international journals and conferences</li>
+</ul>
 
-- **Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)
-
-- **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
-
-- **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
-
-- **Reviewer** for international journals and conferences
+<ul class="services-list" data-lang="zh" hidden>
+  <li><strong>青年编委</strong>：<a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence &amp; Control Systems</a>（2025 至今）</li>
+  <li><strong>会议组织者</strong>：2025 第十届 ACIRS “机器人系统的分布式优化与控制”专题</li>
+  <li><strong>课程助教</strong>：香港理工大学《动力系统与控制》（2025 年 9 月至今）</li>
+  <li><strong>审稿人</strong>：多家国际期刊与会议</li>
+</ul>
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/services/' | relative_url }}">Explore All Services</a>
+  <a class="btn" href="{{ '/services/' | relative_url }}">
+    <span data-lang="en">Explore All Services</span>
+    <span data-lang="zh" hidden>查看全部服务</span>
+  </a>
 </p>
 
-# 😀 Miscellaneous
+# <span data-lang="en">😀 Miscellaneous</span><span data-lang="zh" hidden>😀 其他资源</span>
 
-- [CloudConvert](https://cloudconvert.com/)
-- [iLoveIMG](https://www.iloveimg.com/)
-- [WordClouds](https://www.wordclouds.com/)
-- [Color Hex](https://www.color-hex.com/color-palettes/)
-- [Unsplash](https://unsplash.com/)
-- [Pngtree](https://pngtree.com/)
-- [How to write rebuttals](https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/)
-- [How to write introduction](http://www-net.cs.umass.edu/kurose/writing/intro-style.html)
-- [Emojipedia](https://emojipedia.org/)
+<ul class="misc-list" data-lang="en">
+  <li><a href="https://cloudconvert.com/">CloudConvert</a></li>
+  <li><a href="https://www.iloveimg.com/">iLoveIMG</a></li>
+  <li><a href="https://www.wordclouds.com/">WordClouds</a></li>
+  <li><a href="https://www.color-hex.com/color-palettes/">Color Hex</a></li>
+  <li><a href="https://unsplash.com/">Unsplash</a></li>
+  <li><a href="https://pngtree.com/">Pngtree</a></li>
+  <li><a href="https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/">How to write rebuttals</a></li>
+  <li><a href="http://www-net.cs.umass.edu/kurose/writing/intro-style.html">How to write introduction</a></li>
+  <li><a href="https://emojipedia.org/">Emojipedia</a></li>
+</ul>
+
+<ul class="misc-list" data-lang="zh" hidden>
+  <li><a href="https://cloudconvert.com/">CloudConvert 文件转换</a></li>
+  <li><a href="https://www.iloveimg.com/">iLoveIMG 图片工具</a></li>
+  <li><a href="https://www.wordclouds.com/">WordClouds 词云生成</a></li>
+  <li><a href="https://www.color-hex.com/color-palettes/">Color Hex 配色方案</a></li>
+  <li><a href="https://unsplash.com/">Unsplash 高清图片</a></li>
+  <li><a href="https://pngtree.com/">Pngtree 素材库</a></li>
+  <li><a href="https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/">如何撰写答辩意见</a></li>
+  <li><a href="http://www-net.cs.umass.edu/kurose/writing/intro-style.html">如何撰写论文引言</a></li>
+  <li><a href="https://emojipedia.org/">Emojipedia 表情百科</a></li>
+</ul>

--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -1,11 +1,12 @@
-# 🎓 Educations
+# <span data-lang="en">🎓 Educations</span><span data-lang="zh" hidden>🎓 教育背景</span>
 
-<ul class="cv-list">
+<ul class="cv-list" data-lang="en">
   <li class="cv-item">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>), 
+        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a>
+        (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
         <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
       </div>
       <div class="cv-date">09/2021–03/2025</div>
@@ -17,7 +18,7 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>, 
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
         <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
       </div>
       <div class="cv-date">09/2018–06/2021</div>
@@ -29,10 +30,48 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>, 
+        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
         <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
       </div>
       <div class="cv-date">09/2014–06/2018</div>
+    </div>
+  </li>
+</ul>
+
+<ul class="cv-list" data-lang="zh" hidden>
+  <li class="cv-item">
+    <div class="cv-row">
+      <div class="cv-main">
+        <span class="cv-degree">博士 (Ph.D.)</span>，电子信息工程，
+        <a href="https://sais.sjtu.edu.cn/">上海交通大学自动化与人工智能研究院</a>
+        （<a href="https://automation.sjtu.edu.cn/">自动化系</a>）、
+        <a href="https://www.sjtu.edu.cn/">上海交通大学 (SJTU)</a>，中国上海
+      </div>
+      <div class="cv-date">2021/09–2025/03</div>
+    </div>
+    <div class="cv-sub">导师：<a href="https://automation.sjtu.edu.cn/wdzhang"><b>张卫东</b></a> 教授、<a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>卢俊国</b></a> 教授</div>
+  </li>
+
+  <li class="cv-item">
+    <div class="cv-row">
+      <div class="cv-main">
+        <span class="cv-degree">硕士 (M.E.)</span>，电气工程，
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">大连海事大学海洋电气工程学院</a>、
+        <a href="https://www.dlmu.edu.cn/">大连海事大学 (DMU)</a>，中国大连
+      </div>
+      <div class="cv-date">2018/09–2021/06</div>
+    </div>
+    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>王丹</b></a> 教授、<a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>彭周华</b></a> 教授</div>
+  </li>
+
+  <li class="cv-item">
+    <div class="cv-row">
+      <div class="cv-main">
+        <span class="cv-degree">学士 (B.E.)</span>，电气工程及其自动化，
+        <a href="https://www.seiee.sjtu.edu.cn/">电气与电子工程学院</a>、
+        <a href="http://www.hrbust.edu.cn/">哈尔滨理工大学 (HUST)</a>，中国哈尔滨
+      </div>
+      <div class="cv-date">2014/09–2018/06</div>
     </div>
   </li>
 </ul>

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -1,11 +1,12 @@
-# 📖 Experiences
-<ul class="cv-list">
+# <span data-lang="en">📖 Experiences</span><span data-lang="zh" hidden>📖 工作与访学经历</span>
+
+<ul class="cv-list" data-lang="en">
   <li class="cv-item">
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Postdoctoral Fellow</span> in
         <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>, 
+        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
         <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
       </div>
       <div class="cv-date">04/2025–Present</div>
@@ -17,11 +18,38 @@
     <div class="cv-row">
       <div class="cv-main">
         <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>, 
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
         <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
       </div>
       <div class="cv-date">01/2024–11/2024</div>
     </div>
     <div class="cv-sub">Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi (施阳)</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)</div>
+  </li>
+</ul>
+
+<ul class="cv-list" data-lang="zh" hidden>
+  <li class="cv-item">
+    <div class="cv-row">
+      <div class="cv-main">
+        <span class="cv-role">博士后研究员</span>，就职于
+        <a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心 (RCLAE)</a>、
+        <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系 (AAE)</a>，
+        <a href="https://www.polyu.edu.hk/">香港理工大学 (PolyU)</a>，香港，中国
+      </div>
+      <div class="cv-date">2025/04–至今</div>
+    </div>
+    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>陈文华</b></a> 教授（IEEE、IMechE、IET、HEA 会士）</div>
+  </li>
+
+  <li class="cv-item">
+    <div class="cv-row">
+      <div class="cv-main">
+        <span class="cv-role">访问学者</span>，在
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">维多利亚大学机械工程系 (ME)</a>，
+        <a href="https://www.uvic.ca/">维多利亚大学 (UVic)</a>，加拿大维多利亚
+      </div>
+      <div class="cv-date">2024/01–2024/11</div>
+    </div>
+    <div class="cv-sub">导师：<a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>施阳</b></a> 教授（RSC、CAE、EIC、IEEE、ASME、CSME 会士）</div>
   </li>
 </ul>

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,11 +1,55 @@
-# 👨🏻‍🎓 Biography
+# <span data-lang="en">👨🏻‍🎓 Biography</span><span data-lang="zh" hidden>👨🏻‍🎓 个人简介</span>
 
-I am currently a Postdoctoral Fellow in [Research Centre for Low Altitude Economy](https://www.polyu.edu.hk/rclae/), [Department of Aeronautical and Aviation Engineering](https://www.polyu.edu.hk/aae/), [The Hong Kong Polytechnic University](https://www.polyu.edu.hk/), under the supervision of Prof. [Wen-Hua Chen](https://scholar.google.com/citations?user=UfIb9GkAAAAJ).
+<p data-lang="en">
+  I am currently a Postdoctoral Fellow in
+  <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy</a>,
+  <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering</a>,
+  <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University</a>, under the supervision of Prof.
+  <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ">Wen-Hua Chen</a>.
+</p>
+<p data-lang="zh" hidden>
+  我目前在<a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心</a>、
+  <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系</a>担任博士后研究员，由
+  <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ">陈文华教授</a>指导。
+</p>
 
-I am a Youth Editorial Board Member of the [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS). I am also an organizer for Special Session 2 of the 2025 10th ACIRS. I was selected for the inaugural **Doctoral Special Program of Young Elite Scientist Sponsorship Program** by China Association for Science and Technology (CAST) in 2025. I obtained **National Scholarships** for Graduate Students (Top 1%) in 2020, 2023, and 2024. My master's thesis received the **Excellent Master Dissertation Award** of Liaoning Province!
+<p data-lang="en">
+  I am a Youth Editorial Board Member of the
+  <a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence &amp; Control Systems</a>.
+  I am also an organizer for Special Session 2 of the 2025 10th ACIRS.
+  I was selected for the inaugural <strong>Doctoral Special Program of Young Elite Scientist Sponsorship Program</strong> by China Association for
+  Science and Technology (CAST) in 2025. I obtained <strong>National Scholarships</strong> for Graduate Students (Top 1%) in 2020, 2023, and 2024.
+  My master's thesis received the <strong>Excellent Master Dissertation Award</strong> of Liaoning Province!
+</p>
+<p data-lang="zh" hidden>
+  我是<a href="http://www.coscipress.com/journal/JAICS">《人工智能与控制系统期刊》</a>青年编委，同时担任 2025 年第十届 ACIRS 第二分会
+  “机器人系统的分布式优化与控制”组织者。2025 年入选中国科协<strong>“青年人才托举工程博士专项计划”</strong>，并于 2020、2023、2024 年获得
+  <strong>研究生国家奖学金</strong>，硕士论文荣获<strong>辽宁省优秀硕士学位论文</strong>。
+</p>
 
-My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. 
-I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a>
-in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+<p data-lang="en">
+  My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and
+  their applications to autonomous vehicles and multi-agent systems. I have published 30+ papers
+  <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'>
+    <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&amp;url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&amp;labelColor=f6f6f6&amp;color=9cf&amp;style=flat&amp;label=citations" alt="Google Scholar citations">
+  </a>
+  in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+</p>
+<p data-lang="zh" hidden>
+  我的研究兴趣包括分布式控制、安全关键控制、强化学习、博弈优化及其在自主车辆和多智能体系统中的应用。我已在 IEEE T-CYB、IEEE/CAA JAS、
+  IEEE T-ITS、IEEE T-FS、IEEE CDC 等国际顶级期刊与会议发表 30 余篇论文
+  <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'>
+    <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&amp;url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&amp;labelColor=f6f6f6&amp;color=9cf&amp;style=flat&amp;label=citations" alt="Google Scholar 引用数">
+  </a>。
+</p>
 
-Welcome to contact me for academic collaboration! Please feel free to email me at [wtwu95@gmail.com](mailto:wtwu95@gmail.com) or [wen-tao.wu@polyu.edu.hk](mailto:wen-tao.wu@polyu.edu.hk).
+<p data-lang="en">
+  Welcome to contact me for academic collaboration! Please feel free to email me at
+  <a href="mailto:wtwu95@gmail.com">wtwu95@gmail.com</a> or
+  <a href="mailto:wen-tao.wu@polyu.edu.hk">wen-tao.wu@polyu.edu.hk</a>.
+</p>
+<p data-lang="zh" hidden>
+  欢迎与我交流科研合作事宜，可通过邮箱
+  <a href="mailto:wtwu95@gmail.com">wtwu95@gmail.com</a> 或
+  <a href="mailto:wen-tao.wu@polyu.edu.hk">wen-tao.wu@polyu.edu.hk</a> 与我联系。
+</p>

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,4 +1,4 @@
-# 💬 News
+# <span data-lang="en">💬 News</span><span data-lang="zh" hidden>💬 最新动态</span>
 
 {% assign news_items = site.data.news | default: [] %}
 {% assign news_count = news_items | size %}
@@ -20,11 +20,15 @@
 {% endfor %}
 {: .news-list}
 {% else %}
-<p>No news items are available right now. Please check back later.</p>
+<p data-lang="en">No news items are available right now. Please check back later.</p>
+<p data-lang="zh" hidden>暂无新闻更新，欢迎稍后再来查看。</p>
 {% endif %}
 
 {% if include.show_button and limit < news_count %}
 <p class="news-actions">
-  <a class="btn" href="{{ '/news/' | relative_url }}">Read More News</a>
+  <a class="btn" href="{{ '/news/' | relative_url }}">
+    <span data-lang="en">Read More News</span>
+    <span data-lang="zh" hidden>查看更多新闻</span>
+  </a>
 </p>
 {% endif %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -623,3 +623,305 @@ mark.publication-highlight {
     border-left-color: #f87171;
   }
 }
+
+.masthead .greedy-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(0.5rem, 1vw, 1rem);
+  padding-right: 3.5rem;
+}
+
+.masthead .greedy-nav > button {
+  right: 0.5rem;
+}
+
+.masthead .greedy-nav .visible-links {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+}
+
+.masthead .greedy-nav .visible-links li {
+  display: flex;
+  align-items: center;
+}
+
+.masthead .greedy-nav .visible-links li a {
+  margin: 0 clamp(0.6rem, 1.2vw, 1rem);
+  padding: 0.55rem 0;
+}
+
+.masthead__toggles {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 0.75rem;
+}
+
+.masthead__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2.25rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  color: #1f2937;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 6px 18px -12px rgba(15, 23, 42, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
+    background 0.2s ease, border-color 0.2s ease;
+}
+
+.masthead__toggle:hover,
+.masthead__toggle:focus {
+  transform: translateY(-1px);
+  border-color: rgba(37, 99, 235, 0.55);
+  color: #1e3a8a;
+  outline: none;
+  box-shadow: 0 10px 24px -14px rgba(30, 64, 175, 0.45);
+  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+}
+
+.masthead__toggle[aria-pressed='true'] {
+  border-color: rgba(30, 64, 175, 0.85);
+  color: #1e3a8a;
+  background: linear-gradient(135deg, #e0f2fe 0%, #bfdbfe 100%);
+  box-shadow: 0 12px 28px -16px rgba(30, 58, 138, 0.55);
+}
+
+.masthead__toggle-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.masthead__toggle-label {
+  font-size: 0.78rem;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+@media (max-width: 900px) {
+  .masthead .greedy-nav {
+    padding-right: 3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .masthead__toggles {
+    justify-content: flex-start;
+    width: 100%;
+    margin-top: 0.65rem;
+    padding-left: 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .masthead__toggle {
+    min-height: 2.05rem;
+    padding: 0.35rem 0.6rem;
+  }
+
+  .masthead__toggle-label {
+    display: none;
+  }
+}
+
+body.theme-dark {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body.theme-dark .masthead {
+  background-color: #0d1425;
+  border-bottom-color: rgba(148, 163, 184, 0.25);
+}
+
+body.theme-dark .greedy-nav {
+  background: transparent;
+}
+
+body.theme-dark .greedy-nav .visible-links {
+  background: transparent;
+}
+
+body.theme-dark .masthead__toggles {
+  background: transparent;
+}
+
+body.theme-dark .masthead__toggle {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.95) 0%,
+      rgba(15, 23, 42, 0.95) 100%);
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 12px 32px -18px rgba(8, 15, 35, 0.9);
+}
+
+body.theme-dark .masthead__toggle:hover,
+body.theme-dark .masthead__toggle:focus {
+  color: #bfdbfe;
+  border-color: rgba(96, 165, 250, 0.75);
+  background: linear-gradient(
+    135deg,
+    rgba(37, 99, 235, 0.35) 0%,
+    rgba(37, 99, 235, 0.15) 100%
+  );
+  box-shadow: 0 16px 40px -22px rgba(37, 99, 235, 0.45);
+}
+
+body.theme-dark .masthead__toggle[aria-pressed='true'] {
+  color: #e0f2fe;
+  border-color: rgba(96, 165, 250, 0.9);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.55) 0%,
+      rgba(30, 64, 175, 0.55) 100%);
+}
+
+body.theme-dark .masthead__toggle-label {
+  color: inherit;
+}
+
+body.theme-dark .page,
+body.theme-dark .page__inner-wrap,
+body.theme-dark #main,
+body.theme-dark .sidebar,
+body.theme-dark .site-nav {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body.theme-dark .page__content,
+body.theme-dark .page__content p,
+body.theme-dark .page__content li,
+body.theme-dark .page__content h1,
+body.theme-dark .page__content h2,
+body.theme-dark .page__content h3,
+body.theme-dark .page__content h4,
+body.theme-dark .page__content h5,
+body.theme-dark .page__content h6 {
+  color: #e2e8f0;
+}
+
+body.theme-dark .page__content h1 {
+  border-bottom-color: rgba(148, 163, 184, 0.3);
+}
+
+body.theme-dark a {
+  color: #93c5fd;
+}
+
+body.theme-dark a:hover,
+body.theme-dark a:focus {
+  color: #bfdbfe;
+}
+
+body.theme-dark .btn,
+body.theme-dark .publication-badge img,
+body.theme-dark .publication-actions .publication-cite {
+  background: rgba(37, 99, 235, 0.15);
+  color: #bfdbfe;
+  border-color: rgba(147, 197, 253, 0.4);
+}
+
+body.theme-dark .btn:hover,
+body.theme-dark .btn:focus {
+  background: rgba(37, 99, 235, 0.25);
+  color: #e0f2fe;
+}
+
+body.theme-dark .paper-box {
+  border-color: rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+body.theme-dark .cv-item {
+  border-bottom-color: rgba(148, 163, 184, 0.25);
+}
+
+body.theme-dark .cv-date {
+  color: #cbd5f5;
+}
+
+body.theme-dark .cv-sub {
+  color: #c7d2fe;
+}
+
+body.theme-dark .contact-card {
+  background: rgba(30, 41, 59, 0.85);
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.95);
+}
+
+body.theme-dark .awards-list,
+body.theme-dark .services-list,
+body.theme-dark .misc-list,
+body.theme-dark .news-list {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 0.85rem;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+body.theme-dark .news-list {
+  padding-left: 1.75rem;
+}
+
+body.theme-dark .cv-list {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+body.theme-dark .map-api-warning {
+  background: rgba(127, 29, 29, 0.35);
+  color: #fecaca;
+}
+
+body.theme-dark .masthead__menu-item a,
+body.theme-dark .masthead__menu-item a:visited {
+  color: inherit;
+}
+
+body.theme-dark .masthead__menu-item a:hover,
+body.theme-dark .masthead__menu-item a:focus {
+  color: #93c5fd;
+}
+
+body.theme-dark .news-actions .btn {
+  background: rgba(30, 64, 175, 0.3);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+body.theme-dark .news-actions .btn:hover,
+body.theme-dark .news-actions .btn:focus {
+  background: rgba(59, 130, 246, 0.35);
+  color: #f0f9ff;
+}
+
+.awards-list,
+.services-list,
+.misc-list {
+  margin: 0 0 1rem 0;
+  padding-left: 1.25rem;
+}
+
+.awards-list li,
+.services-list li,
+.misc-list li {
+  margin-bottom: 0.35rem;
+  list-style: disc outside;
+}

--- a/assets/js/site-toggles.js
+++ b/assets/js/site-toggles.js
@@ -1,0 +1,166 @@
+(function () {
+  const LANGUAGE_KEY = 'site-language';
+  const THEME_KEY = 'site-theme';
+
+  function readStoredValue(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function writeStoredValue(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (error) {
+      /* localStorage might be unavailable */
+    }
+  }
+
+  function initialLanguage() {
+    const stored = readStoredValue(LANGUAGE_KEY);
+    if (stored === 'zh' || stored === 'en') {
+      return stored;
+    }
+    return 'en';
+  }
+
+  function initialTheme() {
+    const stored = readStoredValue(THEME_KEY);
+    if (stored === 'dark' || stored === 'light') {
+      return stored;
+    }
+
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+
+    return 'light';
+  }
+
+  function toggleLanguageLabel(label, lang) {
+    if (!label) {
+      return;
+    }
+    label.textContent = lang === 'zh' ? '中文' : 'EN';
+  }
+
+  function toggleThemeIcon(icon, theme) {
+    if (!icon) {
+      return;
+    }
+    icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+  }
+
+  function toggleThemeLabel(label, theme, language) {
+    if (!label) {
+      return;
+    }
+
+    const activeLanguage = language === 'zh' ? 'zh' : 'en';
+    if (activeLanguage === 'zh') {
+      label.textContent = theme === 'dark' ? '夜间' : '白天';
+    } else {
+      label.textContent = theme === 'dark' ? 'Night' : 'Day';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const body = document.body;
+    const html = document.documentElement;
+    const languageToggle = document.getElementById('language-toggle');
+    const languageLabel = document.getElementById('language-toggle-label');
+    const themeToggle = document.getElementById('theme-toggle');
+    const themeIcon = document.getElementById('theme-toggle-icon');
+    const themeLabel = document.getElementById('theme-toggle-label');
+    const languageElements = Array.prototype.slice.call(
+      document.querySelectorAll('[data-lang]')
+    );
+
+    let activeLanguage = initialLanguage();
+    let activeTheme = initialTheme();
+
+    function applyLanguage(lang) {
+      activeLanguage = lang === 'zh' ? 'zh' : 'en';
+      body.setAttribute('data-language', activeLanguage);
+      html.setAttribute('lang', activeLanguage === 'zh' ? 'zh-Hans' : 'en');
+
+      languageElements.forEach(function (element) {
+        if (element.dataset.lang === activeLanguage) {
+          element.removeAttribute('hidden');
+        } else {
+          element.setAttribute('hidden', '');
+        }
+      });
+
+      toggleLanguageLabel(languageLabel, activeLanguage);
+      toggleThemeLabel(themeLabel, activeTheme, activeLanguage);
+
+      if (languageToggle) {
+        languageToggle.setAttribute('aria-pressed', activeLanguage === 'zh' ? 'true' : 'false');
+        var languageTitle =
+          activeLanguage === 'zh'
+            ? 'Switch to English / 切换到英文'
+            : 'Switch to Chinese / 切换到中文';
+        languageToggle.setAttribute('aria-label', languageTitle);
+        languageToggle.setAttribute('title', languageTitle);
+      }
+
+      writeStoredValue(LANGUAGE_KEY, activeLanguage);
+    }
+
+    function applyTheme(theme) {
+      activeTheme = theme === 'dark' ? 'dark' : 'light';
+      body.setAttribute('data-theme', activeTheme);
+      body.classList.toggle('theme-dark', activeTheme === 'dark');
+
+      if (themeToggle) {
+        themeToggle.setAttribute('aria-pressed', activeTheme === 'dark' ? 'true' : 'false');
+        var themeTitle =
+          activeTheme === 'dark'
+            ? 'Switch to light mode / 切换到浅色模式'
+            : 'Switch to dark mode / 切换到深色模式';
+        themeToggle.setAttribute('aria-label', themeTitle);
+        themeToggle.setAttribute('title', themeTitle);
+      }
+
+      toggleThemeIcon(themeIcon, activeTheme);
+      toggleThemeLabel(themeLabel, activeTheme, activeLanguage);
+      writeStoredValue(THEME_KEY, activeTheme);
+    }
+
+    applyLanguage(activeLanguage);
+    applyTheme(activeTheme);
+
+    if (languageToggle) {
+      languageToggle.addEventListener('click', function () {
+        const nextLanguage = activeLanguage === 'zh' ? 'en' : 'zh';
+        applyLanguage(nextLanguage);
+      });
+    }
+
+    if (themeToggle) {
+      themeToggle.addEventListener('click', function () {
+        const nextTheme = activeTheme === 'dark' ? 'light' : 'dark';
+        applyTheme(nextTheme);
+      });
+    }
+
+    if (window.matchMedia) {
+      var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      var respondToPreference = function (event) {
+        const stored = readStoredValue(THEME_KEY);
+        if (stored !== 'dark' && stored !== 'light') {
+          applyTheme(event.matches ? 'dark' : 'light');
+        }
+      };
+
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', respondToPreference);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(respondToPreference);
+      }
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- restyle the masthead to host responsive language and theme toggle buttons with clearer labels and accessible metadata
- update the toggle script to track the active language/theme, sync button states, and surface localized text for the controls
- deepen dark-mode contrast by adjusting masthead, card, and list backgrounds while preserving light-theme spacing

## Testing
- `bundle exec jekyll build` *(fails: jekyll gem not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6902fd360832dbd598955df85db3b