### PR TITLE
Unify pill-style button look across the site

### DIFF
--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -9,44 +9,24 @@
 
 .btn {
   /* default button */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
+  @include pill-button;
   margin-bottom: 0.25em;
-  padding: 0.45em 1.15em;
   color: $text-color !important;
-  font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: 600;
-  line-height: 1.2;
   text-align: center;
   text-decoration: none;
-  background-color: rgba($background-color, 0.65);
-  border: 1px solid transparent;
-  border-radius: 999px;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(#000, 0.08);
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
-              transform 0.2s ease;
 
   &:hover,
   &:focus-visible {
-    background-color: mix($background-color, $primary-color, 88%);
-    border-color: rgba($primary-color, 0.35);
     color: mix($text-color, $primary-color, 85%) !important;
-    outline: none;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.25),
+      0 8px 18px rgba($primary-color, 0.22);
   }
 
   &:focus:not(:focus-visible) {
     box-shadow: 0 2px 8px rgba(#000, 0.08);
-    border-color: transparent;
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
   }
 
   .icon {

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -127,26 +127,25 @@ html.theme-dark .page__footer a:hover {
 
 html.theme-dark .btn {
   color: #f9fafb !important;
-  background-color: rgba(#111827, 0.7);
-  border-color: transparent;
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
+  background-color: rgba(#111827, 0.72);
+  box-shadow: 0 10px 24px rgba(#000, 0.32);
 }
 
 html.theme-dark .btn:hover,
 html.theme-dark .btn:focus-visible {
   background-color: rgba(#1f2937, 0.92);
-  border-color: rgba(#60a5fa, 0.45);
   color: #f9fafb !important;
-  box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+  box-shadow: 0 12px 28px rgba(#1e3a8a, 0.45);
 }
 
 html.theme-dark .btn:focus-visible {
   outline: none;
+  box-shadow: 0 0 0 3px rgba(#60a5fa, 0.35),
+    0 12px 28px rgba(#1e3a8a, 0.45);
 }
 
 html.theme-dark .btn:focus:not(:focus-visible) {
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
-  border-color: transparent;
+  box-shadow: 0 10px 24px rgba(#000, 0.32);
 }
 
 html.theme-dark table,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -84,41 +84,7 @@
 }
 
 .toggle-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.45rem 1.15rem;
-  font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: 600;
-  line-height: 1.2;
-  color: $text-color;
-  background-color: rgba($background-color, 0.65);
-  border: 1px solid transparent;
-  border-radius: 999px;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(#000, 0.08);
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-
-  &:hover,
-  &:focus-visible {
-    background-color: mix($background-color, $primary-color, 88%);
-    border-color: rgba($primary-color, 0.35);
-    color: mix($text-color, $primary-color, 85%);
-    outline: none;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
-  }
-
-  &:focus:not(:focus-visible) {
-    box-shadow: 0 2px 8px rgba(#000, 0.08);
-    border-color: transparent;
-  }
-
-  &:focus-visible {
-    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
-  }
+  @include pill-button;
 
   &__icon {
     display: inline-flex;
@@ -139,23 +105,24 @@
 
 html.theme-dark {
   .toggle-button {
-    background-color: rgba(#111827, 0.7);
-    border-color: transparent;
+    background-color: rgba(#111827, 0.72);
     color: #f9fafb;
-    box-shadow: 0 6px 18px rgba(#000, 0.35);
+    box-shadow: 0 10px 24px rgba(#000, 0.32);
 
     &:hover,
     &:focus-visible {
       background-color: rgba(#1f2937, 0.92);
-      border-color: rgba(#60a5fa, 0.45);
       color: #f9fafb;
-      transform: translateY(-1px);
-      box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+      box-shadow: 0 12px 28px rgba(#1e3a8a, 0.45);
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px rgba(#60a5fa, 0.35),
+        0 12px 28px rgba(#1e3a8a, 0.45);
     }
 
     &:focus:not(:focus-visible) {
-      box-shadow: 0 6px 18px rgba(#000, 0.35);
-      border-color: transparent;
+      box-shadow: 0 10px 24px rgba(#000, 0.32);
     }
   }
 

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -52,23 +52,40 @@
   }
 }
 
-@mixin cta-button {
-  margin-bottom: 0;
+@mixin pill-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.85rem;
-  height: var(--publication-control-height);
-  min-height: var(--publication-control-height);
-  border-radius: 0.45rem;
-  border: 1px solid $cta-button-border !important;
-  background-color: $cta-button-background;
-  color: $cta-button-text !important;
-  font-size: 0.95rem;
+  gap: 0.35rem;
+  padding: 0.45rem 1.15rem;
+  font-family: $sans-serif;
+  font-size: $type-size-6;
   font-weight: 600;
   line-height: 1.2;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease,
-    background-color 0.2s ease, color 0.2s ease;
-  text-decoration: none;
-  box-shadow: none;
+  color: $text-color;
+  background-color: rgba($background-color, 0.65);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(#000, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease, border-color 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background-color: mix($background-color, $primary-color, 88%);
+    color: mix($text-color, $primary-color, 85%);
+    outline: none;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba($primary-color, 0.22);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba($primary-color, 0.25),
+      0 8px 18px rgba($primary-color, 0.22);
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: 0 2px 8px rgba(#000, 0.08);
+  }
 }

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -131,25 +131,7 @@
     margin-top: 0.75rem;
 
     .btn {
-      @include cta-button;
-    }
-
-    .btn:hover {
-      background-color: $cta-button-background-hover;
-      border-color: $cta-button-background-hover !important;
-      text-decoration: none;
-    }
-
-    .btn:active {
-      background-color: $cta-button-background-active;
-      border-color: $cta-button-background-active !important;
-    }
-
-    .btn:hover,
-    .btn:focus-visible {
-      border-color: var(--publication-accent) !important;
-      box-shadow: 0 0 0 3px var(--publication-accent-soft);
-      outline: none;
+      margin-bottom: 0;
     }
   }
 
@@ -160,6 +142,10 @@
 
     li {
       margin-bottom: 0.5rem;
+    }
+
+    strong {
+      font-weight: 700;
     }
   }
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -73,12 +73,6 @@ $info-color                 : #224b8d;
 // $info-color                 : #52adc8;
 
 /* call-to-action buttons */
-$cta-button-background      : #e0e0e0;
-$cta-button-background-hover: #d5d5d5;
-$cta-button-background-active: #cbcbcb;
-$cta-button-border          : #c1c7d0;
-$cta-button-text            : #494e52;
-
 /* brands */
 $behance-color              : #1769FF;
 $dribbble-color             : #ea4c89;


### PR DESCRIPTION
## Summary
- add a reusable `pill-button` mixin and apply it to navigation toggles and `.btn` links for a consistent, borderless appearance
- align dark theme styling with the new pill buttons and simplify news section action buttons to share the same visuals
- ensure bold formatting in the awards list renders at the expected weight

## Testing
- Not run (bundler executable was unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d6bf05be44832d9e8461aa1d757180