### PR TITLE
Unify toggle/button styling and localize news feed

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,31 +1,62 @@
-- "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/11164660))!"
-- "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-IE** ([Link](10.1109/TIE.2025.3600515))!"
-- "*06/2025* &nbsp;👏 I was awarded the **Outstanding Graduates of Shanghai**!"
-- "*01/2025* &nbsp;👏🎉 I obtained **Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program** by CAST!"
-- "*09/2024* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
-- "*08/2024* &nbsp;🎉 One paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!"
-- "*07/2024* &nbsp;🎉  One co-author's paper was accepted by IEEE **CDC** ([Link]())!"
-- "*07/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](10.1109/TFUZZ.2024.3434711))!"
-- "*03/2024* &nbsp;🎉 One  paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/10549852))!"
-- "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/document/10462491))!"
-- "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/10449447))!"
-- "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/document/10416809))!"
-- "*12/2023* &nbsp;👏 I obtained the **Scientific Research Talens Graduate Student Scholarship** awarded by Sanya Yazhou Bay Science and Technology City!"
-- "*12/2023* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/document/10414035))!"
-- "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
-- "*11/2023* &nbsp;👏  My conference paper was awarded the **Best Student Paper Nomination Award** at 2023 7th CCSICC!"
-- "*11/2023* &nbsp;👏  I won the **National third prize** of the First Air Force Aviation Innovation Challenge in 2023!"
-- "*11/2023* &nbsp;👏  I obtained the **First-class Scholarship** for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!"
-- "*09/2023* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
-- "*09/2023* &nbsp;🎉  One paper was accepted by **IEEE T-ITS** ([Link](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979))!"
-- "*08/2023* &nbsp;🎉  One paper was accepted by **IEEE CAA/JAS** ([Link](https://www.ieee-jas.net/indexen.html))!"
-- "*07/2023* &nbsp;👏  I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!"
-- "*02/2023* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/abstract/document/10059139))!"
-- "*12/2022* &nbsp;🎉  I won the **First Prize** in the Hainan Free Trade Port Entrepreneurship Competition!"
-- "*10/2022* &nbsp;🎉  One co-author's paper was accepted by IEEE **T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9950329))!"
-- "*10/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
-- "*09/2022* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/abstract/document/9900363))!"
-- "*06/2022* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9878245))!"
-- "*04/2022* &nbsp;🎉  One paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!"
-- "*01/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!"
-- "*04/2021* &nbsp;🎉  One paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!"
+- >-
+  <span data-lang="en"><em>08/2025</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-FS</strong> (<a href="https://ieeexplore.ieee.org/document/11164660">Link</a>)!</span><span data-lang="zh" hidden><em>2025/08</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-FS</strong> 录用（<a href="https://ieeexplore.ieee.org/document/11164660">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>08/2025</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-IE</strong> (<a href="https://doi.org/10.1109/TIE.2025.3600515">Link</a>)!</span><span data-lang="zh" hidden><em>2025/08</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-IE</strong> 录用（<a href="https://doi.org/10.1109/TIE.2025.3600515">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>06/2025</em> &nbsp;👏 I was awarded the <strong>Outstanding Graduate of Shanghai</strong>!</span><span data-lang="zh" hidden><em>2025/06</em> &nbsp;👏 我获评 <strong>上海市优秀毕业生</strong>！</span>
+- >-
+  <span data-lang="en"><em>01/2025</em> &nbsp;👏🎉 I obtained the <strong>Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</strong> by CAST!</span><span data-lang="zh" hidden><em>2025/01</em> &nbsp;👏🎉 我入选中国科协的 <strong>青年人才托举工程博士专项计划（首批）</strong>！</span>
+- >-
+  <span data-lang="en"><em>09/2024</em> &nbsp;👏👏 I obtained the <strong>National Scholarship</strong> for doctoral students in Shanghai Jiao Tong University!</span><span data-lang="zh" hidden><em>2024/09</em> &nbsp;👏👏 我在上海交通大学获评博士研究生 <strong>国家奖学金</strong>！</span>
+- >-
+  <span data-lang="en"><em>08/2024</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-VT</strong>!</span><span data-lang="zh" hidden><em>2024/08</em> &nbsp;🎉 我的论文被 <strong>IEEE T-VT</strong> 录用！</span>
+- >-
+  <span data-lang="en"><em>07/2024</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE CDC</strong>!</span><span data-lang="zh" hidden><em>2024/07</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE CDC</strong> 录用！</span>
+- >-
+  <span data-lang="en"><em>07/2024</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-FS</strong> (<a href="https://doi.org/10.1109/TFUZZ.2024.3434711">Link</a>)!</span><span data-lang="zh" hidden><em>2024/07</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-FS</strong> 录用（<a href="https://doi.org/10.1109/TFUZZ.2024.3434711">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>03/2024</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-FS</strong> (<a href="https://ieeexplore.ieee.org/document/10549852">Link</a>)!</span><span data-lang="zh" hidden><em>2024/03</em> &nbsp;🎉 我的论文被 <strong>IEEE T-FS</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10549852">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>02/2024</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-CSII</strong> (<a href="https://ieeexplore.ieee.org/document/10462491">Link</a>)!</span><span data-lang="zh" hidden><em>2024/02</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-CSII</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10462491">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>02/2024</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-VT</strong> (<a href="https://ieeexplore.ieee.org/document/10449447">Link</a>)!</span><span data-lang="zh" hidden><em>2024/02</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-VT</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10449447">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>12/2023</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-CYB</strong> (<a href="https://ieeexplore.ieee.org/document/10416809">Link</a>)!</span><span data-lang="zh" hidden><em>2023/12</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-CYB</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10416809">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>12/2023</em> &nbsp;👏 I obtained the <strong>Scientific Research Talents Graduate Student Scholarship</strong> awarded by Sanya Yazhou Bay Science and Technology City!</span><span data-lang="zh" hidden><em>2023/12</em> &nbsp;👏 我获得三亚崖州湾科技城颁发的 <strong>科研人才研究生奖学金</strong>！</span>
+- >-
+  <span data-lang="en"><em>12/2023</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-SMCA</strong> (<a href="https://ieeexplore.ieee.org/document/10414035">Link</a>)!</span><span data-lang="zh" hidden><em>2023/12</em> &nbsp;🎉 我的论文被 <strong>IEEE T-SMCA</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10414035">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>12/2023</em> &nbsp;🎉 One co-author's paper was accepted by <strong>OE</strong> (<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497">Link</a>)!</span><span data-lang="zh" hidden><em>2023/12</em> &nbsp;🎉 合作作者的一篇论文被 <strong>OE</strong> 录用（<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>11/2023</em> &nbsp;👏 My conference paper was awarded the <strong>Best Student Paper Nomination Award</strong> at 2023 7th CCSICC!</span><span data-lang="zh" hidden><em>2023/11</em> &nbsp;👏 我的会议论文在 2023 第七届 CCSICC 获得 <strong>最佳学生论文提名奖</strong>！</span>
+- >-
+  <span data-lang="en"><em>11/2023</em> &nbsp;👏 I won the <strong>National third prize</strong> of the First Air Force Aviation Innovation Challenge in 2023!</span><span data-lang="zh" hidden><em>2023/11</em> &nbsp;👏 我荣获 2023 年空军首届航空创新挑战赛 <strong>全国三等奖</strong>！</span>
+- >-
+  <span data-lang="en"><em>11/2023</em> &nbsp;👏 I obtained the <strong>First-class Scholarship</strong> for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!</span><span data-lang="zh" hidden><em>2023/11</em> &nbsp;👏 我获得上海交通大学海南研究院颁发的博士研究生 <strong>一等奖学金</strong>！</span>
+- >-
+  <span data-lang="en"><em>09/2023</em> &nbsp;👏👏 I obtained the <strong>National Scholarship</strong> for doctoral students in Shanghai Jiao Tong University!</span><span data-lang="zh" hidden><em>2023/09</em> &nbsp;👏👏 我在上海交通大学获评博士研究生 <strong>国家奖学金</strong>！</span>
+- >-
+  <span data-lang="en"><em>09/2023</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-ITS</strong> (<a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979">Link</a>)!</span><span data-lang="zh" hidden><em>2023/09</em> &nbsp;🎉 我的论文被 <strong>IEEE T-ITS</strong> 录用（<a href="https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>08/2023</em> &nbsp;🎉 One paper was accepted by <strong>IEEE CAA/JAS</strong> (<a href="https://www.ieee-jas.net/indexen.html">Link</a>)!</span><span data-lang="zh" hidden><em>2023/08</em> &nbsp;🎉 我的论文被 <strong>IEEE CAA/JAS</strong> 录用（<a href="https://www.ieee-jas.net/indexen.html">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>07/2023</em> &nbsp;👏 I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!</span><span data-lang="zh" hidden><em>2023/07</em> &nbsp;👏 我入选国家建设高水平大学公派研究生项目，将赴加拿大维多利亚大学交流！</span>
+- >-
+  <span data-lang="en"><em>02/2023</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-CSII</strong> (<a href="https://ieeexplore.ieee.org/document/10059139">Link</a>)!</span><span data-lang="zh" hidden><em>2023/02</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-CSII</strong> 录用（<a href="https://ieeexplore.ieee.org/document/10059139">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>12/2022</em> &nbsp;🎉 I won the <strong>First Prize</strong> in the Hainan Free Trade Port Innovation and Entrepreneurship Contest!</span><span data-lang="zh" hidden><em>2022/12</em> &nbsp;🎉 我荣获海南自由贸易港创新创业大赛 <strong>一等奖</strong>！</span>
+- >-
+  <span data-lang="en"><em>10/2022</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-IV</strong> (<a href="https://ieeexplore.ieee.org/abstract/document/9950329">Link</a>)!</span><span data-lang="zh" hidden><em>2022/10</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-IV</strong> 录用（<a href="https://ieeexplore.ieee.org/abstract/document/9950329">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>10/2022</em> &nbsp;🎉 One paper was accepted by <strong>OE</strong> (<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497">Link</a>)!</span><span data-lang="zh" hidden><em>2022/10</em> &nbsp;🎉 我的论文被 <strong>OE</strong> 录用（<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>09/2022</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-SMCA</strong> (<a href="https://ieeexplore.ieee.org/abstract/document/9900363">Link</a>)!</span><span data-lang="zh" hidden><em>2022/09</em> &nbsp;🎉 我的论文被 <strong>IEEE T-SMCA</strong> 录用（<a href="https://ieeexplore.ieee.org/abstract/document/9900363">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>06/2022</em> &nbsp;🎉 One co-author's paper was accepted by <strong>IEEE T-IV</strong> (<a href="https://ieeexplore.ieee.org/abstract/document/9878245">Link</a>)!</span><span data-lang="zh" hidden><em>2022/06</em> &nbsp;🎉 合作作者的一篇论文被 <strong>IEEE T-IV</strong> 录用（<a href="https://ieeexplore.ieee.org/abstract/document/9878245">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>04/2022</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-IV</strong> (<a href="https://ieeexplore.ieee.org/abstract/document/9762043">Link</a>)!</span><span data-lang="zh" hidden><em>2022/04</em> &nbsp;🎉 我的论文被 <strong>IEEE T-IV</strong> 录用（<a href="https://ieeexplore.ieee.org/abstract/document/9762043">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>01/2022</em> &nbsp;🎉 One paper was accepted by <strong>OE</strong> (<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445">Link</a>)!</span><span data-lang="zh" hidden><em>2022/01</em> &nbsp;🎉 我的论文被 <strong>OE</strong> 录用（<a href="https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445">链接</a>）！</span>
+- >-
+  <span data-lang="en"><em>04/2021</em> &nbsp;🎉 One paper was accepted by <strong>IEEE T-CYB</strong> (<a href="https://ieeexplore.ieee.org/abstract/document/9440777">Link</a>)!</span><span data-lang="zh" hidden><em>2021/04</em> &nbsp;🎉 我的论文被 <strong>IEEE T-CYB</strong> 录用（<a href="https://ieeexplore.ieee.org/abstract/document/9440777">链接</a>）！</span>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -20,7 +20,7 @@ redirect_from:
 {% include_relative includes/news.md limit=5 show_button=true %}
 
 <span class='anchor' id='-publications'></span>
-# 📚 Selected Publications
+# <span data-lang="en">📚 Selected Publications</span><span data-lang="zh" hidden>📚 代表性成果</span>
 
 <div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
 <div class='paper-box-text' markdown="1">
@@ -102,40 +102,49 @@ redirect_from:
 Explore the full list of publications on the [Publications](/publications/) page.
  -->
 <p class="news-actions">
-  <a class="btn" href="{{ '/publications/' | relative_url }}">Show Full List</a>
+  <a class="btn" href="{{ '/publications/' | relative_url }}">
+    <span data-lang="en">Show Full List</span>
+    <span data-lang="zh" hidden>查看全部成果</span>
+  </a>
 </p>
 {% include citation-modal.html %}
 
 <span class='anchor' id='-awards'></span>
-# 🎖 Selected Awards
+# <span data-lang="en">🎖 Selected Awards</span><span data-lang="zh" hidden>🎖 精选荣誉奖励</span>
 
-- 2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**
-- 2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**
-- 2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC
-- 2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province
+- <span data-lang="en">2025 &nbsp; <strong><span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span></strong></span><span data-lang="zh" hidden>2025 &nbsp; <strong><span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span></strong></span>
+- <span data-lang="en">2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">National Scholarships for Graduate Students</span></strong></span><span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">研究生国家奖学金</span></strong></span>
+- <span data-lang="en">2023 &nbsp; <strong><span style="color:red">Best Student Paper Nomination Award</span></strong> of the 7th CCSICC</span><span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC <strong><span style="color:red">最佳学生论文提名奖</span></strong></span>
+- <span data-lang="en">2022 &nbsp; <strong><span style="color:red">Excellent Master Dissertation Award</span></strong> of Liaoning Province</span><span data-lang="zh" hidden>2022 &nbsp; 辽宁省<strong><span style="color:red">优秀硕士学位论文</span></strong></span>
 
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/awards/' | relative_url }}">View All Awards</a>
+  <a class="btn" href="{{ '/awards/' | relative_url }}">
+    <span data-lang="en">View All Awards</span>
+    <span data-lang="zh" hidden>查看全部荣誉</span>
+  </a>
 </p>
 
 <span class='anchor' id='-professional-services'></span>
-# ⚙️ Professional Services
+# <span data-lang="en">⚙️ Professional Services</span><span data-lang="zh" hidden>⚙️ 学术服务</span>
 
 
-- **Young Editorial Board Member**: [Journal of Artificial Intelligence & Control Systems](http://www.coscipress.com/journal/JAICS) (2025-present)
+- <span data-lang="en"><strong>Young Editorial Board Member</strong>: <a href="http://www.coscipress.com/journal/JAICS">Journal of Artificial Intelligence & Control Systems</a> (2025-present)</span><span data-lang="zh" hidden><strong>青年编委</strong>：<a href="http://www.coscipress.com/journal/JAICS">《人工智能与控制系统杂志》</a>（2025 年至今）</span>
 
-- **Organizer** for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)
+- <span data-lang="en"><strong>Organizer</strong> for "Special Session 2. Distributed Optimization and Control for Robot Systems" at the 2025 10th Asia-Pacific Conference on Intelligent Robot Systems (ACIRS)</span><span data-lang="zh" hidden><strong>组织者</strong>：2025 第十届亚太智能机器人系统大会（ACIRS）专题二“机器人系统的分布式优化与控制”</span>
 
-- **Teaching Assistant** for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)
+- <span data-lang="en"><strong>Teaching Assistant</strong> for Dynamical Systems and Control at The Hong Kong Polytechnic University (09/2025 - present)</span><span data-lang="zh" hidden><strong>《动力系统与控制》助教</strong>，香港理工大学（2025 年 9 月至今）</span>
 
-- **Reviewer** for international journals and conferences
+- <span data-lang="en"><strong>Reviewer</strong> for international journals and conferences</span><span data-lang="zh" hidden><strong>审稿人</strong>，服务于多个国际期刊与学术会议</span>
 
 <p class="news-actions">
-  <a class="btn" href="{{ '/services/' | relative_url }}">Explore All Services</a>
+  <a class="btn" href="{{ '/services/' | relative_url }}">
+    <span data-lang="en">Explore All Services</span>
+    <span data-lang="zh" hidden>查看更多学术服务</span>
+  </a>
 </p>
 
-# 😀 Miscellaneous
+# <span data-lang="en">😀 Miscellaneous</span><span data-lang="zh" hidden>😀 实用链接</span>
 
 - [CloudConvert](https://cloudconvert.com/)
 - [iLoveIMG](https://www.iloveimg.com/)

--- a/_pages/includes/award.md
+++ b/_pages/includes/award.md
@@ -2,24 +2,24 @@
 
 <ul class="award-list">
   <li>
-    <span data-lang="en">2025 &nbsp; **<span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span>**</span>
-    <span data-lang="zh" hidden>2025 &nbsp; **<span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span>**</span>
+    <span data-lang="en">2025 &nbsp; <strong><span style="color:red">Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program</span></strong></span>
+    <span data-lang="zh" hidden>2025 &nbsp; <strong><span style="color:red">中国科协青年人才托举工程博士专项计划（首批入选）</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2025 &nbsp; Outstanding Graduate of Shanghai</span>
     <span data-lang="zh" hidden>2025 &nbsp; 上海市优秀毕业生</span>
   </li>
   <li>
-    <span data-lang="en">2024 · 2023 · 2020 &nbsp; **<span style="color:red">National Scholarships for Graduate Students</span>**</span>
-    <span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; **<span style="color:red">研究生国家奖学金</span>**</span>
+    <span data-lang="en">2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">National Scholarships for Graduate Students</span></strong></span>
+    <span data-lang="zh" hidden>2024 · 2023 · 2020 &nbsp; <strong><span style="color:red">研究生国家奖学金</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2023 &nbsp; State-Sponsored Postgraduate Program for National Construction of High-Level Universities</span>
     <span data-lang="zh" hidden>2023 &nbsp; 国家建设高水平大学公派研究生项目</span>
   </li>
   <li>
-    <span data-lang="en">2023 &nbsp; **<span style="color:red">Best Student Paper Nomination Award</span>** of the 7th CCSICC</span>
-    <span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC **<span style="color:red">最佳学生论文提名奖</span>**</span>
+    <span data-lang="en">2023 &nbsp; <strong><span style="color:red">Best Student Paper Nomination Award</span></strong> of the 7th CCSICC</span>
+    <span data-lang="zh" hidden>2023 &nbsp; 第七届 CCSICC <strong><span style="color:red">最佳学生论文提名奖</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2023 &nbsp; First-Level Scholarship for Doctoral Students</span>
@@ -34,8 +34,8 @@
     <span data-lang="zh" hidden>2023 &nbsp; 空军首届航空创新挑战赛全国三等奖</span>
   </li>
   <li>
-    <span data-lang="en">2022 &nbsp; **<span style="color:red">Excellent Master Dissertation Award</span>** of Liaoning Province</span>
-    <span data-lang="zh" hidden>2022 &nbsp; 辽宁省**<span style="color:red">优秀硕士学位论文</span>**</span>
+    <span data-lang="en">2022 &nbsp; <strong><span style="color:red">Excellent Master Dissertation Award</span></strong> of Liaoning Province</span>
+    <span data-lang="zh" hidden>2022 &nbsp; 辽宁省<strong><span style="color:red">优秀硕士学位论文</span></strong></span>
   </li>
   <li>
     <span data-lang="en">2022 &nbsp; Top 10 High-Impact Papers of Chinese Journal of Ship Research — selected from articles published in 2019–2021</span>

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -6,25 +6,11 @@
    Default button
    ========================================================================== */
 
+
+
 .btn {
   /* default button */
-  display: inline-block;
-  margin-bottom: 0.25em;
-  padding: 0.5em 1em;
-  color: #fff !important;
-  font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: bold;
-  text-align: center;
-  text-decoration: none;
-  background-color: $primary-color;
-  /* border: 0 !important; */
-  /* border-radius: $border-radius; */
-  cursor: pointer;
-
-  &:hover {
-    background-color: mix(white, #000, 20%);
-  }
+  @include pill-button-base;
 
   .icon {
     margin-right: 0.5em;

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -125,22 +125,35 @@ html.theme-dark .page__footer a:hover {
   color: #bfdbfe;
 }
 
-html.theme-dark .btn {
-  color: #0f172a !important;
-  background-color: #bfdbfe;
+html.theme-dark .btn,
+html.theme-dark .toggle-button {
+  color: #f9fafb !important;
+  background-color: rgba(#111827, 0.7);
+  box-shadow: 0 6px 18px rgba(#000, 0.35);
 }
 
-html.theme-dark .btn:hover {
-  background-color: #93c5fd;
+html.theme-dark .btn:hover,
+html.theme-dark .btn:focus-visible,
+html.theme-dark .toggle-button:hover,
+html.theme-dark .toggle-button:focus-visible {
+  background-color: rgba(#1f2937, 0.92);
+  color: #f9fafb !important;
+  box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+}
+
+html.theme-dark .btn:focus-visible,
+html.theme-dark .toggle-button:focus-visible {
+  outline: none;
+}
+
+html.theme-dark .btn:focus:not(:focus-visible),
+html.theme-dark .toggle-button:focus:not(:focus-visible) {
+  box-shadow: 0 6px 18px rgba(#000, 0.35);
 }
 
 html.theme-dark table,
 html.theme-dark .page__content .news-list {
   border-color: rgba(255, 255, 255, 0.12);
-}
-
-html.theme-dark .news-actions .btn {
-  color: #0f172a !important;
 }
 
 html.theme-dark .publication-controls input,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -84,40 +84,8 @@
 }
 
 .toggle-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: 600;
-  line-height: 1.2;
-  color: inherit;
-  background-color: rgba($background-color, 0.65);
-  border: 1px solid transparent;
-  border-radius: 999px;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(#000, 0.08);
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-
-  &:hover,
-  &:focus-visible {
-    background-color: mix($background-color, $primary-color, 88%);
-    border-color: rgba($primary-color, 0.35);
-    color: mix($text-color, $primary-color, 85%);
-    outline: none;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
-  }
-
-  &:focus:not(:focus-visible) {
-    box-shadow: 0 2px 8px rgba(#000, 0.08);
-    border-color: transparent;
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
-  }
+  @include pill-button-base;
+  margin-bottom: 0;
 
   &__icon {
     display: inline-flex;
@@ -136,36 +104,13 @@
   }
 }
 
-html.theme-dark {
-  .toggle-button {
-    background-color: rgba(#111827, 0.7);
-    border-color: transparent;
-    color: #f9fafb;
-    box-shadow: 0 6px 18px rgba(#000, 0.35);
-
-    &:hover,
-    &:focus-visible {
-      background-color: rgba(#1f2937, 0.92);
-      border-color: rgba(#60a5fa, 0.45);
-      color: #f9fafb;
-      transform: translateY(-1px);
-      box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
-    }
-
-    &:focus:not(:focus-visible) {
-      box-shadow: 0 6px 18px rgba(#000, 0.35);
-      border-color: transparent;
-    }
+.toggle-button--theme {
+  .toggle-button__icon--sun {
+    display: none;
   }
 
-  .toggle-button--theme {
-    .toggle-button__icon--sun {
-      display: none;
-    }
-
-    .toggle-button__icon--moon {
-      display: inline-flex;
-    }
+  .toggle-button__icon--moon {
+    display: inline-flex;
   }
 }
 

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -72,3 +72,43 @@
   text-decoration: none;
   box-shadow: none;
 }
+
+@mixin pill-button-base {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  margin-bottom: 0.25em;
+  padding: 0.45em 1.15em;
+  color: $text-color !important;
+  font-family: $sans-serif;
+  font-size: $type-size-6;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: center;
+  text-decoration: none;
+  background-color: rgba($background-color, 0.65);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(#000, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background-color: mix($background-color, $primary-color, 88%);
+    color: mix($text-color, $primary-color, 85%) !important;
+    outline: none;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: 0 2px 8px rgba(#000, 0.08);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
+  }
+}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -161,6 +161,10 @@
     li {
       margin-bottom: 0.5rem;
     }
+
+    strong {
+      font-weight: 700;
+    }
   }
 
   /* blockquote citations */


### PR DESCRIPTION
## Summary
- create a shared pill-button mixin for both `.btn` elements and the masthead toggle button to ensure consistent borderless styling across viewports and themes
- align dark-mode treatments for the toggle and call-to-action buttons while restoring strong-weight emphasis for awards listings
- translate the news data entries into bilingual HTML spans so Chinese mode renders localized announcements

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6a40a3c832dbd18602532a72b22