### PR TITLE
Redesign theme toggle to match masthead styling

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -30,8 +30,48 @@
       aria-label="Switch to dark mode"
       aria-pressed="false"
     >
-      <span class="toggle-button__icon toggle-button__icon--sun" aria-hidden="true">☀️</span>
-      <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">🌙</span>
+      <span
+        class="toggle-button__icon toggle-button__icon--theme toggle-button__icon--sun"
+        aria-hidden="true"
+      >
+        <svg
+          class="toggle-icon"
+          viewBox="0 0 24 24"
+          role="presentation"
+          focusable="false"
+          aria-hidden="true"
+        >
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 3.25v1.5m0 14.5v1.5m8.25-8.25h-1.5m-14.5 0h-1.5m15.157-7.093-1.06 1.06M7.031 16.657l-1.06 1.06m12.726 0-1.06-1.06M7.031 7.03l-1.06-1.06M12 8.75a3.25 3.25 0 1 1 0 6.5 3.25 3.25 0 0 1 0-6.5Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="toggle-button__icon toggle-button__icon--theme toggle-button__icon--moon"
+        aria-hidden="true"
+      >
+        <svg
+          class="toggle-icon"
+          viewBox="0 0 24 24"
+          role="presentation"
+          focusable="false"
+          aria-hidden="true"
+        >
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 12.79A9 9 0 0 1 11.21 3 7.25 7.25 0 1 0 21 12.79Z"
+          />
+        </svg>
+      </span>
     </button>
     {% endcapture %}
     <div class="masthead__menu">

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -6,6 +6,23 @@
   --masthead-toggle-icon-primary: #4d5258;
   --masthead-toggle-icon-secondary: #ffffff;
   --masthead-toggle-underline: #{mix(#fff, $primary-color, 50%)};
+  --theme-toggle-track-bg: rgba($primary-color, 0.16);
+  --theme-toggle-inactive-bg: #{mix(#fff, $primary-color, 90%)};
+  --theme-toggle-icon-inactive: #{mix(#000, $primary-color, 60%)};
+  --theme-toggle-sun-active-bg: linear-gradient(
+    135deg,
+    #fde68a,
+    #f97316
+  );
+  --theme-toggle-sun-icon-color: #7c2d12;
+  --theme-toggle-moon-active-bg: linear-gradient(
+    135deg,
+    #334155,
+    #0f172a
+  );
+  --theme-toggle-moon-icon-color: #e2e8f0;
+  --theme-toggle-shadow-strong: 0 10px 22px rgba($primary-color, 0.28);
+  --theme-toggle-shadow-soft: 0 6px 14px rgba($primary-color, 0.16);
   --language-toggle-active-bg: linear-gradient(
     135deg,
     #{mix(#fff, $primary-color, 22%)},
@@ -222,6 +239,66 @@
   }
 }
 
+.toggle-button--theme {
+  width: 2.6rem;
+  height: 1.6rem;
+  padding: 0;
+  margin: 0 0.5rem;
+  overflow: visible;
+
+  &::after {
+    content: none;
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 0.65rem;
+    background: var(--theme-toggle-track-bg);
+    transform: translate3d(0.25rem, 0.25rem, 0);
+    transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
+      background 0.35s ease;
+    z-index: 0;
+  }
+
+  .toggle-button__icon--theme {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 0.65rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--theme-toggle-inactive-bg);
+    color: var(--theme-toggle-icon-inactive);
+    box-shadow: var(--theme-toggle-shadow-soft);
+    transform: translate3d(0.25rem, 0.25rem, -10px) scale(0.95);
+    transition: transform 0.35s cubic-bezier(0.33, 1, 0.68, 1),
+      background 0.3s ease,
+      color 0.3s ease,
+      box-shadow 0.35s ease;
+    pointer-events: none;
+    z-index: 1;
+
+    svg {
+      width: 1.15rem;
+      height: 1.15rem;
+    }
+  }
+
+  .toggle-button__icon--sun {
+    display: inline-flex;
+    background: var(--theme-toggle-sun-active-bg);
+    color: var(--theme-toggle-sun-icon-color);
+    box-shadow: var(--theme-toggle-shadow-strong);
+    transform: translate3d(-0.15rem, -0.15rem, 0);
+    z-index: 2;
+  }
+}
+
 .masthead__actions .toggle-button {
   margin: 0;
 }
@@ -233,6 +310,18 @@
 
 html.theme-dark {
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
+  --theme-toggle-track-bg: rgba(148, 163, 184, 0.28);
+  --theme-toggle-inactive-bg: #{mix(#000, $primary-color, 65%)};
+  --theme-toggle-icon-inactive: #{mix(#fff, $primary-color, 70%)};
+  --theme-toggle-sun-icon-color: #fde68a;
+  --theme-toggle-moon-active-bg: linear-gradient(
+    135deg,
+    #{mix(#fff, $primary-color, 18%)},
+    #0b1220
+  );
+  --theme-toggle-moon-icon-color: #f1f5f9;
+  --theme-toggle-shadow-strong: 0 12px 26px rgba(15, 23, 42, 0.48);
+  --theme-toggle-shadow-soft: 0 8px 18px rgba(15, 23, 42, 0.3);
   --language-toggle-active-bg: linear-gradient(
     135deg,
     #{mix(#fff, $primary-color, 12%)},
@@ -265,14 +354,22 @@ html.theme-dark {
   .toggle-button--language::before {
     background: rgba(148, 163, 184, 0.28);
   }
-}
 
-html.theme-dark .toggle-button--theme .toggle-button__icon--sun {
-  display: inline-flex;
-}
+  .toggle-button--theme .toggle-button__icon--sun {
+    background: var(--theme-toggle-inactive-bg);
+    color: var(--theme-toggle-icon-inactive);
+    box-shadow: var(--theme-toggle-shadow-soft);
+    transform: translate3d(0.25rem, 0.25rem, -10px) scale(0.95);
+    z-index: 1;
+  }
 
-html.theme-dark .toggle-button--theme .toggle-button__icon--moon {
-  display: none;
+  .toggle-button--theme .toggle-button__icon--moon {
+    background: var(--theme-toggle-moon-active-bg);
+    color: var(--theme-toggle-moon-icon-color);
+    box-shadow: var(--theme-toggle-shadow-strong);
+    transform: translate3d(-0.15rem, -0.15rem, 0);
+    z-index: 2;
+  }
 }
 
 html[data-language='zh'] .toggle-button--language .toggle-button__icon--language-en {


### PR DESCRIPTION
## Summary
- replace the emoji-based theme toggle with custom sun and moon SVG icons similar to the language switcher
- add masthead SCSS variables and styling so the theme toggle has a consistent pill layout and dark-mode transitions

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll; bundler install blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d7909af7ec832d81b25b8a536ebd61