### PR TITLE
Use icon-only toggles with language-specific colors

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -30,8 +30,69 @@
         aria-label="Switch to Chinese"
         aria-pressed="false"
       >
-        <span class="toggle-button__icon" aria-hidden="true">🌐</span>
-        <span class="toggle-button__label" data-language-label>EN</span>
+        <span
+          class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-en"
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+            <path
+              d="M6.5 18.5 12 5l5.5 13.5"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+            <path
+              d="M8.75 14.25h6.5"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+          </svg>
+        </span>
+        <span
+          class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-zh"
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+            <path
+              d="M4.5 6.5h15"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+            <path
+              d="M6.8 6.5c2.9 3.75 6 6.2 10.7 7.75"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+            <path
+              d="M17.2 6.5c-2.9 3.75-6 6.2-10.7 7.75"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+            <path
+              d="M9.25 17.75h5.5"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+            <path
+              d="M12 13.75v6"
+              fill="none"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+            ></path>
+          </svg>
+        </span>
       </button>
       <button
         type="button"
@@ -42,7 +103,6 @@
       >
         <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">☀️</span>
         <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">🌙</span>
-        <span class="toggle-button__label" data-theme-label>Light</span>
       </button>
     </div>
   </div>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -2,6 +2,12 @@
    MASTHEAD
    ========================================================================== */
 
+:root {
+  --language-icon-color-en: #224b8d;
+  --language-icon-color-zh: #d9534f;
+  --language-icon-color: var(--language-icon-color-en);
+}
+
 .masthead {
   position: sticky;
   top: 0;
@@ -132,9 +138,37 @@
     display: none;
   }
 
+  &__icon--language {
+    width: 1.35rem;
+    height: 1.35rem;
+    color: var(--language-icon-color);
+    transition: color 0.2s ease;
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    path {
+      stroke: currentColor;
+    }
+  }
+
   &__label {
     letter-spacing: 0.02em;
   }
+}
+
+.toggle-button--language,
+.toggle-button--theme {
+  padding: 0.45rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  gap: 0;
+}
+
+.toggle-button__icon--language-zh {
+  display: none;
 }
 
 html.theme-dark {
@@ -176,6 +210,23 @@ html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon {
 
 html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
   display: none;
+}
+
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
+  display: none;
+}
+
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
+  display: inline-flex;
+}
+
+html[data-language='en'],
+html:not([data-language]) {
+  --language-icon-color: var(--language-icon-color-en);
+}
+
+html[data-language='zh'] {
+  --language-icon-color: var(--language-icon-color-zh);
 }
 
 

--- a/assets/js/toggles.js
+++ b/assets/js/toggles.js
@@ -12,20 +12,10 @@
   const html = document.documentElement;
   const metaTheme = document.querySelector('meta[name="theme-color"]#site-theme-color');
   const themeToggle = document.querySelector('[data-theme-toggle]');
-  const themeLabel = themeToggle ? themeToggle.querySelector('[data-theme-label]') : null;
   const languageToggle = document.querySelector('[data-language-toggle]');
-  const languageLabel = languageToggle ? languageToggle.querySelector('[data-language-label]') : null;
 
   function getActiveLanguage() {
     return html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
-  }
-
-  function getThemeLabel(isDark, language) {
-    if (language === 'zh') {
-      return isDark ? '深色' : '浅色';
-    }
-
-    return isDark ? 'Dark' : 'Light';
   }
 
   function getThemeAriaLabel(isDark, language) {
@@ -59,9 +49,6 @@
       themeToggle.setAttribute('aria-pressed', String(isDark));
       themeToggle.setAttribute('aria-label', getThemeAriaLabel(isDark, language));
 
-      if (themeLabel) {
-        themeLabel.textContent = getThemeLabel(isDark, language);
-      }
     }
 
     updateMetaThemeColor(normalized);
@@ -140,10 +127,6 @@
         'aria-label',
         isChinese ? '切换到英文' : 'Switch to Chinese'
       );
-
-      if (languageLabel) {
-        languageLabel.textContent = isChinese ? '中' : 'EN';
-      }
 
       languageToggle.dataset.nextLanguage = nextLanguage;
     }


### PR DESCRIPTION
## Summary
- replace the masthead language toggle with custom SVG icons and drop the text labels on both switches
- style the language toggle to adopt the homepage color palette when switching between English and Chinese
- simplify the toggle script by removing now-unused label management logic

## Testing
- bundle install *(fails: 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c88903b0832d83f294f4d0fd1f0b