### PR TITLE
Adjust masthead toggles on narrow screens

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -201,12 +201,28 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
 }
 
 @media (max-width: 640px) {
+  .masthead__inner-wrap {
+    align-items: flex-start;
+  }
+
+  .masthead__menu {
+    flex: 1 1 100%;
+  }
+
   .masthead__actions {
-    display: none;
+    display: flex;
+    flex: 1 1 100%;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding-top: 0.25rem;
+  }
+
+  .masthead__actions .toggle-button {
+    margin: 0;
   }
 
   .masthead__menu-item--toggle {
-    display: table-cell;
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the language/theme toggle buttons in the masthead actions tray on narrow viewports
- ensure the masthead actions wrap to their own row and align to the right on small screens
- hide the duplicate toggle buttons that were previously rendered inside the navigation menu when space is limited

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: missing gems due to 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d75f11e87c832dbc9ffd4745a0bcdd