### PR TITLE
Improve masthead toggles and dark mode

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,22 +1,29 @@
 # main links links
 main:
-  - title: "Biography"
+  - title_en: "Biography"
+    title_zh: "个人简介"
     url: "/#about-me"
 
-  # - title: "Experiences"
+  # - title_en: "Experiences"
+  #   title_zh: "经历"
   #   url: "/#-experiences"
 
-  # - title: "Educations"
+  # - title_en: "Educations"
+  #   title_zh: "教育背景"
   #   url: "/#-educations"
 
-  - title: "News"
+  - title_en: "News"
+    title_zh: "动态"
     url: "/#-news"
 
-  - title: "Publications"
+  - title_en: "Publications"
+    title_zh: "出版物"
     url: "/#-publications"
 
-  - title: "Awards"
+  - title_en: "Awards"
+    title_zh: "荣誉奖励"
     url: "/#-awards"
 
-  - title: "Services"
+  - title_en: "Services"
+    title_zh: "学术服务"
     url: "/#-professional-services"

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -6,7 +6,7 @@
 <meta name="msapplication-TileColor" content="#000000">
 <meta name="msapplication-TileImage" content="{{ '/images/mstile-144x144.png?v=M44lzPylqQ' | relative_url }}">
 <meta name="msapplication-config" content="{{ '/images/browserconfig.xml?v=M44lzPylqQ' | relative_url }}">
-<meta name="theme-color" content="#ffffff">
+<meta name="theme-color" content="#ffffff" id="site-theme-color">
 <link rel="stylesheet" href="{{ '/assets/css/academicons.css' | relative_url }}"/>
 
 <script type="text/x-mathjax-config"> MathJax.Hub.Config({ TeX: { equationNumbers: { autoNumber: "all" } } }); </script>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -5,16 +5,45 @@
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
-            <a href="{{ '/' | relative_url }}#about-me" target="_self">Homepage</a>
+            <a href="{{ '/' | relative_url }}#about-me" target="_self">
+              <span data-lang="en">Homepage</span>
+              <span data-lang="zh" hidden>首页</span>
+            </a>
           </li>
           {% for link in site.data.navigation.main %}
             <li class="masthead__menu-item">
-              <a href="{{ link.url | relative_url }}" target="_self">{{ link.title }}</a>
+              <a href="{{ link.url | relative_url }}" target="_self">
+                <span data-lang="en">{{ link.title_en }}</span>
+                <span data-lang="zh" hidden>{{ link.title_zh }}</span>
+              </a>
             </li>
           {% endfor %}
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
+    </div>
+    <div class="masthead__actions" role="presentation">
+      <button
+        type="button"
+        class="toggle-button toggle-button--language"
+        data-language-toggle
+        aria-label="Switch to Chinese"
+        aria-pressed="false"
+      >
+        <span class="toggle-button__icon" aria-hidden="true">🌐</span>
+        <span class="toggle-button__label" data-language-label>EN</span>
+      </button>
+      <button
+        type="button"
+        class="toggle-button toggle-button--theme"
+        data-theme-toggle
+        aria-label="Switch to dark mode"
+        aria-pressed="false"
+      >
+        <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">☀️</span>
+        <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">🌙</span>
+        <span class="toggle-button__label" data-theme-label>Light</span>
+      </button>
     </div>
   </div>
 </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/toggles.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>

--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -1,17 +1,64 @@
-# 🎖 Awards
+# <span data-lang="en">🎖 Awards</span><span data-lang="zh" hidden>🎖 荣誉奖励</span>
 
-- 2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**
-- 2025 &nbsp; Outstanding Graduate of Shanghai
-- 2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**
-- 2023 &nbsp; State-Sponsored Postgraduate Program for National Construction of High-Level Universities
-- 2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC
-- 2023 &nbsp; First-Level Scholarship for Doctoral Students
-- 2023 &nbsp; Scientific Research Talents Graduate Student Scholarship
-- 2023 &nbsp; Third Award of the First Aviation Innovation Challenge of the PLA Air Force
-- 2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province
-- 2022 &nbsp; Top 10 High-Impact Papers of Chinese Journal of Ship Research — selected from articles published in 2019–2021
-- 2022 &nbsp; First Prize of Hainan Free Trade Port Innovation and Entrepreneurship Contest
-- 2021 &nbsp; Excellent Master Dissertation Award of Dalian Maritime University
-- 2020 &nbsp; Outstanding Graduate of Dalian
-- 2020 &nbsp; First Prize of Liaoning Provincial Graduate Electronic Design Contest
-- 2019 · 2020 &nbsp; First Prizes of National Graduate Electronic Design Contest in Northeast Division
+<ul class="award-list">
+  <li>
+    <span data-lang="en">2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**</span>
+    <span data-lang="zh" hidden>2025 &nbsp; **<span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span>**</span>
+  </li>
+  <li>
+    <span data-lang="en">2025 &nbsp; Outstanding Graduate of Shanghai</span>
+    <span data-lang="zh" hidden>2025 &nbsp; 上海市优秀毕业生</span>
+  </li>
+  <li>
+    <span data-lang="en">2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**</span>
+    <span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; **<span style="color:red">研究生国家奖学金</span>**</span>
+  </li>
+  <li>
+    <span data-lang="en">2023 &nbsp; State-Sponsored Postgraduate Program for National Construction of High-Level Universities</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 国家建设高水平大学公派研究生项目</span>
+  </li>
+  <li>
+    <span data-lang="en">2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC **<span style="color:red">最佳学生论文提名奖</span>**</span>
+  </li>
+  <li>
+    <span data-lang="en">2023 &nbsp; First-Level Scholarship for Doctoral Students</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 博士研究生一等奖学金</span>
+  </li>
+  <li>
+    <span data-lang="en">2023 &nbsp; Scientific Research Talents Graduate Student Scholarship</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 科研人才研究生奖学金</span>
+  </li>
+  <li>
+    <span data-lang="en">2023 &nbsp; Third Award of the First Aviation Innovation Challenge of the PLA Air Force</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 空军首届航空创新挑战赛全国三等奖</span>
+  </li>
+  <li>
+    <span data-lang="en">2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province</span>
+    <span data-lang="zh" hidden>2022 &nbsp; 辽宁省**<span style="color:red">优秀硕士学位论文</span>**</span>
+  </li>
+  <li>
+    <span data-lang="en">2022 &nbsp; Top 10 High-Impact Papers of Chinese Journal of Ship Research — selected from articles published in 2019–2021</span>
+    <span data-lang="zh" hidden>2022 &nbsp; 《中国舰船研究》2019–2021 年度十大高影响力论文</span>
+  </li>
+  <li>
+    <span data-lang="en">2022 &nbsp; First Prize of Hainan Free Trade Port Innovation and Entrepreneurship Contest</span>
+    <span data-lang="zh" hidden>2022 &nbsp; 海南自由贸易港创新创业大赛一等奖</span>
+  </li>
+  <li>
+    <span data-lang="en">2021 &nbsp; Excellent Master Dissertation Award of Dalian Maritime University</span>
+    <span data-lang="zh" hidden>2021 &nbsp; 大连海事大学优秀硕士学位论文</span>
+  </li>
+  <li>
+    <span data-lang="en">2020 &nbsp; Outstanding Graduate of Dalian</span>
+    <span data-lang="zh" hidden>2020 &nbsp; 大连市优秀毕业生</span>
+  </li>
+  <li>
+    <span data-lang="en">2020 &nbsp; First Prize of Liaoning Provincial Graduate Electronic Design Contest</span>
+    <span data-lang="zh" hidden>2020 &nbsp; 辽宁省研究生电子设计竞赛一等奖</span>
+  </li>
+  <li>
+    <span data-lang="en">2019 · 2020 &nbsp; First Prizes of National Graduate Electronic Design Contest in Northeast Division</span>
+    <span data-lang="zh" hidden>2019 · 2020 &nbsp; 全国研究生电子设计竞赛东北赛区一等奖</span>
+  </li>
+</ul>

--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -1,36 +1,58 @@
-# 🎓 Educations
+# <span data-lang="en">🎓 Educations</span><span data-lang="zh" hidden>🎓 教育背景</span>
 
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main">
+      <div class="cv-main" data-lang="en">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>), 
+        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
         <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
+      </div>
+      <div class="cv-main" data-lang="zh" hidden>
+        <span class="cv-degree">博士</span>（电子信息工程），就读于
+        <a href="https://sais.sjtu.edu.cn/">上海交通大学自动化与智能感知学院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>），中国上海
       </div>
       <div class="cv-date">09/2021–03/2025</div>
     </div>
-    <div class="cv-sub">Supervisors: Chair Professor <a href="https://automation.sjtu.edu.cn/wdzhang"><b>Weidong Zhang (张卫东)</b></a> and Professor <a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>Junguo Lu (卢俊国)</b></a></div>
+    <div class="cv-sub" data-lang="en">
+      Supervisors: Chair Professor <a href="https://automation.sjtu.edu.cn/wdzhang"><b>Weidong Zhang (张卫东)</b></a> and Professor <a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>Junguo Lu (卢俊国)</b></a>
+    </div>
+    <div class="cv-sub" data-lang="zh" hidden>
+      导师：<a href="https://automation.sjtu.edu.cn/wdzhang"><b>张卫东教授</b></a>、<a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>卢俊国教授</b></a>
+    </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main">
+      <div class="cv-main" data-lang="en">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>, 
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
         <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
+      </div>
+      <div class="cv-main" data-lang="zh" hidden>
+        <span class="cv-degree">硕士</span>（电气工程），就读于
+        <a href="https://cbdq.dlmu.edu.cn/index.htm">大连海事大学船舶电气工程学院</a>，中国大连
       </div>
       <div class="cv-date">09/2018–06/2021</div>
     </div>
-    <div class="cv-sub">Supervisors: Professor <a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>Dan Wang (王丹)</b></a> and Professor <a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>Zhouhua Peng (彭周华)</b></a></div>
+    <div class="cv-sub" data-lang="en">
+      Supervisors: Professor <a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>Dan Wang (王丹)</b></a> and Professor <a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>Zhouhua Peng (彭周华)</b></a>
+    </div>
+    <div class="cv-sub" data-lang="zh" hidden>
+      导师：<a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>王丹教授</b></a>、<a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>彭周华教授</b></a>
+    </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main">
+      <div class="cv-main" data-lang="en">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>, 
+        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
         <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
+      </div>
+      <div class="cv-main" data-lang="zh" hidden>
+        <span class="cv-degree">学士</span>（电气工程及其自动化），毕业于
+        <a href="https://www.seiee.sjtu.edu.cn/">哈尔滨理工大学电气与电子工程学院</a>，中国哈尔滨
       </div>
       <div class="cv-date">09/2014–06/2018</div>
     </div>

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -1,27 +1,46 @@
-# 📖 Experiences
+# <span data-lang="en">📖 Experiences</span><span data-lang="zh" hidden>📖 经历</span>
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main">
+      <div class="cv-main" data-lang="en">
         <span class="cv-role">Postdoctoral Fellow</span> in
         <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>, 
+        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
         <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
+      </div>
+      <div class="cv-main" data-lang="zh" hidden>
+        <span class="cv-role">博士后研究员</span>，就职于
+        <a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心（RCLAE）</a>、
+        <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系（AAE）</a>，<a href="https://www.polyu.edu.hk/">香港理工大学（PolyU）</a>，中国香港
       </div>
       <div class="cv-date">04/2025–Present</div>
     </div>
-    <div class="cv-sub">Supervisor: Chair Professor <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>Wen-Hua Chen (陈文华)</b></a> (Fellow of IEEE, IMechE, IET, HEA)</div>
+    <div class="cv-sub" data-lang="en">
+      Supervisor: Chair Professor <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>Wen-Hua Chen (陈文华)</b></a> (Fellow of IEEE, IMechE, IET, HEA)
+    </div>
+    <div class="cv-sub" data-lang="zh" hidden>
+      导师：<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>陈文华教授</b></a>（IEEE、IMechE、IET、HEA 会士）
+    </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main">
+      <div class="cv-main" data-lang="en">
         <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>, 
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
         <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
+      </div>
+      <div class="cv-main" data-lang="zh" hidden>
+        <span class="cv-role">访问学者</span>，于加拿大维多利亚大学（<a href="https://www.uvic.ca/">UVic</a>）
+        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">机械工程系（ME）</a>进行合作研究，地点位于加拿大维多利亚
       </div>
       <div class="cv-date">01/2024–11/2024</div>
     </div>
-    <div class="cv-sub">Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi (施阳)</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)</div>
+    <div class="cv-sub" data-lang="en">
+      Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi (施阳)</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)
+    </div>
+    <div class="cv-sub" data-lang="zh" hidden>
+      导师：<a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>施阳教授</b></a>（RSC、CAE、EIC、IEEE、ASME、CSME 会士）
+    </div>
   </li>
 </ul>

--- a/_pages/includes/intro.md
+++ b/_pages/includes/intro.md
@@ -1,11 +1,55 @@
-# 👨🏻‍🎓 Biography
+# <span data-lang="en">👨🏻‍🎓 Biography</span><span data-lang="zh" hidden>👨🏻‍🎓 个人简介</span>
 
-I am currently a Postdoctoral Fellow in [Research Centre for Low Altitude Economy](https://www.polyu.edu.hk/rclae/), [Department of Aeronautical and Aviation Engineering](https://www.polyu.edu.hk/aae/), [The Hong Kong Polytechnic University](https://www.polyu.edu.hk/), under the supervision of Prof. [Wen-Hua Chen](https://scholar.google.com/citations?user=UfIb9GkAAAAJ).
+<p data-lang="en">
+  I am currently a Postdoctoral Fellow in
+  <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy</a>,
+  <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering</a>,
+  <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University</a>, under the supervision of Prof.
+  <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ">Wen-Hua Chen</a>.
+</p>
+<p data-lang="zh" hidden>
+  我目前在<a href="https://www.polyu.edu.hk/rclae/">香港理工大学低空经济研究中心</a>、
+  <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系</a>担任博士后研究员，由
+  <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ">陈文华教授</a>指导。
+</p>
 
-I am a Youth Editorial Board Member of the [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS). I am also an organizer for Special Session 2 of the 2025 10th ACIRS. I was selected for the inaugural **Doctoral Special Program of Young Elite Scientist Sponsorship Program** by China Association for Science and Technology (CAST) in 2025. I obtained **National Scholarships** for Graduate Students (Top 1%) in 2020, 2023, and 2024. My master's thesis received the **Excellent Master Dissertation Award** of Liaoning Province!
+<p data-lang="en">
+  I am a Youth Editorial Board Member of the
+  <a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence &amp; Control Systems</a>.
+  I am also an organizer for Special Session 2 of the 2025 10th ACIRS.
+  I was selected for the inaugural <strong>Doctoral Special Program of Young Elite Scientist Sponsorship Program</strong> by China Association for
+  Science and Technology (CAST) in 2025. I obtained <strong>National Scholarships</strong> for Graduate Students (Top 1%) in 2020, 2023, and 2024.
+  My master's thesis received the <strong>Excellent Master Dissertation Award</strong> of Liaoning Province!
+</p>
+<p data-lang="zh" hidden>
+  我是<a href="http://www.coscipress.com/journal/JAICS">《人工智能与控制系统期刊》</a>青年编委，同时担任 2025 年第十届 ACIRS 第二分会
+  “机器人系统的分布式优化与控制”组织者。2025 年入选中国科协<strong>“青年人才托举工程博士专项计划”</strong>，并于 2020、2023、2024 年获得
+  <strong>研究生国家奖学金</strong>，硕士论文荣获<strong>辽宁省优秀硕士学位论文</strong>。
+</p>
 
-My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and their applications to autonomous vehicles and multi-agent systems. 
-I have published 30+ papers <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'> <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&labelColor=f6f6f6&color=9cf&style=flat&label=citations"></a>
-in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+<p data-lang="en">
+  My research interests include distributed control, safety-critical control, reinforcement learning, game-based optimization, and
+  their applications to autonomous vehicles and multi-agent systems. I have published 30+ papers
+  <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'>
+    <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&amp;url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&amp;labelColor=f6f6f6&amp;color=9cf&amp;style=flat&amp;label=citations" alt="Google Scholar citations">
+  </a>
+  in top journals and international conferences such as IEEE T-CYB, IEEE/CAA JAS, IEEE T-ITS, IEEE T-FS, and IEEE CDC.
+</p>
+<p data-lang="zh" hidden>
+  我的研究兴趣包括分布式控制、安全关键控制、强化学习、博弈优化及其在自主车辆和多智能体系统中的应用。我已在 IEEE T-CYB、IEEE/CAA JAS、
+  IEEE T-ITS、IEEE T-FS、IEEE CDC 等国际顶级期刊与会议发表 30 余篇论文
+  <a href='https://scholar.google.com/citations?user=e2ban1wAAAAJ'>
+    <img src="https://img.shields.io/endpoint?logo=Google%20Scholar&amp;url=https://raw.githubusercontent.com/wtwu95/wtwu95.github.io/google-scholar-stats/gs_data_shieldsio.json&amp;labelColor=f6f6f6&amp;color=9cf&amp;style=flat&amp;label=citations" alt="Google Scholar 引用数">
+  </a>。
+</p>
 
-Welcome to contact me for academic collaboration! Please feel free to email me at [wtwu95@gmail.com](mailto:wtwu95@gmail.com) or [wen-tao.wu@polyu.edu.hk](mailto:wen-tao.wu@polyu.edu.hk).
+<p data-lang="en">
+  Welcome to contact me for academic collaboration! Please feel free to email me at
+  <a href="mailto:wtwu95@gmail.com">wtwu95@gmail.com</a> or
+  <a href="mailto:wen-tao.wu@polyu.edu.hk">wen-tao.wu@polyu.edu.hk</a>.
+</p>
+<p data-lang="zh" hidden>
+  欢迎与我交流科研合作事宜，可通过邮箱
+  <a href="mailto:wtwu95@gmail.com">wtwu95@gmail.com</a> 或
+  <a href="mailto:wen-tao.wu@polyu.edu.hk">wen-tao.wu@polyu.edu.hk</a> 与我联系。
+</p>

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -1,4 +1,4 @@
-# 💬 News
+# <span data-lang="en">💬 News</span><span data-lang="zh" hidden>💬 最新动态</span>
 
 {% assign news_items = site.data.news | default: [] %}
 {% assign news_count = news_items | size %}
@@ -20,11 +20,15 @@
 {% endfor %}
 {: .news-list}
 {% else %}
-<p>No news items are available right now. Please check back later.</p>
+<p data-lang="en">No news items are available right now. Please check back later.</p>
+<p data-lang="zh" hidden>暂无新闻更新，欢迎稍后再来查看。</p>
 {% endif %}
 
 {% if include.show_button and limit < news_count %}
 <p class="news-actions">
-  <a class="btn" href="{{ '/news/' | relative_url }}">Read More News</a>
+  <a class="btn" href="{{ '/news/' | relative_url }}">
+    <span data-lang="en">Read More News</span>
+    <span data-lang="zh" hidden>查看更多新闻</span>
+  </a>
 </p>
 {% endif %}

--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -1,4 +1,4 @@
-# 📚 Publications
+# <span data-lang="en">📚 Publications</span><span data-lang="zh" hidden>📚 代表性成果</span>
 
 
 <div class="publication-controls">
@@ -8,14 +8,25 @@
     class="publication-search"
     placeholder="Search publications..."
     aria-label="Search publications"
+    data-placeholder-en="Search publications..."
+    data-placeholder-zh="搜索成果..."
+    data-aria-label-en="Search publications"
+    data-aria-label-zh="搜索成果"
   >
-  <select id="publication-type-filter">
+  <select id="publication-type-filter" data-label-en="Type" data-label-zh="类型">
     <option value="all">Type</option>
   </select>
-  <select id="publication-year-filter">
+  <select id="publication-year-filter" data-label-en="Date" data-label-zh="日期">
     <option value="all">Date</option>
   </select>
-  <button type="button" id="publication-year-sort" class="publication-sort">⬇</button>
+  <button
+    type="button"
+    id="publication-year-sort"
+    class="publication-sort"
+    aria-label="Sort by newest"
+    data-aria-label-en="Sort by newest"
+    data-aria-label-zh="按最新排序"
+  >⬇</button>
 </div>
 
 <ol id="publication-list" class="publication-list"></ol>

--- a/_pages/includes/serv.md
+++ b/_pages/includes/serv.md
@@ -1,18 +1,18 @@
-# ⚙️ Professional Services
+# <span data-lang="en">⚙️ Professional Services</span><span data-lang="zh" hidden>⚙️ 学术服务</span>
 
-## Journal Editorial Boards
+## <span data-lang="en">Journal Editorial Boards</span><span data-lang="zh" hidden>期刊编委</span>
 
-- **Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)
+- <span data-lang="en">**Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)</span><span data-lang="zh" hidden>**青年编委**： [Journal of Artificial Intelligence &amp; Control Systems](http://www.coscipress.com/journal/JAICS)（2025 至今）</span>
 
-## Conference Program Committee and Editorial
+## <span data-lang="en">Conference Program Committee and Editorial</span><span data-lang="zh" hidden>会议组织与编委</span>
 
-- **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
+- <span data-lang="en">**Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)</span><span data-lang="zh" hidden>**组织者**：2025 第十届亚太智能机器人系统大会（ACIRS）专题二“机器人系统的分布式优化与控制”</span>
 
-## Teaching
+## <span data-lang="en">Teaching</span><span data-lang="zh" hidden>教学工作</span>
 
-- **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
+- <span data-lang="en">**Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)</span><span data-lang="zh" hidden>**《动力系统与控制》助教**，香港理工大学（2025 年 9 月至今）</span>
 
-## Journal Reviewer
+## <span data-lang="en">Journal Reviewer</span><span data-lang="zh" hidden>期刊审稿</span>
 
 - [IEEE Transactions on Automatic Control](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=9)
 - [IEEE Control Systems Letters](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=7782673)
@@ -33,7 +33,7 @@
 - [Nonlinear Dynamics](https://link.springer.com/journal/11071)
 - [Unmanned Systems](https://www.editorialmanager.com/us/default2.aspx)
 
-## Conference Reviewer
+## <span data-lang="en">Conference Reviewer</span><span data-lang="zh" hidden>会议审稿</span>
 
 - IEEE Conference on Decision and Control (CDC)
 - American Control Conference (ACC)

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -1,0 +1,164 @@
+html.theme-light {
+  color-scheme: light;
+}
+
+html.theme-dark {
+  color-scheme: dark;
+}
+
+html.theme-dark body {
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+html.theme-dark .masthead {
+  background-color: #111827;
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+html.theme-dark .masthead__menu a {
+  color: #e2e8f0;
+}
+
+html.theme-dark .masthead__menu a:hover {
+  color: #bfdbfe;
+}
+
+html.theme-dark .greedy-nav {
+  background: transparent;
+}
+
+html.theme-dark .greedy-nav button {
+  background-color: #2563eb;
+  color: #f8fafc;
+}
+
+html.theme-dark .greedy-nav .hidden-links {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+}
+
+html.theme-dark .greedy-nav .hidden-links a {
+  color: #e2e8f0;
+}
+
+html.theme-dark .greedy-nav .hidden-links a:hover {
+  color: #bfdbfe;
+  background: rgba(59, 130, 246, 0.2);
+}
+
+html.theme-dark .page__content {
+  color: inherit;
+}
+
+html.theme-dark .page__content h1,
+html.theme-dark .page__content hr {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+html.theme-dark .page__content a {
+  color: #93c5fd;
+}
+
+html.theme-dark .page__content a:hover,
+html.theme-dark .page__content a:focus {
+  color: #bfdbfe;
+  background-color: rgba(59, 130, 246, 0.12);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+
+html.theme-dark .page__content code {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: none;
+  color: #e2e8f0;
+}
+
+html.theme-dark blockquote {
+  border-left-color: rgba(59, 130, 246, 0.7);
+  background: rgba(30, 41, 59, 0.6);
+}
+
+html.theme-dark .sidebar {
+  color: inherit;
+}
+
+html.theme-dark .sidebar a {
+  color: #93c5fd;
+}
+
+html.theme-dark .sidebar a:hover {
+  color: #bfdbfe;
+}
+
+html.theme-dark .author__avatar img {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+html.theme-dark .author__urls {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
+}
+
+html.theme-dark .author__urls a {
+  color: #e2e8f0;
+}
+
+html.theme-dark .author__urls a:hover {
+  color: #bfdbfe;
+  background: rgba(59, 130, 246, 0.25);
+}
+
+html.theme-dark .page__footer {
+  background-color: #111827;
+  border-top-color: rgba(255, 255, 255, 0.08);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+html.theme-dark .page__footer a {
+  color: #e2e8f0;
+}
+
+html.theme-dark .page__footer a:hover {
+  color: #bfdbfe;
+}
+
+html.theme-dark .btn {
+  color: #0f172a !important;
+  background-color: #bfdbfe;
+}
+
+html.theme-dark .btn:hover {
+  background-color: #93c5fd;
+}
+
+html.theme-dark table,
+html.theme-dark .page__content .news-list {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+html.theme-dark .news-actions .btn {
+  color: #0f172a !important;
+}
+
+html.theme-dark .publication-controls input,
+html.theme-dark .publication-controls select {
+  background-color: #1f2937;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #e2e8f0;
+}
+
+html.theme-dark .publication-controls input::placeholder {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+html.theme-dark .publication-controls select option {
+  color: #0f172a;
+}
+
+html.theme-dark .publication-badge img,
+html.theme-dark .publication-cite img {
+  filter: brightness(0.95) saturate(1.1);
+}

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -16,6 +16,11 @@
   &__inner-wrap {
     @include container;
     @include clearfix;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
     padding: .5em;
     font-family: $sans-serif-narrow;
 
@@ -24,6 +29,7 @@
     }
 
     nav {
+      width: 100%;
       z-index: 10;
     }
 
@@ -34,12 +40,28 @@
 }
 
 .masthead__menu {
+  flex: 1 1 auto;
+  min-width: 0;
 
   ul {
     margin: 0;
     padding: 0;
     clear: both;
     list-style-type: none;
+  }
+}
+
+.masthead__actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .masthead__actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 
@@ -59,6 +81,86 @@
     padding-right: 2em;
     font-weight: 700;
   }
+}
+
+.toggle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  font-family: $sans-serif;
+  font-size: $type-size-6;
+  font-weight: 600;
+  line-height: 1.2;
+  color: inherit;
+  background-color: rgba($background-color, 0.85);
+  border: 1px solid $border-color;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus {
+    background-color: mix($background-color, $primary-color, 90%);
+    border-color: mix($border-color, $primary-color, 45%);
+    color: mix($text-color, $primary-color, 85%);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba($primary-color, 0.15);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.2);
+  }
+
+  &__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  &__icon--moon {
+    display: none;
+  }
+
+  &__label {
+    letter-spacing: 0.02em;
+  }
+}
+
+html.theme-dark {
+  .toggle-button {
+    background-color: rgba(#111827, 0.85);
+    border-color: rgba(#ffffff, 0.12);
+    color: #f9fafb;
+
+    &:hover,
+    &:focus {
+      background-color: rgba(#1f2937, 0.95);
+      border-color: rgba(#60a5fa, 0.5);
+      color: #f9fafb;
+      box-shadow: 0 0 0 2px rgba(#60a5fa, 0.35);
+    }
+  }
+
+  .toggle-button--theme {
+    .toggle-button__icon--sun {
+      display: none;
+    }
+
+    .toggle-button__icon--moon {
+      display: inline-flex;
+    }
+  }
+}
+
+html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon {
+  display: none;
+}
+
+html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
+  display: none;
 }
 
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -153,6 +153,16 @@
     }
   }
 
+  .award-list {
+    margin: 1rem 0;
+    padding-left: 1.25rem;
+    list-style-position: outside;
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+  }
+
   /* blockquote citations */
   blockquote + .small {
     margin-top: -1.5em;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,6 +38,7 @@
 @import "vendor/font-awesome/solid";
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
+@import "custom-theme";
 @import "print";
 
 .paper-box {

--- a/assets/js/toggles.js
+++ b/assets/js/toggles.js
@@ -1,0 +1,202 @@
+(function () {
+  const STORAGE_KEYS = {
+    theme: 'site-theme-preference',
+    language: 'site-language-preference',
+  };
+
+  const META_THEME_COLORS = {
+    light: '#ffffff',
+    dark: '#0f172a',
+  };
+
+  const html = document.documentElement;
+  const metaTheme = document.querySelector('meta[name="theme-color"]#site-theme-color');
+  const themeToggle = document.querySelector('[data-theme-toggle]');
+  const themeLabel = themeToggle ? themeToggle.querySelector('[data-theme-label]') : null;
+  const languageToggle = document.querySelector('[data-language-toggle]');
+  const languageLabel = languageToggle ? languageToggle.querySelector('[data-language-label]') : null;
+
+  function getActiveLanguage() {
+    return html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
+  }
+
+  function getThemeLabel(isDark, language) {
+    if (language === 'zh') {
+      return isDark ? '深色' : '浅色';
+    }
+
+    return isDark ? 'Dark' : 'Light';
+  }
+
+  function getThemeAriaLabel(isDark, language) {
+    if (language === 'zh') {
+      return isDark ? '切换到浅色模式' : '切换到深色模式';
+    }
+
+    return isDark ? 'Switch to light mode' : 'Switch to dark mode';
+  }
+
+  function updateMetaThemeColor(theme) {
+    if (!metaTheme) {
+      return;
+    }
+
+    const color = META_THEME_COLORS[theme] || META_THEME_COLORS.light;
+    metaTheme.setAttribute('content', color);
+  }
+
+  function applyTheme(theme, options) {
+    const settings = Object.assign({ persist: true }, options);
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+
+    html.classList.toggle('theme-dark', normalized === 'dark');
+    html.classList.toggle('theme-light', normalized !== 'dark');
+    html.setAttribute('data-theme', normalized);
+
+    if (themeToggle) {
+      const isDark = normalized === 'dark';
+      const language = getActiveLanguage();
+      themeToggle.setAttribute('aria-pressed', String(isDark));
+      themeToggle.setAttribute('aria-label', getThemeAriaLabel(isDark, language));
+
+      if (themeLabel) {
+        themeLabel.textContent = getThemeLabel(isDark, language);
+      }
+    }
+
+    updateMetaThemeColor(normalized);
+
+    if (settings.persist) {
+      try {
+        window.localStorage.setItem(STORAGE_KEYS.theme, normalized);
+      } catch (error) {
+        /* localStorage may be unavailable */
+      }
+    }
+  }
+
+  function applyLanguage(language, options) {
+    const settings = Object.assign({ persist: true }, options);
+    const normalized = language === 'zh' ? 'zh' : 'en';
+    const nextLanguage = normalized === 'zh' ? 'en' : 'zh';
+
+    html.setAttribute('data-language', normalized);
+    html.setAttribute('lang', normalized);
+
+    document.querySelectorAll('[data-lang]').forEach(function (node) {
+      const nodeLang = node.getAttribute('data-lang');
+      const shouldShow = nodeLang === normalized;
+
+      if (shouldShow) {
+        node.removeAttribute('hidden');
+      } else if (!node.hasAttribute('data-lang-persistent')) {
+        node.setAttribute('hidden', '');
+      } else {
+        node.hidden = true;
+      }
+    });
+
+    document.querySelectorAll('[data-placeholder-en]').forEach(function (input) {
+      const placeholder = normalized === 'zh'
+        ? input.getAttribute('data-placeholder-zh')
+        : input.getAttribute('data-placeholder-en');
+      if (placeholder) {
+        input.setAttribute('placeholder', placeholder);
+      }
+
+      const ariaLabel = normalized === 'zh'
+        ? input.getAttribute('data-aria-label-zh')
+        : input.getAttribute('data-aria-label-en');
+      if (ariaLabel) {
+        input.setAttribute('aria-label', ariaLabel);
+      }
+    });
+
+    document.querySelectorAll('select[data-label-en]').forEach(function (select) {
+      const label = normalized === 'zh'
+        ? select.getAttribute('data-label-zh')
+        : select.getAttribute('data-label-en');
+      if (label) {
+        if (select.options.length > 0) {
+          select.options[0].textContent = label;
+        }
+        select.setAttribute('aria-label', label);
+      }
+    });
+
+    document.querySelectorAll('[data-aria-label-en]').forEach(function (element) {
+      const ariaLabel = normalized === 'zh'
+        ? element.getAttribute('data-aria-label-zh')
+        : element.getAttribute('data-aria-label-en');
+      if (ariaLabel) {
+        element.setAttribute('aria-label', ariaLabel);
+      }
+    });
+
+    if (languageToggle) {
+      const isChinese = normalized === 'zh';
+      languageToggle.setAttribute('aria-pressed', String(isChinese));
+      languageToggle.setAttribute(
+        'aria-label',
+        isChinese ? '切换到英文' : 'Switch to Chinese'
+      );
+
+      if (languageLabel) {
+        languageLabel.textContent = isChinese ? '中' : 'EN';
+      }
+
+      languageToggle.dataset.nextLanguage = nextLanguage;
+    }
+
+    applyTheme(html.getAttribute('data-theme') || 'light', { persist: false });
+
+    if (settings.persist) {
+      try {
+        window.localStorage.setItem(STORAGE_KEYS.language, normalized);
+      } catch (error) {
+        /* localStorage may be unavailable */
+      }
+    }
+  }
+
+  function resolveStoredPreference(key) {
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  const storedTheme = resolveStoredPreference(STORAGE_KEYS.theme);
+  const prefersDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+  const initialTheme = storedTheme || (prefersDark && prefersDark.matches ? 'dark' : 'light');
+  applyTheme(initialTheme, { persist: Boolean(storedTheme) });
+
+  if (prefersDark && typeof prefersDark.addEventListener === 'function') {
+    prefersDark.addEventListener('change', function (event) {
+      if (!resolveStoredPreference(STORAGE_KEYS.theme)) {
+        applyTheme(event.matches ? 'dark' : 'light', { persist: false });
+      }
+    });
+  }
+
+  const storedLanguage = resolveStoredPreference(STORAGE_KEYS.language);
+  const initialLanguage = storedLanguage || html.getAttribute('lang') || 'en';
+  applyLanguage(initialLanguage, { persist: Boolean(storedLanguage) });
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', function () {
+      const currentTheme = html.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      applyTheme(nextTheme);
+    });
+  }
+
+  if (languageToggle) {
+    languageToggle.addEventListener('click', function () {
+      const currentLanguage = html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
+      const nextLanguage = currentLanguage === 'zh' ? 'en' : 'zh';
+      applyLanguage(nextLanguage);
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- add responsive language and theme toggle controls in the masthead with supporting script updates
- localize key homepage sections with bilingual content and dynamic labels for interface controls
- introduce dark theme styling refinements so text and backgrounds remain legible across modes

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a779b868832d88e418666fc1c41a