### PR TITLE
Update toggle buttons for clearer language and theme states

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -25,7 +25,7 @@
             y="16"
             text-anchor="middle"
             dominant-baseline="middle"
-          >文</text>
+          >En</text>
           <rect class="language-icon__card language-icon__card--front" x="10" y="4" width="20" height="24" rx="3"></rect>
           <text
             class="language-icon__glyph language-icon__glyph--primary"
@@ -33,7 +33,7 @@
             y="16"
             text-anchor="middle"
             dominant-baseline="middle"
-          >En</text>
+          >中</text>
         </svg>
       </span>
       <span
@@ -53,7 +53,7 @@
             y="16"
             text-anchor="middle"
             dominant-baseline="middle"
-          >En</text>
+          >中</text>
           <rect class="language-icon__card language-icon__card--front language-icon__card--front-zh" x="10" y="4" width="20" height="24" rx="3"></rect>
           <text
             class="language-icon__glyph language-icon__glyph--inverted"
@@ -61,7 +61,7 @@
             y="16"
             text-anchor="middle"
             dominant-baseline="middle"
-          >文</text>
+          >En</text>
         </svg>
       </span>
     </button>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -217,6 +217,8 @@
 }
 
 html.theme-dark {
+  --masthead-toggle-icon-primary: #ffffff;
+  --masthead-toggle-icon-secondary: #4d5258;
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
 
   .masthead__actions {
@@ -238,12 +240,26 @@ html.theme-dark {
   }
 }
 
-html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon,
+html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--sun {
+  display: none;
+}
+
+html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon {
+  display: inline-flex;
+}
+
+html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
+  display: inline-flex;
+}
+
+html.theme-dark .toggle-button--theme .toggle-button__icon--moon {
+  display: none;
+}
+
 html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
   display: none;
 }
 
-html.theme-dark .toggle-button--theme .toggle-button__icon--sun,
 html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
   display: inline-flex;
 }


### PR DESCRIPTION
## Summary
- update the masthead language toggle so English pages show the Chinese character and Chinese pages show “En”
- invert the visible theme icon per mode and swap dark-mode toggle colors for better contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d74201e744832d8bb036b91350e65c