### PR TITLE
Match theme toggle background to language toggle

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -7,20 +7,12 @@
   --masthead-toggle-icon-secondary: #ffffff;
   --masthead-toggle-underline: #{mix(#fff, $primary-color, 50%)};
   --theme-toggle-track-bg: rgba($primary-color, 0.16);
-  --theme-toggle-inactive-bg: #{mix(#fff, $primary-color, 90%)};
-  --theme-toggle-icon-inactive: #{mix(#000, $primary-color, 60%)};
-  --theme-toggle-sun-active-bg: linear-gradient(
-    135deg,
-    #fde68a,
-    #f97316
-  );
-  --theme-toggle-sun-icon-color: #7c2d12;
-  --theme-toggle-moon-active-bg: linear-gradient(
-    135deg,
-    #334155,
-    #0f172a
-  );
-  --theme-toggle-moon-icon-color: #e2e8f0;
+  --theme-toggle-inactive-bg: var(--language-toggle-inactive-bg);
+  --theme-toggle-icon-inactive: var(--language-toggle-text-inactive);
+  --theme-toggle-sun-active-bg: var(--language-toggle-active-bg);
+  --theme-toggle-sun-icon-color: var(--language-toggle-text-active);
+  --theme-toggle-moon-active-bg: var(--language-toggle-active-bg);
+  --theme-toggle-moon-icon-color: var(--language-toggle-text-active);
   --theme-toggle-shadow-strong: 0 10px 22px rgba($primary-color, 0.28);
   --theme-toggle-shadow-soft: 0 6px 14px rgba($primary-color, 0.16);
   --language-toggle-active-bg: linear-gradient(
@@ -309,17 +301,17 @@
 }
 
 html.theme-dark {
+  .toggle-button--theme::before {
+    transform: translate3d(-0.15rem, -0.15rem, 0);
+  }
+
   --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
   --theme-toggle-track-bg: rgba(148, 163, 184, 0.28);
-  --theme-toggle-inactive-bg: #{mix(#000, $primary-color, 65%)};
-  --theme-toggle-icon-inactive: #{mix(#fff, $primary-color, 70%)};
-  --theme-toggle-sun-icon-color: #fde68a;
-  --theme-toggle-moon-active-bg: linear-gradient(
-    135deg,
-    #{mix(#fff, $primary-color, 18%)},
-    #0b1220
-  );
-  --theme-toggle-moon-icon-color: #f1f5f9;
+  --theme-toggle-inactive-bg: var(--language-toggle-inactive-bg);
+  --theme-toggle-icon-inactive: var(--language-toggle-text-inactive);
+  --theme-toggle-sun-icon-color: var(--language-toggle-text-inactive);
+  --theme-toggle-moon-active-bg: var(--language-toggle-active-bg);
+  --theme-toggle-moon-icon-color: var(--language-toggle-text-active);
   --theme-toggle-shadow-strong: 0 12px 26px rgba(15, 23, 42, 0.48);
   --theme-toggle-shadow-soft: 0 8px 18px rgba(15, 23, 42, 0.3);
   --language-toggle-active-bg: linear-gradient(
@@ -389,6 +381,8 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .toggle-button--theme::before,
+  .toggle-button--theme .toggle-button__icon--theme,
   .toggle-button--language::before,
   .toggle-button--language .toggle-button__icon--language {
     transition: none;


### PR DESCRIPTION
## Summary
- reuse the language toggle color variables for the theme toggle backgrounds so both toggles share the same styling

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d794976ff8832dbea4db7c92d79d31