### PR TITLE
Integrate masthead toggles into navigation flow

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -62,9 +62,5 @@
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
-    <div class="masthead__actions" role="presentation">
-      {{ language_toggle | strip }}
-      {{ theme_toggle | strip }}
-    </div>
   </div>
 </div>

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -48,6 +48,16 @@ html.theme-dark .greedy-nav .hidden-links a:hover {
   background: rgba(59, 130, 246, 0.2);
 }
 
+html.theme-dark .greedy-nav .hidden-links .masthead__menu-item--toggle .toggle-button {
+  color: #e2e8f0;
+}
+
+html.theme-dark .greedy-nav .hidden-links .masthead__menu-item--toggle .toggle-button:hover,
+html.theme-dark .greedy-nav .hidden-links .masthead__menu-item--toggle .toggle-button:focus-visible {
+  color: #bfdbfe;
+  background: rgba(59, 130, 246, 0.2);
+}
+
 html.theme-dark .page__content {
   color: inherit;
 }

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -57,14 +57,6 @@
   }
 }
 
-.masthead__actions {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 1.25rem;
-  color: $masthead-link-color;
-}
-
 .masthead__menu-home-item {
   @include breakpoint($medium) {
     display: block !important;
@@ -85,11 +77,14 @@
 
 
 .masthead__menu-item--toggle {
-  display: none;
+  display: table-cell;
   color: $masthead-link-color;
+  text-align: center;
+  vertical-align: middle;
 
   .toggle-button {
-    margin: 0 1rem;
+    margin: 0;
+    padding: 0.5rem 1rem;
   }
 }
 
@@ -153,10 +148,6 @@
   }
 }
 
-.masthead__actions .toggle-button {
-  margin: 0;
-}
-
 .toggle-icon {
   width: 100%;
   height: auto;
@@ -164,15 +155,6 @@
 
 html.theme-dark {
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
-
-  .masthead__actions {
-    color: #e2e8f0;
-  }
-
-  .masthead__actions .toggle-button:hover,
-  .masthead__actions .toggle-button:focus-visible {
-    color: #bfdbfe;
-  }
 
   .masthead__menu-item--toggle {
     color: #e2e8f0;
@@ -201,12 +183,12 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
 }
 
 @media (max-width: 640px) {
-  .masthead__actions {
-    display: none;
+  .masthead__inner-wrap {
+    align-items: flex-start;
   }
 
-  .masthead__menu-item--toggle {
-    display: table-cell;
+  .masthead__menu {
+    flex: 1 1 100%;
   }
 }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -271,6 +271,29 @@
       }
     }
 
+    .masthead__menu-item--toggle {
+      display: block;
+      border-bottom: 1px solid $border-color;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      .toggle-button {
+        width: 100%;
+        margin: 0;
+        padding: 10px 20px;
+        justify-content: flex-start;
+        text-align: left;
+
+        &:hover,
+        &:focus-visible {
+          color: $masthead-link-color-hover;
+          background: mix(#fff, $primary-color, 75%);
+        }
+      }
+    }
+
     &:before {
       content: "";
       position: absolute;


### PR DESCRIPTION
## Summary
- remove the separate masthead actions tray and render the language and theme toggles exclusively inside the greedy navigation list
- restyle the toggle buttons to share the navigation layout and ensure they collapse cleanly into the hidden menu on narrow viewports
- extend dark theme styling so toggle buttons remain legible in both the main navigation row and the hidden overflow menu

## Testing
- bundle exec jekyll build *(fails: bundler cannot find the `jekyll` executable without installing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d75f11e87c832dbc9ffd4745a0bcdd