### PR TITLE
Adjust toggle button placement on small screens

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -212,9 +212,11 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
   .masthead__actions {
     display: flex;
     flex: 1 1 100%;
+    order: -1;
     justify-content: flex-end;
     gap: 0.75rem;
     padding-top: 0.25rem;
+    padding-right: clamp(0rem, 6vw, 3rem);
   }
 
   .masthead__actions .toggle-button {


### PR DESCRIPTION
## Summary
- reorder the masthead action buttons ahead of the navigation at narrow widths to keep them visible
- add responsive end padding so the buttons do not overlap the greedy navigation toggle

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d76fe6b2cc832db1af7b2e456fd1da