### PR TITLE
Adjust homepage dark theme styling and navigation

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -16,6 +16,7 @@ redirect_from:
 
 {% include_relative includes/edu.md %}
 
+<span class='anchor' id='-news'></span>
 {% include_relative includes/news.md limit=5 show_button=true %}
 
 <span class='anchor' id='-publications'></span>

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -162,3 +162,51 @@ html.theme-dark .publication-badge img,
 html.theme-dark .publication-cite img {
   filter: brightness(0.95) saturate(1.1);
 }
+
+html.theme-dark .cv-item {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
+html.theme-dark .cv-main {
+  color: rgba(226, 232, 240, 0.92);
+}
+
+html.theme-dark .cv-date {
+  color: rgba(226, 232, 240, 0.65);
+}
+
+html.theme-dark .cv-sub {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+html.theme-dark .paper-box {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
+html.theme-dark .paper-box-text {
+  color: inherit;
+}
+
+html.theme-dark .badge {
+  background-color: rgba(59, 130, 246, 0.85);
+  color: #0b1120;
+}
+
+html.theme-dark .publication-actions .btn {
+  box-shadow: none;
+}
+
+html.theme-dark .author__urls {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+html.theme-dark .author__urls:before,
+html.theme-dark .author__urls:after {
+  display: none;
+}
+
+html.theme-dark .author__urls li {
+  background: transparent;
+}

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -93,23 +93,30 @@
   font-weight: 600;
   line-height: 1.2;
   color: inherit;
-  background-color: rgba($background-color, 0.85);
-  border: 1px solid $border-color;
+  background-color: rgba($background-color, 0.65);
+  border: 1px solid transparent;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 8px rgba(#000, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
   &:hover,
-  &:focus {
-    background-color: mix($background-color, $primary-color, 90%);
-    border-color: mix($border-color, $primary-color, 45%);
+  &:focus-visible {
+    background-color: mix($background-color, $primary-color, 88%);
+    border-color: rgba($primary-color, 0.35);
     color: mix($text-color, $primary-color, 85%);
     outline: none;
-    box-shadow: 0 0 0 2px rgba($primary-color, 0.15);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: 0 2px 8px rgba(#000, 0.08);
+    border-color: transparent;
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 3px rgba($primary-color, 0.2);
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
   }
 
   &__icon {
@@ -131,16 +138,23 @@
 
 html.theme-dark {
   .toggle-button {
-    background-color: rgba(#111827, 0.85);
-    border-color: rgba(#ffffff, 0.12);
+    background-color: rgba(#111827, 0.7);
+    border-color: transparent;
     color: #f9fafb;
+    box-shadow: 0 6px 18px rgba(#000, 0.35);
 
     &:hover,
-    &:focus {
-      background-color: rgba(#1f2937, 0.95);
-      border-color: rgba(#60a5fa, 0.5);
+    &:focus-visible {
+      background-color: rgba(#1f2937, 0.92);
+      border-color: rgba(#60a5fa, 0.45);
       color: #f9fafb;
-      box-shadow: 0 0 0 2px rgba(#60a5fa, 0.35);
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: 0 6px 18px rgba(#000, 0.35);
+      border-color: transparent;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated anchor before the home news section so the News menu item scrolls correctly
- refresh the language and theme toggle buttons with subtler styling and hover behaviour that resets when the cursor leaves
- tune dark theme colours for CV entries, publications, and author details to keep text legible without sidebar boxes

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d6afcc33bc832d882b93995bbf5a4a