### PR TITLE
Ensure header toggles display correctly on mobile

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -52,14 +52,21 @@
               </a>
             </li>
           {% endfor %}
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language">
+        </ul>
+        <ul class="hidden-links hidden">
+          <li
+            class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language"
+            data-static
+          >
             {{ language_toggle | strip }}
           </li>
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme">
+          <li
+            class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme"
+            data-static
+          >
             {{ theme_toggle | strip }}
           </li>
         </ul>
-        <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
     <div class="masthead__actions" role="presentation">

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -85,11 +85,15 @@
 
 
 .masthead__menu-item--toggle {
-  display: none;
   color: $masthead-link-color;
 
   .toggle-button {
-    margin: 0 1rem;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin: 0;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }
 
@@ -206,7 +210,9 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
   }
 
   .masthead__menu-item--toggle {
-    display: table-cell;
+    .toggle-button {
+      justify-content: flex-start;
+    }
   }
 }
 

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -13,49 +13,44 @@ var $hlinks = $('#site-nav .hidden-links');
 var breaks = [];
 
 function updateNav() {
-
+  var isMobile = window.matchMedia ? window.matchMedia('(max-width: 640px)').matches : window.innerWidth <= 640;
   var availableSpace = $btn.hasClass('hidden') ? $nav.width() : $nav.width() - $btn.width() - 30;
+  var $movableItems = $vlinks.children(':not([data-static])');
+  var $hiddenMovableItems = $hlinks.children(':not([data-static])');
+  var hasStaticHiddenItems = $hlinks.children('[data-static]').length > 0;
 
-  // The visible list is overflowing the nav
-  if($vlinks.width() > availableSpace) {
-
-    // Record the width of the list
+  while ($movableItems.length && $vlinks.width() > availableSpace) {
     breaks.push($vlinks.width());
+    $movableItems.last().prependTo($hlinks);
+    $btn.removeClass('hidden');
+    availableSpace = $nav.width() - $btn.width() - 30;
+    $movableItems = $vlinks.children(':not([data-static])');
+  }
 
-    // Move item to the hidden list
-    $vlinks.children().last().prependTo($hlinks);
-
-    // Show the dropdown btn
-    if($btn.hasClass('hidden')) {
-      $btn.removeClass('hidden');
-    }
-
-  // The visible list is not overflowing
-  } else {
-
-    // There is space for another item in the nav
-    if(availableSpace > breaks[breaks.length-1]) {
-
-      // Move the item to the visible list
-      $hlinks.children().first().appendTo($vlinks);
+  while (breaks.length && availableSpace > breaks[breaks.length - 1]) {
+    if ($hiddenMovableItems.length) {
+      $hiddenMovableItems.first().appendTo($vlinks);
       breaks.pop();
+      availableSpace = $btn.hasClass('hidden') ? $nav.width() : $nav.width() - $btn.width() - 30;
+      $hiddenMovableItems = $hlinks.children(':not([data-static])');
+      continue;
     }
 
-    // Hide the dropdown btn if hidden list is empty
-    if(breaks.length < 1) {
-      $btn.addClass('hidden');
-      $hlinks.addClass('hidden');
-    }
+    breaks.pop();
   }
 
-  // Keep counter updated
-  $btn.attr("count", breaks.length);
-
-  // Recur if the visible list is still overflowing the nav
-  if($vlinks.width() > availableSpace) {
-    updateNav();
+  if (!breaks.length && !(isMobile && hasStaticHiddenItems)) {
+    $btn.addClass('hidden');
+    $hlinks.addClass('hidden');
+  } else {
+    $btn.removeClass('hidden');
   }
 
+  if (isMobile && hasStaticHiddenItems) {
+    $btn.removeClass('hidden');
+  }
+
+  $btn.attr('count', breaks.length);
 }
 
 // Window listeners


### PR DESCRIPTION
## Summary
- move the language and theme toggle buttons into the greedy navigation dropdown for small screens
- adjust masthead styles so the toggle buttons span the dropdown width and align with other items
- update the greedy navigation script to keep static dropdown items available on narrow viewports

## Testing
- bundle exec jekyll build *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_68d75aa995a0832da655ff3f2c2d8c78