### PR TITLE
Refine masthead toggle icons

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,59 +11,13 @@
       <span
         class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-en"
         aria-hidden="true"
+        >A</span
       >
-        <svg
-          class="language-icon language-icon--en"
-          viewBox="0 0 48 32"
-          role="presentation"
-          focusable="false"
-        >
-          <rect class="language-icon__card language-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
-          <text
-            class="language-icon__glyph language-icon__glyph--inverted"
-            x="28"
-            y="16"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >文</text>
-          <rect class="language-icon__card language-icon__card--front" x="10" y="4" width="20" height="24" rx="3"></rect>
-          <text
-            class="language-icon__glyph language-icon__glyph--primary"
-            x="20"
-            y="16"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >En</text>
-        </svg>
-      </span>
       <span
         class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-zh"
         aria-hidden="true"
+        >中</span
       >
-        <svg
-          class="language-icon language-icon--zh"
-          viewBox="0 0 48 32"
-          role="presentation"
-          focusable="false"
-        >
-          <rect class="language-icon__card language-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
-          <text
-            class="language-icon__glyph language-icon__glyph--primary"
-            x="28"
-            y="16"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >En</text>
-          <rect class="language-icon__card language-icon__card--front language-icon__card--front-zh" x="10" y="4" width="20" height="24" rx="3"></rect>
-          <text
-            class="language-icon__glyph language-icon__glyph--inverted"
-            x="20"
-            y="16"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >文</text>
-        </svg>
-      </span>
     </button>
     {% endcapture %}
     {% capture theme_toggle %}
@@ -74,58 +28,8 @@
       aria-label="Switch to dark mode"
       aria-pressed="false"
     >
-      <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">
-        <svg
-          class="theme-icon theme-icon--sun"
-          viewBox="0 0 48 32"
-          role="presentation"
-          focusable="false"
-        >
-          <rect class="theme-icon__card theme-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
-          <path
-            class="theme-icon__glyph theme-icon__glyph--moon"
-            d="M30.5 10.25a7.4 7.4 0 0 0 3.94 11.26 8.2 8.2 0 0 1-9.7-9.7 7.36 7.36 0 0 0 5.76-1.56z"
-          ></path>
-          <rect class="theme-icon__card theme-icon__card--front" x="10" y="4" width="20" height="24" rx="3"></rect>
-          <circle class="theme-icon__glyph theme-icon__glyph--sun-core" cx="20" cy="16" r="5"></circle>
-          <g class="theme-icon__glyph theme-icon__glyph--sun-rays">
-            <line x1="20" y1="6.5" x2="20" y2="9.5"></line>
-            <line x1="20" y1="22.5" x2="20" y2="25.5"></line>
-            <line x1="10.5" y1="16" x2="13.5" y2="16"></line>
-            <line x1="26.5" y1="16" x2="29.5" y2="16"></line>
-            <line x1="13.5" y1="9.5" x2="15.6" y2="11.6"></line>
-            <line x1="24.4" y1="20.4" x2="26.5" y2="22.5"></line>
-            <line x1="13.5" y1="22.5" x2="15.6" y2="20.4"></line>
-            <line x1="24.4" y1="11.6" x2="26.5" y2="9.5"></line>
-          </g>
-        </svg>
-      </span>
-      <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">
-        <svg
-          class="theme-icon theme-icon--moon"
-          viewBox="0 0 48 32"
-          role="presentation"
-          focusable="false"
-        >
-          <rect class="theme-icon__card theme-icon__card--back" x="18" y="4" width="20" height="24" rx="3"></rect>
-          <circle class="theme-icon__glyph theme-icon__glyph--sun-core" cx="28" cy="16" r="5"></circle>
-          <g class="theme-icon__glyph theme-icon__glyph--sun-rays">
-            <line x1="28" y1="6.5" x2="28" y2="9.5"></line>
-            <line x1="28" y1="22.5" x2="28" y2="25.5"></line>
-            <line x1="18.5" y1="16" x2="21.5" y2="16"></line>
-            <line x1="34.5" y1="16" x2="37.5" y2="16"></line>
-            <line x1="21.5" y1="9.5" x2="23.6" y2="11.6"></line>
-            <line x1="32.4" y1="20.4" x2="34.5" y2="22.5"></line>
-            <line x1="21.5" y1="22.5" x2="23.6" y2="20.4"></line>
-            <line x1="32.4" y1="11.6" x2="34.5" y2="9.5"></line>
-          </g>
-          <rect class="theme-icon__card theme-icon__card--front theme-icon__card--front-dark" x="10" y="4" width="20" height="24" rx="3"></rect>
-          <path
-            class="theme-icon__glyph theme-icon__glyph--moon"
-            d="M22.5 10.25a7.4 7.4 0 0 0 3.94 11.26 8.2 8.2 0 0 1-9.7-9.7 7.36 7.36 0 0 0 5.76-1.56z"
-          ></path>
-        </svg>
-      </span>
+      <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">☀️</span>
+      <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">🌙</span>
     </button>
     {% endcapture %}
     <div class="masthead__menu">

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -142,78 +142,20 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.4rem;
-    height: 2.4rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    font-size: 1.15rem;
+    font-weight: 600;
   }
 
-  &__icon svg {
-    width: 100%;
-    height: auto;
-  }
-
-  &__icon--moon,
-  &__icon--language-zh {
+  &__icon--sun,
+  &__icon--language-en {
     display: none;
   }
 }
 
 .masthead__actions .toggle-button {
   margin: 0;
-}
-
-.language-icon,
-.theme-icon {
-  width: 100%;
-  height: auto;
-}
-
-.language-icon__card--back,
-.theme-icon__card--back {
-  fill: var(--masthead-toggle-icon-primary);
-}
-
-.language-icon__card--front,
-.theme-icon__card--front {
-  fill: var(--masthead-toggle-icon-secondary);
-  stroke: var(--masthead-toggle-icon-primary);
-  stroke-width: 1.5;
-}
-
-.language-icon__card--front-zh,
-.theme-icon__card--front-dark {
-  fill: var(--masthead-toggle-icon-primary);
-  stroke: none;
-}
-
-.language-icon__glyph,
-.theme-icon__glyph {
-  font-family: 'Noto Sans SC', 'Microsoft YaHei', 'PingFang SC', sans-serif;
-  font-weight: 600;
-}
-
-.language-icon__glyph--primary {
-  fill: var(--masthead-toggle-icon-primary);
-  font-size: 11px;
-  letter-spacing: 0.02em;
-}
-
-.language-icon__glyph--inverted {
-  fill: var(--masthead-toggle-icon-secondary);
-  font-size: 15px;
-}
-
-.theme-icon__glyph--sun-core {
-  fill: var(--masthead-toggle-icon-primary);
-}
-
-.theme-icon__glyph--sun-rays line {
-  stroke: var(--masthead-toggle-icon-primary);
-  stroke-width: 1.6;
-  stroke-linecap: round;
-}
-
-.theme-icon__glyph--moon {
-  fill: var(--masthead-toggle-icon-secondary);
 }
 
 html.theme-dark {
@@ -238,14 +180,20 @@ html.theme-dark {
   }
 }
 
-html:not(.theme-dark) .toggle-button--theme .toggle-button__icon--moon,
-html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
+html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
+  display: inline-flex;
+}
+
+html.theme-dark .toggle-button--theme .toggle-button__icon--moon {
   display: none;
 }
 
-html.theme-dark .toggle-button--theme .toggle-button__icon--sun,
-html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
   display: inline-flex;
+}
+
+html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
+  display: none;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- replace the toggle SVGs with compact text-based icons so they inherit the button styling cleanly
- show the moon icon in light mode and the sun icon in dark mode to reflect the available theme switch
- display “中” when the site is in English and “A” when in Chinese so the language toggle clarifies the target locale

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d74b8583c0832d8af5775020c29338