### PR TITLE
Align button styles and improve Chinese localization

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -20,7 +20,7 @@ redirect_from:
 {% include_relative includes/news.md limit=5 show_button=true %}
 
 <span class='anchor' id='-publications'></span>
-# 📚 Selected Publications
+# <span data-lang="en">📚 Selected Publications</span><span data-lang="zh" hidden>📚 代表性成果</span>
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -102,40 +102,49 @@ redirect_from:
 Explore the full list of publications on the [Publications](/publications/) page.
  -->
 <p class="news-actions">
-  <a class="btn" href="{{ '/publications/' | relative_url }}">Show Full List</a>
+  <a class="btn" href="{{ '/publications/' | relative_url }}">
+    <span data-lang="en">Show Full List</span>
+    <span data-lang="zh" hidden>查看全部成果</span>
+  </a>
 </p>
 {% include citation-modal.html %}
 
 <span class='anchor' id='-awards'></span>
-# 🎖 Selected Awards
+# <span data-lang="en">🎖 Selected Awards</span><span data-lang="zh" hidden>🎖 精选荣誉奖励</span>
 
-- 2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**
-- 2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**
-- 2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC
-- 2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province
+- <span data-lang="en">2025 &nbsp; <strong><span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span></strong></span><span data-lang="zh" hidden>2025 &nbsp; <strong><span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span></strong></span>
+- <span data-lang="en">2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">National Scholarships for Graduate Students</span></strong></span><span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">研究生国家奖学金</span></strong></span>
+- <span data-lang="en">2023 &nbsp; <strong><span style="color:red">Best Student Paper Nomination Award</span></strong> of the 7th CCSICC</span><span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC <strong><span style="color:red">最佳学生论文提名奖</span></strong></span>
+- <span data-lang="en">2022 &nbsp; <strong><span style="color:red">Excellent Master Dissertation Award</span></strong> of Liaoning Province</span><span data-lang="zh" hidden>2022 &nbsp; 辽宁省<strong><span style="color:red">优秀硕士学位论文</span></strong></span>
 
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/awards/' | relative_url }}">View All Awards</a>
+  <a class="btn" href="{{ '/awards/' | relative_url }}">
+    <span data-lang="en">View All Awards</span>
+    <span data-lang="zh" hidden>查看全部荣誉</span>
+  </a>
 </p>
 
 <span class='anchor' id='-professional-services'></span>
-# ⚙️ Professional Services
+# <span data-lang="en">⚙️ Professional Services</span><span data-lang="zh" hidden>⚙️ 学术服务</span>
 
 
-- **Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)
+- <span data-lang="en"><strong>Young Editorial Board Member</strong>: <a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence & Control Systems</a> (2025-present)</span><span data-lang="zh" hidden><strong>青年编委</strong>：<a href="http://www.coscipress.com/journal/JAICS">《人工智能与控制系统杂志》</a>（2025 年至今）</span>
 
-- **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
+- <span data-lang="en"><strong>Organizer</strong> for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)</span><span data-lang="zh" hidden><strong>组织者</strong>：2025 第十届亚太智能机器人系统大会（ACIRS）专题二“机器人系统的分布式优化与控制”</span>
 
-- **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
+- <span data-lang="en"><strong>Teaching Assistant</strong> for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)</span><span data-lang="zh" hidden><strong>《动力系统与控制》助教</strong>，香港理工大学（2025 年 9 月至今）</span>
 
-- **Reviewer** for international journals and conferences
+- <span data-lang="en"><strong>Reviewer</strong> for international journals and conferences</span><span data-lang="zh" hidden><strong>审稿人</strong>，服务于多个国际期刊与学术会议</span>
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/services/' | relative_url }}">Explore All Services</a>
+  <a class="btn" href="{{ '/services/' | relative_url }}">
+    <span data-lang="en">Explore All Services</span>
+    <span data-lang="zh" hidden>查看更多学术服务</span>
+  </a>
 </p>
 
-# 😀 Miscellaneous
+# <span data-lang="en">😀 Miscellaneous</span><span data-lang="zh" hidden>😀 实用链接</span>
 
 - [CloudConvert](https://cloudconvert.com/)
 - [iLoveIMG](https://www.iloveimg.com/)

--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -2,24 +2,24 @@
 
 <ul class="award-list">
   <li>
-    <span data-lang="en">2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**</span>
-    <span data-lang="zh" hidden>2025 &nbsp; **<span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span>**</span>
+    <span data-lang="en">2025 &nbsp; <strong><span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span></strong></span>
+    <span data-lang="zh" hidden>2025 &nbsp; <strong><span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2025 &nbsp; Outstanding Graduate of Shanghai</span>
     <span data-lang="zh" hidden>2025 &nbsp; 上海市优秀毕业生</span>
   </li>
   <li>
-    <span data-lang="en">2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**</span>
-    <span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; **<span style="color:red">研究生国家奖学金</span>**</span>
+    <span data-lang="en">2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">National Scholarships for Graduate Students</span></strong></span>
+    <span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">研究生国家奖学金</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2023 &nbsp; State-Sponsored Postgraduate Program for National Construction of High-Level Universities</span>
     <span data-lang="zh" hidden>2023 &nbsp; 国家建设高水平大学公派研究生项目</span>
   </li>
   <li>
-    <span data-lang="en">2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC</span>
-    <span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC **<span style="color:red">最佳学生论文提名奖</span>**</span>
+    <span data-lang="en">2023 &nbsp; <strong><span style="color:red">Best Student Paper Nomination Award</span></strong> of the 7th CCSICC</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC <strong><span style="color:red">最佳学生论文提名奖</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2023 &nbsp; First-Level Scholarship for Doctoral Students</span>
@@ -34,8 +34,8 @@
     <span data-lang="zh" hidden>2023 &nbsp; 空军首届航空创新挑战赛全国三等奖</span>
   </li>
   <li>
-    <span data-lang="en">2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province</span>
-    <span data-lang="zh" hidden>2022 &nbsp; 辽宁省**<span style="color:red">优秀硕士学位论文</span>**</span>
+    <span data-lang="en">2022 &nbsp; <strong><span style="color:red">Excellent Master Dissertation Award</span></strong> of Liaoning Province</span>
+    <span data-lang="zh" hidden>2022 &nbsp; 辽宁省<strong><span style="color:red">优秀硕士学位论文</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2022 &nbsp; Top 10 High-Impact Papers of Chinese Journal of Ship Research — selected from articles published in 2019–2021</span>

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -6,24 +6,47 @@
    Default button
    ========================================================================== */
 
+
 .btn {
   /* default button */
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   margin-bottom: 0.25em;
-  padding: 0.5em 1em;
-  color: #fff !important;
+  padding: 0.45em 1.15em;
+  color: $text-color !important;
   font-family: $sans-serif;
   font-size: $type-size-6;
-  font-weight: bold;
+  font-weight: 600;
+  line-height: 1.2;
   text-align: center;
   text-decoration: none;
-  background-color: $primary-color;
-  /* border: 0 !important; */
-  /* border-radius: $border-radius; */
+  background-color: rgba($background-color, 0.65);
+  border: 1px solid transparent;
+  border-radius: 999px;
   cursor: pointer;
+  box-shadow: 0 2px 8px rgba(#000, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+              transform 0.2s ease;
 
-  &:hover {
-    background-color: mix(white, #000, 20%);
+  &:hover,
+  &:focus-visible {
+    background-color: mix($background-color, $primary-color, 88%);
+    border-color: rgba($primary-color, 0.35);
+    color: mix($text-color, $primary-color, 85%) !important;
+    outline: none;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: 0 2px 8px rgba(#000, 0.08);
+    border-color: transparent;
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
   }
 
   .icon {

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -126,21 +126,32 @@ html.theme-dark .page__footer a:hover {
 }
 
 html.theme-dark .btn {
-  color: #0f172a !important;
-  background-color: #bfdbfe;
+  color: #f9fafb !important;
+  background-color: rgba(#111827, 0.7);
+  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(#000, 0.35);
 }
 
-html.theme-dark .btn:hover {
-  background-color: #93c5fd;
+html.theme-dark .btn:hover,
+html.theme-dark .btn:focus-visible {
+  background-color: rgba(#1f2937, 0.92);
+  border-color: rgba(#60a5fa, 0.45);
+  color: #f9fafb !important;
+  box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+}
+
+html.theme-dark .btn:focus-visible {
+  outline: none;
+}
+
+html.theme-dark .btn:focus:not(:focus-visible) {
+  box-shadow: 0 6px 18px rgba(#000, 0.35);
+  border-color: transparent;
 }
 
 html.theme-dark table,
 html.theme-dark .page__content .news-list {
   border-color: rgba(255, 255, 255, 0.12);
-}
-
-html.theme-dark .news-actions .btn {
-  color: #0f172a !important;
 }
 
 html.theme-dark .publication-controls input,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -86,13 +86,14 @@
 .toggle-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
+  padding: 0.45rem 1.15rem;
   font-family: $sans-serif;
   font-size: $type-size-6;
   font-weight: 600;
   line-height: 1.2;
-  color: inherit;
+  color: $text-color;
   background-color: rgba($background-color, 0.65);
   border: 1px solid transparent;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- unify toggle button sizing and colors and match call-to-action buttons with the same styling in light and dark modes
- refresh primary button styles so homepage links such as “Read More News” and “Explore All Services” render consistently in both themes
- expand Chinese translations for homepage sections and repair bold styling on the awards page entries

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6a40a3c832dbd18602532a72b22