### PR TITLE
Make masthead toggles responsive to screen width

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -62,9 +62,5 @@
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
-    <div class="masthead__actions" role="presentation">
-      {{ language_toggle | strip }}
-      {{ theme_toggle | strip }}
-    </div>
   </div>
 </div>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -57,14 +57,6 @@
   }
 }
 
-.masthead__actions {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 1.25rem;
-  color: $masthead-link-color;
-}
-
 .masthead__menu-home-item {
   @include breakpoint($medium) {
     display: block !important;
@@ -85,11 +77,10 @@
 
 
 .masthead__menu-item--toggle {
-  display: none;
   color: $masthead-link-color;
 
   .toggle-button {
-    margin: 0 1rem;
+    margin: 0 0.75rem;
   }
 }
 
@@ -153,10 +144,6 @@
   }
 }
 
-.masthead__actions .toggle-button {
-  margin: 0;
-}
-
 .toggle-icon {
   width: 100%;
   height: auto;
@@ -164,15 +151,6 @@
 
 html.theme-dark {
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
-
-  .masthead__actions {
-    color: #e2e8f0;
-  }
-
-  .masthead__actions .toggle-button:hover,
-  .masthead__actions .toggle-button:focus-visible {
-    color: #bfdbfe;
-  }
 
   .masthead__menu-item--toggle {
     color: #e2e8f0;
@@ -207,22 +185,6 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
 
   .masthead__menu {
     flex: 1 1 100%;
-  }
-
-  .masthead__actions {
-    display: flex;
-    flex: 1 1 100%;
-    justify-content: flex-end;
-    gap: 0.75rem;
-    padding-top: 0.25rem;
-  }
-
-  .masthead__actions .toggle-button {
-    margin: 0;
-  }
-
-  .masthead__menu-item--toggle {
-    display: none;
   }
 }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -304,6 +304,16 @@
       &:last-child {
         border-bottom: none;
       }
+
+      &.masthead__menu-item--toggle {
+        padding: 0;
+
+        .toggle-button {
+          width: 100%;
+          margin: 0;
+          justify-content: center;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- move the language and theme toggle buttons into the greedy navigation list so they follow the same responsive behavior as the menu links
- simplify masthead styling and adjust dark-mode hover states for the nav-based toggle buttons
- ensure toggle buttons render correctly when they are moved into the hidden dropdown menu on smaller viewports

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in the container)*
- `bundle install` *(fails: cannot download gems in this environment, receiving HTTP 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d764b62c34832db565918a886c8ed9