### PR TITLE
Restyle masthead toggles for icons and mobile menu

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,5 +1,133 @@
 <div class="masthead">
   <div class="masthead__inner-wrap">
+    {% capture language_toggle %}
+    <button
+      type="button"
+      class="toggle-button toggle-button--language"
+      data-language-toggle
+      aria-label="Switch to Chinese"
+      aria-pressed="false"
+    >
+      <span
+        class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-en"
+        aria-hidden="true"
+      >
+        <svg
+          class="language-icon language-icon--en"
+          viewBox="0 0 48 32"
+          role="presentation"
+          focusable="false"
+        >
+          <rect class="language-icon__card language-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
+          <text
+            class="language-icon__glyph language-icon__glyph--inverted"
+            x="28"
+            y="16"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >文</text>
+          <rect class="language-icon__card language-icon__card--front" x="10" y="4" width="20" height="24" rx="3"></rect>
+          <text
+            class="language-icon__glyph language-icon__glyph--primary"
+            x="20"
+            y="16"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >En</text>
+        </svg>
+      </span>
+      <span
+        class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-zh"
+        aria-hidden="true"
+      >
+        <svg
+          class="language-icon language-icon--zh"
+          viewBox="0 0 48 32"
+          role="presentation"
+          focusable="false"
+        >
+          <rect class="language-icon__card language-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
+          <text
+            class="language-icon__glyph language-icon__glyph--primary"
+            x="28"
+            y="16"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >En</text>
+          <rect class="language-icon__card language-icon__card--front language-icon__card--front-zh" x="10" y="4" width="20" height="24" rx="3"></rect>
+          <text
+            class="language-icon__glyph language-icon__glyph--inverted"
+            x="20"
+            y="16"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >文</text>
+        </svg>
+      </span>
+    </button>
+    {% endcapture %}
+    {% capture theme_toggle %}
+    <button
+      type="button"
+      class="toggle-button toggle-button--theme"
+      data-theme-toggle
+      aria-label="Switch to dark mode"
+      aria-pressed="false"
+    >
+      <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">
+        <svg
+          class="theme-icon theme-icon--sun"
+          viewBox="0 0 48 32"
+          role="presentation"
+          focusable="false"
+        >
+          <rect class="theme-icon__card theme-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
+          <path
+            class="theme-icon__glyph theme-icon__glyph--moon"
+            d="M30.5 10.25a7.4 7.4 0 0 0 3.94 11.26 8.2 8.2 0 0 1-9.7-9.7 7.36 7.36 0 0 0 5.76-1.56z"
+          ></path>
+          <rect class="theme-icon__card theme-icon__card--front" x="10" y="4" width="20" height="24" rx="3"></rect>
+          <circle class="theme-icon__glyph theme-icon__glyph--sun-core" cx="20" cy="16" r="5"></circle>
+          <g class="theme-icon__glyph theme-icon__glyph--sun-rays">
+            <line x1="20" y1="6.5" x2="20" y2="9.5"></line>
+            <line x1="20" y1="22.5" x2="20" y2="25.5"></line>
+            <line x1="10.5" y1="16" x2="13.5" y2="16"></line>
+            <line x1="26.5" y1="16" x2="29.5" y2="16"></line>
+            <line x1="13.5" y1="9.5" x2="15.6" y2="11.6"></line>
+            <line x1="24.4" y1="20.4" x2="26.5" y2="22.5"></line>
+            <line x1="13.5" y1="22.5" x2="15.6" y2="20.4"></line>
+            <line x1="24.4" y1="11.6" x2="26.5" y2="9.5"></line>
+          </g>
+        </svg>
+      </span>
+      <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">
+        <svg
+          class="theme-icon theme-icon--moon"
+          viewBox="0 0 48 32"
+          role="presentation"
+          focusable="false"
+        >
+          <rect class="theme-icon__card theme-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
+          <circle class="theme-icon__glyph theme-icon__glyph--sun-core" cx="28" cy="16" r="5"></circle>
+          <g class="theme-icon__glyph theme-icon__glyph--sun-rays">
+            <line x1="28" y1="6.5" x2="28" y2="9.5"></line>
+            <line x1="28" y1="22.5" x2="28" y2="25.5"></line>
+            <line x1="18.5" y1="16" x2="21.5" y2="16"></line>
+            <line x1="34.5" y1="16" x2="37.5" y2="16"></line>
+            <line x1="21.5" y1="9.5" x2="23.6" y2="11.6"></line>
+            <line x1="32.4" y1="20.4" x2="34.5" y2="22.5"></line>
+            <line x1="21.5" y1="22.5" x2="23.6" y2="20.4"></line>
+            <line x1="32.4" y1="11.6" x2="34.5" y2="9.5"></line>
+          </g>
+          <rect class="theme-icon__card theme-icon__card--front theme-icon__card--front-dark" x="10" y="4" width="20" height="24" rx="3"></rect>
+          <path
+            class="theme-icon__glyph theme-icon__glyph--moon"
+            d="M22.5 10.25a7.4 7.4 0 0 0 3.94 11.26 8.2 8.2 0 0 1-9.7-9.7 7.36 7.36 0 0 0 5.76-1.56z"
+          ></path>
+        </svg>
+      </span>
+    </button>
+    {% endcapture %}
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         <button><div class="navicon"></div></button>
@@ -18,32 +146,19 @@
               </a>
             </li>
           {% endfor %}
+          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language">
+            {{ language_toggle | strip }}
+          </li>
+          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme">
+            {{ theme_toggle | strip }}
+          </li>
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
     <div class="masthead__actions" role="presentation">
-      <button
-        type="button"
-        class="toggle-button toggle-button--language"
-        data-language-toggle
-        aria-label="Switch to Chinese"
-        aria-pressed="false"
-      >
-        <span class="toggle-button__icon" aria-hidden="true">🌐</span>
-        <span class="toggle-button__label" data-language-label>EN</span>
-      </button>
-      <button
-        type="button"
-        class="toggle-button toggle-button--theme"
-        data-theme-toggle
-        aria-label="Switch to dark mode"
-        aria-pressed="false"
-      >
-        <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">☀️</span>
-        <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">🌙</span>
-        <span class="toggle-button__label" data-theme-label>Light</span>
-      </button>
+      {{ language_toggle | strip }}
+      {{ theme_toggle | strip }}
     </div>
   </div>
 </div>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -2,6 +2,12 @@
    MASTHEAD
    ========================================================================== */
 
+:root {
+  --masthead-toggle-icon-primary: #4d5258;
+  --masthead-toggle-icon-secondary: #ffffff;
+  --masthead-toggle-underline: #{mix(#fff, $primary-color, 50%)};
+}
+
 .masthead {
   position: sticky;
   top: 0;
@@ -55,14 +61,8 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 0.5rem;
-}
-
-@media (max-width: 480px) {
-  .masthead__actions {
-    width: 100%;
-    justify-content: flex-end;
-  }
+  gap: 1.25rem;
+  color: $masthead-link-color;
 }
 
 .masthead__menu-home-item {
@@ -83,99 +83,179 @@
   }
 }
 
+
+.masthead__menu-item--toggle {
+  display: none;
+  color: $masthead-link-color;
+
+  .toggle-button {
+    margin: 0 1rem;
+  }
+}
+
 .toggle-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.35rem;
-  padding: 0.45rem 1.15rem;
-  font-family: $sans-serif;
-  font-size: $type-size-6;
-  font-weight: 600;
-  line-height: 1.2;
-  color: $text-color;
-  background-color: rgba($background-color, 0.65);
-  border: 1px solid transparent;
-  border-radius: 999px;
+  padding: 0.5rem 0;
+  margin: 0 1rem;
+  background: none;
+  border: 0;
+  color: inherit;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(#000, 0.08);
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  line-height: 1;
+  transition: color 0.2s ease;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 4px;
+    background: var(--masthead-toggle-underline);
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.2s ease;
+  }
 
   &:hover,
   &:focus-visible {
-    background-color: mix($background-color, $primary-color, 88%);
-    border-color: rgba($primary-color, 0.35);
-    color: mix($text-color, $primary-color, 85%);
-    outline: none;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 14px rgba($primary-color, 0.18);
+    color: $masthead-link-color-hover;
   }
 
-  &:focus:not(:focus-visible) {
-    box-shadow: 0 2px 8px rgba(#000, 0.08);
-    border-color: transparent;
+  &:hover::after,
+  &:focus-visible::after {
+    transform: scaleX(1);
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
+    outline: none;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
   }
 
   &__icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1rem;
-    line-height: 1;
+    width: 2.4rem;
+    height: 2.4rem;
   }
 
-  &__icon--moon {
+  &__icon svg {
+    width: 100%;
+    height: auto;
+  }
+
+  &__icon--moon,
+  &__icon--language-zh {
     display: none;
   }
+}
 
-  &__label {
-    letter-spacing: 0.02em;
-  }
+.masthead__actions .toggle-button {
+  margin: 0;
+}
+
+.language-icon,
+.theme-icon {
+  width: 100%;
+  height: auto;
+}
+
+.language-icon__card--back,
+.theme-icon__card--back {
+  fill: var(--masthead-toggle-icon-primary);
+}
+
+.language-icon__card--front,
+.theme-icon__card--front {
+  fill: var(--masthead-toggle-icon-secondary);
+  stroke: var(--masthead-toggle-icon-primary);
+  stroke-width: 1.5;
+}
+
+.language-icon__card--front-zh,
+.theme-icon__card--front-dark {
+  fill: var(--masthead-toggle-icon-primary);
+  stroke: none;
+}
+
+.language-icon__glyph,
+.theme-icon__glyph {
+  font-family: 'Noto Sans SC', 'Microsoft YaHei', 'PingFang SC', sans-serif;
+  font-weight: 600;
+}
+
+.language-icon__glyph--primary {
+  fill: var(--masthead-toggle-icon-primary);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.language-icon__glyph--inverted {
+  fill: var(--masthead-toggle-icon-secondary);
+  font-size: 15px;
+}
+
+.theme-icon__glyph--sun-core {
+  fill: var(--masthead-toggle-icon-primary);
+}
+
+.theme-icon__glyph--sun-rays line {
+  stroke: var(--masthead-toggle-icon-primary);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+.theme-icon__glyph--moon {
+  fill: var(--masthead-toggle-icon-secondary);
 }
 
 html.theme-dark {
-  .toggle-button {
-    background-color: rgba(#111827, 0.7);
-    border-color: transparent;
-    color: #f9fafb;
-    box-shadow: 0 6px 18px rgba(#000, 0.35);
+  --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
 
-    &:hover,
-    &:focus-visible {
-      background-color: rgba(#1f2937, 0.92);
-      border-color: rgba(#60a5fa, 0.45);
-      color: #f9fafb;
-      transform: translateY(-1px);
-      box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
-    }
-
-    &:focus:not(:focus-visible) {
-      box-shadow: 0 6px 18px rgba(#000, 0.35);
-      border-color: transparent;
-    }
+  .masthead__actions {
+    color: #e2e8f0;
   }
 
-  .toggle-button--theme {
-    .toggle-button__icon--sun {
-      display: none;
-    }
+  .masthead__actions .toggle-button:hover,
+  .masthead__actions .toggle-button:focus-visible {
+    color: #bfdbfe;
+  }
 
-    .toggle-button__icon--moon {
-      display: inline-flex;
-    }
+  .masthead__menu-item--toggle {
+    color: #e2e8f0;
+  }
+
+  .masthead__menu-item--toggle .toggle-button:hover,
+  .masthead__menu-item--toggle .toggle-button:focus-visible {
+    color: #bfdbfe;
   }
 }
 
-html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon {
+html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon,
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
   display: none;
 }
 
-html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
-  display: none;
+html.theme-dark .toggle-button--theme .toggle-button__icon--sun,
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
+  display: inline-flex;
+}
+
+@media (max-width: 640px) {
+  .masthead__actions {
+    display: none;
+  }
+
+  .masthead__menu-item--toggle {
+    display: table-cell;
+  }
 }
 
 

--- a/assets/js/toggles.js
+++ b/assets/js/toggles.js
@@ -11,21 +11,11 @@
 
   const html = document.documentElement;
   const metaTheme = document.querySelector('meta[name="theme-color"]#site-theme-color');
-  const themeToggle = document.querySelector('[data-theme-toggle]');
-  const themeLabel = themeToggle ? themeToggle.querySelector('[data-theme-label]') : null;
-  const languageToggle = document.querySelector('[data-language-toggle]');
-  const languageLabel = languageToggle ? languageToggle.querySelector('[data-language-label]') : null;
+  const themeToggles = Array.from(document.querySelectorAll('[data-theme-toggle]'));
+  const languageToggles = Array.from(document.querySelectorAll('[data-language-toggle]'));
 
   function getActiveLanguage() {
     return html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
-  }
-
-  function getThemeLabel(isDark, language) {
-    if (language === 'zh') {
-      return isDark ? '深色' : '浅色';
-    }
-
-    return isDark ? 'Dark' : 'Light';
   }
 
   function getThemeAriaLabel(isDark, language) {
@@ -53,16 +43,13 @@
     html.classList.toggle('theme-light', normalized !== 'dark');
     html.setAttribute('data-theme', normalized);
 
-    if (themeToggle) {
-      const isDark = normalized === 'dark';
-      const language = getActiveLanguage();
-      themeToggle.setAttribute('aria-pressed', String(isDark));
-      themeToggle.setAttribute('aria-label', getThemeAriaLabel(isDark, language));
+    const isDark = normalized === 'dark';
+    const language = getActiveLanguage();
 
-      if (themeLabel) {
-        themeLabel.textContent = getThemeLabel(isDark, language);
-      }
-    }
+    themeToggles.forEach(function (toggle) {
+      toggle.setAttribute('aria-pressed', String(isDark));
+      toggle.setAttribute('aria-label', getThemeAriaLabel(isDark, language));
+    });
 
     updateMetaThemeColor(normalized);
 
@@ -133,20 +120,17 @@
       }
     });
 
-    if (languageToggle) {
-      const isChinese = normalized === 'zh';
-      languageToggle.setAttribute('aria-pressed', String(isChinese));
-      languageToggle.setAttribute(
+    const isChinese = normalized === 'zh';
+
+    languageToggles.forEach(function (toggle) {
+      toggle.setAttribute('aria-pressed', String(isChinese));
+      toggle.setAttribute(
         'aria-label',
         isChinese ? '切换到英文' : 'Switch to Chinese'
       );
 
-      if (languageLabel) {
-        languageLabel.textContent = isChinese ? '中' : 'EN';
-      }
-
-      languageToggle.dataset.nextLanguage = nextLanguage;
-    }
+      toggle.dataset.nextLanguage = nextLanguage;
+    });
 
     applyTheme(html.getAttribute('data-theme') || 'light', { persist: false });
 
@@ -184,19 +168,19 @@
   const initialLanguage = storedLanguage || html.getAttribute('lang') || 'en';
   applyLanguage(initialLanguage, { persist: Boolean(storedLanguage) });
 
-  if (themeToggle) {
-    themeToggle.addEventListener('click', function () {
+  themeToggles.forEach(function (toggle) {
+    toggle.addEventListener('click', function () {
       const currentTheme = html.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
       const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
       applyTheme(nextTheme);
     });
-  }
+  });
 
-  if (languageToggle) {
-    languageToggle.addEventListener('click', function () {
+  languageToggles.forEach(function (toggle) {
+    toggle.addEventListener('click', function () {
       const currentLanguage = html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
       const nextLanguage = currentLanguage === 'zh' ? 'en' : 'zh';
       applyLanguage(nextLanguage);
     });
-  }
+  });
 })();


### PR DESCRIPTION
## Summary
- replace the masthead language and theme toggles with reusable SVG icon buttons that mirror the provided palette
- restyle the toggle interactions to match the navigation hover underline and surface the buttons inside the menu on narrow viewports
- update the toggle script to keep aria labels and pressed states in sync across multiple toggle instances

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing without installing gems)*
- bundle install *(fails: rubygems.org returns 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c88903b0832d83f294f4d0fd1f0b