### PR TITLE
Enhance language toggle styling

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -8,17 +8,10 @@
       aria-label="Switch to Chinese"
       aria-pressed="false"
     >
-      <span
-        class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-en"
-        aria-hidden="true"
-      >
-        A
-      </span>
-      <span
-        class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-zh"
-        aria-hidden="true"
-      >
-        中
+      <span class="toggle-button__track" aria-hidden="true">
+        <span class="toggle-button__option toggle-button__option--en">EN</span>
+        <span class="toggle-button__option toggle-button__option--zh">中文</span>
+        <span class="toggle-button__thumb"></span>
       </span>
     </button>
     {% endcapture %}

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -6,6 +6,13 @@
   --masthead-toggle-icon-primary: #4d5258;
   --masthead-toggle-icon-secondary: #ffffff;
   --masthead-toggle-underline: #{mix(#fff, $primary-color, 50%)};
+  --language-toggle-track-bg: #{rgba(#2563eb, 0.12)};
+  --language-toggle-track-border: #{rgba(#2563eb, 0.35)};
+  --language-toggle-thumb-bg: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  --language-toggle-thumb-shadow: 0 10px 18px rgba(37, 99, 235, 0.22);
+  --language-toggle-thumb-shadow-active: 0 16px 32px rgba(37, 99, 235, 0.22);
+  --language-toggle-text-active: #0f172a;
+  --language-toggle-text-muted: #{rgba(#0f172a, 0.55)};
 }
 
 .masthead {
@@ -153,6 +160,81 @@
   }
 }
 
+.toggle-button--language {
+  padding: 0;
+  margin: 0;
+
+  &::after {
+    display: none;
+  }
+
+  .toggle-button__track {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+    min-width: 5.5rem;
+    height: 2.25rem;
+    padding: 0.35rem;
+    border-radius: 999px;
+    border: 1px solid var(--language-toggle-track-border);
+    background: var(--language-toggle-track-bg);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+    transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .toggle-button__option {
+    position: relative;
+    z-index: 1;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    text-align: center;
+    color: var(--language-toggle-text-muted);
+    transition: color 0.3s ease;
+  }
+
+  .toggle-button__option--zh {
+    font-size: 0.82rem;
+    letter-spacing: 0.025em;
+    text-transform: none;
+    font-family: inherit;
+  }
+
+  .toggle-button__thumb {
+    position: absolute;
+    top: 0.35rem;
+    bottom: 0.35rem;
+    left: 0.35rem;
+    width: calc(50% - 0.35rem);
+    border-radius: 999px;
+    background: var(--language-toggle-thumb-bg);
+    box-shadow: var(--language-toggle-thumb-shadow);
+    transform: translateX(0);
+    transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), background 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  &:hover .toggle-button__track,
+  &:focus-visible .toggle-button__track {
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25), 0 12px 24px rgba(37, 99, 235, 0.18);
+    border-color: transparent;
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toggle-button--language .toggle-button__track,
+  .toggle-button--language .toggle-button__thumb,
+  .toggle-button--language .toggle-button__option {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+  }
+}
+
 .masthead__actions .toggle-button {
   margin: 0;
 }
@@ -164,6 +246,13 @@
 
 html.theme-dark {
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
+  --language-toggle-track-bg: #{rgba(#94a3b8, 0.16)};
+  --language-toggle-track-border: #{rgba(#94a3b8, 0.35)};
+  --language-toggle-thumb-bg: linear-gradient(135deg, #38bdf8 0%, #818cf8 100%);
+  --language-toggle-thumb-shadow: 0 14px 28px rgba(15, 23, 42, 0.35);
+  --language-toggle-thumb-shadow-active: 0 18px 36px rgba(15, 23, 42, 0.45);
+  --language-toggle-text-active: #f8fafc;
+  --language-toggle-text-muted: #{rgba(#e2e8f0, 0.7)};
 
   .masthead__actions {
     color: #e2e8f0;
@@ -192,12 +281,21 @@ html.theme-dark .toggle-button--theme .toggle-button__icon--moon {
   display: none;
 }
 
-html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-zh {
-  display: none;
+html[data-language='zh'] .toggle-button--language .toggle-button__thumb {
+  transform: translateX(calc(100% + 0.35rem));
+  box-shadow: var(--language-toggle-thumb-shadow-active);
 }
 
-html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {
-  display: inline-flex;
+.toggle-button--language .toggle-button__option--en {
+  color: var(--language-toggle-text-active);
+}
+
+html[data-language='zh'] .toggle-button--language .toggle-button__option--en {
+  color: var(--language-toggle-text-muted);
+}
+
+html[data-language='zh'] .toggle-button--language .toggle-button__option--zh {
+  color: var(--language-toggle-text-active);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- restyle the masthead language toggle with a pill-shaped track, bilingual labels, and an animated thumb that reflects the active locale
- add SCSS variables, dark theme overrides, and reduced-motion fallbacks so the new control matches the site aesthetic in multiple states

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing in container)*
- bundle install *(fails: rubygems.org returned HTTP 403 when fetching gems in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d77d37c264832da255bd21f406e76e