### PR TITLE
Ensure language toggle shows in greedy nav dropdown

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -61,6 +61,16 @@
       z-index: 10;
     }
 
+    @media (min-width: 641px) {
+      flex-wrap: nowrap;
+
+      nav {
+        width: auto;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+    }
+
     a {
       text-decoration: none;
     }
@@ -85,6 +95,13 @@
   align-items: center;
   gap: 1.25rem;
   color: $masthead-link-color;
+  margin-left: auto;
+  white-space: nowrap;
+
+  @media (min-width: 641px) {
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
 }
 
 .masthead__menu-home-item {
@@ -112,6 +129,21 @@
 
   .toggle-button {
     margin: 0 1rem;
+  }
+}
+
+#site-nav button:not(.hidden) ~ .hidden-links .masthead__menu-item--toggle {
+  display: block;
+  padding: 0;
+  text-align: center;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .toggle-button {
+    width: 100%;
+    margin: 0;
   }
 }
 
@@ -296,6 +328,7 @@
 
 .masthead__actions .toggle-button {
   margin: 0;
+  flex-shrink: 0;
 }
 
 .toggle-icon {
@@ -398,16 +431,22 @@ html[data-language='zh'] .toggle-button--language .toggle-button__icon--language
     display: none;
   }
 
-  .masthead__menu-item--toggle {
-    display: table-cell;
-    text-align: right;
+  .greedy-nav {
+    .visible-links .masthead__menu-item--toggle {
+      display: table-cell;
+      text-align: right;
+    }
+
+    .hidden-links .masthead__menu-item--toggle {
+      display: block;
+    }
   }
 
   .masthead__menu-item--toggle .toggle-button {
     margin: 0;
   }
 
-  .masthead__menu-item--toggle + .masthead__menu-item--toggle {
+  .greedy-nav .visible-links .masthead__menu-item--toggle + .masthead__menu-item--toggle {
     padding-left: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- allow the greedy-nav dropdown to display toggle menu items whenever the overflow button is shown
- share the full-width styling so the language control stays visible alongside the theme toggle

## Testing
- bundle exec jekyll build *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_68d806717280832d80f594d55d776dc2