### PR TITLE
Remove drop-shadow panels from call-to-action buttons

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -135,17 +135,15 @@
       background: var(--theme-toggle-sun-active-bg);
       color: var(--theme-toggle-sun-icon-color) !important;
       border-color: transparent !important;
-      box-shadow: var(--theme-toggle-shadow-strong);
       transform: translateY(0);
       transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease,
-        box-shadow 0.35s ease, transform 0.2s ease;
+        transform 0.2s ease;
     }
 
     .btn:hover {
       background: var(--theme-toggle-inactive-bg);
       color: var(--theme-toggle-icon-inactive) !important;
       border-color: transparent !important;
-      box-shadow: var(--theme-toggle-shadow-soft);
       transform: translateY(-1px);
       text-decoration: none;
     }
@@ -154,7 +152,6 @@
       background: var(--theme-toggle-inactive-bg);
       color: var(--theme-toggle-icon-inactive) !important;
       border-color: transparent !important;
-      box-shadow: var(--theme-toggle-shadow-soft);
       transform: translateY(0);
     }
 


### PR DESCRIPTION
## Summary
- remove the box-shadow styling from the news action buttons so only the top panel remains visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e322bc38832dab8b73b46f7654fc