### PR TITLE
Refine author profile map layout

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -3,19 +3,19 @@
 {% endif %}
 
 <div itemscope itemtype="http://schema.org/Person" class="profile_box">
+  <div class="profile_box__info">
+    <div class="author__avatar">
+      <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
+    </div>
 
-  <div class="author__avatar">
-    <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
-  </div>
+    <div class="author__content">
+      <h3 class="author__name">{{ author.name }}</h3>
+      {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
+    </div>
 
-  <div class="author__content">
-    <h3 class="author__name">{{ author.name }}</h3>
-    {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
-  </div>
-
-  <div class="author__urls-wrapper">
-    <!-- <button class="btn btn--inverse">More Info & Contact</button> -->
-    <ul class="author__urls social-icons">
+    <div class="author__urls-wrapper">
+      <!-- <button class="btn btn--inverse">More Info & Contact</button> -->
+      <ul class="author__urls social-icons">
       {% if site.description %}
         <li><div style="white-space: normal; margin-bottom: 1em;">{{ site.description }}</div></li>
       {% endif %}
@@ -117,45 +117,8 @@
       {% endif %}
       {% if author.wikipedia %}
         <li><a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i> Wikipedia</a></li>
-{% endif %}
-    </ul>
-    <div class="author__maps">
-      <div class="author__map author__map--visitors">
-        <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
-      </div>
-      {% if site.google_maps %}
-        <div class="author__map author__map--location">
-          {% if site.google_maps.api_key %}
-            {% assign map_lat = site.google_maps.location.lat | default: 0 %}
-            {% assign map_lng = site.google_maps.location.lng | default: 0 %}
-            {% assign map_zoom = site.google_maps.zoom | default: 14 %}
-            {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
-            {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-            <div
-              class="author-location-map author-location-map--showing-fallback"
-              data-author-map
-              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-              data-lat="{{ map_lat }}"
-              data-lng="{{ map_lng }}"
-              data-zoom="{{ map_zoom }}"
-              data-marker-title="{{ map_title | escape }}"
-              aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
-              <iframe
-                class="author-location-map__fallback"
-                data-author-map-fallback
-                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-                title="{{ map_title | escape }}"
-                loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade"
-                allowfullscreen>
-              </iframe>
-            </div>
-          {% else %}
-            <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
-          {% endif %}
-        </div>
       {% endif %}
-    </div>
+    </ul>
     <div class="author__urls_sm">
       {% if author.uri %}
         <a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i></a>
@@ -249,6 +212,46 @@
       {% endif %}
       {% if author.wikipedia %}
         <a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i></a>
+      {% endif %}
+    </div>
+    </div>
+  </div>
+  <div class="profile_box__maps">
+    <div class="author__maps">
+      <div class="author__map author__map--visitors">
+        <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
+      </div>
+      {% if site.google_maps %}
+        <div class="author__map author__map--location">
+          {% if site.google_maps.api_key %}
+            {% assign map_lat = site.google_maps.location.lat | default: 0 %}
+            {% assign map_lng = site.google_maps.location.lng | default: 0 %}
+            {% assign map_zoom = site.google_maps.zoom | default: 14 %}
+            {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
+            {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
+            <div
+              class="author-location-map author-location-map--showing-fallback"
+              data-author-map
+              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+              data-lat="{{ map_lat }}"
+              data-lng="{{ map_lng }}"
+              data-zoom="{{ map_zoom }}"
+              data-marker-title="{{ map_title | escape }}"
+              aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
+              <iframe
+                class="author-location-map__fallback"
+                data-author-map-fallback
+                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+                title="{{ map_title | escape }}"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                allowfullscreen>
+              </iframe>
+            </div>
+          {% else %}
+            <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
+          {% endif %}
+        </div>
       {% endif %}
     </div>
   </div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -155,3 +155,5 @@ Explore the full list of publications on the [Publications](/publications/) page
 - [How to write rebuttals](https://deviparikh.medium.com/how-we-write-rebuttals-dc84742fece1/)
 - [How to write introduction](http://www-net.cs.umass.edu/kurose/writing/intro-style.html)
 - [Emojipedia](https://emojipedia.org/)
+
+<div class="homepage-author-maps-target"></div>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -68,14 +68,48 @@
 /*
    Author profile and links
    ========================================================================== */
-.profile_box{
-  @include breakpoint($large) {
-    display: block;
-  }
+.profile_box {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+.profile_box__info {
   display: flex;
   justify-content: flex-start;
   align-content: flex-start;
   align-items: center;
+  gap: 1em;
+  flex-wrap: wrap;
+
+  @include breakpoint($large) {
+    display: block;
+  }
+}
+
+.profile_box__maps {
+  display: none;
+
+  @include breakpoint($large) {
+    display: block;
+  }
+}
+
+.profile_box__maps--mobile {
+  display: block;
+}
+
+.homepage-author-maps-target {
+  display: none;
+  margin-top: 2em;
+}
+
+.homepage-author-maps-target--visible {
+  display: block;
+}
+
+.homepage-author-maps-target .author__maps {
+  margin-top: 0;
 }
 
 .author__avatar {
@@ -273,12 +307,13 @@
   margin-top: 1em;
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 0.75em;
 }
 
 .author__map {
-  flex: 1 1 0;
+  flex: 1 1 calc(50% - 0.375em);
+  min-width: 0;
 
   iframe {
     width: 100%;
@@ -317,8 +352,17 @@
 }
 
 @include breakpoint($large) {
+  .profile_box {
+    gap: 2em;
+  }
+
   .author__maps {
     flex-direction: column;
+    flex-wrap: nowrap;
+  }
+
+  .author__map {
+    flex: 1 1 100%;
   }
 
   .author-location-map {

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -1,6 +1,57 @@
 (function () {
   'use strict';
 
+  var MAP_BREAKPOINT = 925;
+  var MAP_WRAPPER_SELECTOR = '.profile_box__maps';
+  var PROFILE_BOX_SELECTOR = '.profile_box';
+  var HOMEPAGE_TARGET_SELECTOR = '.homepage-author-maps-target';
+  var MOBILE_WRAPPER_CLASS = 'profile_box__maps--mobile';
+  var HOMEPAGE_VISIBLE_CLASS = 'homepage-author-maps-target--visible';
+
+  function getMapWrapper() {
+    return document.querySelector(MAP_WRAPPER_SELECTOR);
+  }
+
+  function getSidebarContainer() {
+    return document.querySelector(PROFILE_BOX_SELECTOR);
+  }
+
+  function getHomepageTarget() {
+    return document.querySelector(HOMEPAGE_TARGET_SELECTOR);
+  }
+
+  function shouldUseHomepageTarget(homepageTarget) {
+    return Boolean(homepageTarget) && window.innerWidth < MAP_BREAKPOINT;
+  }
+
+  function relocateMaps() {
+    var wrapper = getMapWrapper();
+    if (!wrapper) {
+      return;
+    }
+
+    var homepageTarget = getHomepageTarget();
+    var useHomepage = shouldUseHomepageTarget(homepageTarget);
+
+    if (useHomepage) {
+      if (!homepageTarget.contains(wrapper)) {
+        homepageTarget.appendChild(wrapper);
+      }
+      wrapper.classList.add(MOBILE_WRAPPER_CLASS);
+      homepageTarget.classList.add(HOMEPAGE_VISIBLE_CLASS);
+      return;
+    }
+
+    var sidebarContainer = getSidebarContainer();
+    if (sidebarContainer && !sidebarContainer.contains(wrapper)) {
+      sidebarContainer.appendChild(wrapper);
+    }
+    wrapper.classList.remove(MOBILE_WRAPPER_CLASS);
+    if (homepageTarget) {
+      homepageTarget.classList.remove(HOMEPAGE_VISIBLE_CLASS);
+    }
+  }
+
   function getFallback(mapContainer) {
     if (!mapContainer) {
       return null;
@@ -144,6 +195,7 @@
   }
 
   function init() {
+    relocateMaps();
     var mapContainer = document.querySelector('[data-author-map]');
     if (!mapContainer) {
       return;
@@ -195,8 +247,14 @@
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('DOMContentLoaded', function () {
+      init();
+      window.addEventListener('resize', relocateMaps);
+      window.addEventListener('orientationchange', relocateMaps);
+    });
   } else {
     init();
+    window.addEventListener('resize', relocateMaps);
+    window.addEventListener('orientationchange', relocateMaps);
   }
 })();


### PR DESCRIPTION
## Summary
- wrap the author profile into info and map sections so contact details and map widgets can be handled independently
- add a homepage map anchor and responsive styles plus JavaScript to move the maps to the main content on small screens
- ensure the map panels display side-by-side on narrow viewports and vertically on wide displays

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c2bf6d04832dac4326cfcd697733