### PR TITLE
Add responsive sticky map sidebar

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -119,43 +119,6 @@
         <li><a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i> Wikipedia</a></li>
 {% endif %}
     </ul>
-    <div class="author__maps">
-      <div class="author__map author__map--visitors">
-        <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
-      </div>
-      {% if site.google_maps %}
-        <div class="author__map author__map--location">
-          {% if site.google_maps.api_key %}
-            {% assign map_lat = site.google_maps.location.lat | default: 0 %}
-            {% assign map_lng = site.google_maps.location.lng | default: 0 %}
-            {% assign map_zoom = site.google_maps.zoom | default: 14 %}
-            {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
-            {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-            <div
-              class="author-location-map author-location-map--showing-fallback"
-              data-author-map
-              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-              data-lat="{{ map_lat }}"
-              data-lng="{{ map_lng }}"
-              data-zoom="{{ map_zoom }}"
-              data-marker-title="{{ map_title | escape }}"
-              aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
-              <iframe
-                class="author-location-map__fallback"
-                data-author-map-fallback
-                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-                title="{{ map_title | escape }}"
-                loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade"
-                allowfullscreen>
-              </iframe>
-            </div>
-          {% else %}
-            <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
-          {% endif %}
-        </div>
-      {% endif %}
-    </div>
     <div class="author__urls_sm">
       {% if author.uri %}
         <a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i></a>
@@ -251,5 +214,45 @@
         <a href="https://en.wikipedia.org/wiki/User:{{ author.wikipedia }}"><i class="fab fa-fw fa-wikipedia-w" aria-hidden="true"></i></a>
       {% endif %}
     </div>
+  </div>
+</div>
+
+<div class="author__map-sidebar">
+  <div class="author__maps">
+    <div class="author__map author__map--visitors">
+      <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
+    </div>
+    {% if site.google_maps %}
+      <div class="author__map author__map--location">
+        {% if site.google_maps.api_key %}
+          {% assign map_lat = site.google_maps.location.lat | default: 0 %}
+          {% assign map_lng = site.google_maps.location.lng | default: 0 %}
+          {% assign map_zoom = site.google_maps.zoom | default: 14 %}
+          {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
+          {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
+          <div
+            class="author-location-map author-location-map--showing-fallback"
+            data-author-map
+            data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+            data-lat="{{ map_lat }}"
+            data-lng="{{ map_lng }}"
+            data-zoom="{{ map_zoom }}"
+            data-marker-title="{{ map_title | escape }}"
+            aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
+            <iframe
+              class="author-location-map__fallback"
+              data-author-map-fallback
+              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+              title="{{ map_title | escape }}"
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+              allowfullscreen>
+            </iframe>
+          </div>
+        {% else %}
+          <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
+        {% endif %}
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -269,16 +269,27 @@
   }
 }
 
+.author__map-sidebar {
+  margin-top: 1.5em;
+}
+
 .author__maps {
-  margin-top: 1em;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   gap: 0.75em;
+  align-items: stretch;
 }
 
 .author__map {
   flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+
+  > * {
+    flex: 1 1 auto;
+  }
 
   iframe {
     width: 100%;
@@ -319,6 +330,18 @@
 @include breakpoint($large) {
   .author__maps {
     flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+  }
+
+  .author__map-sidebar {
+    position: sticky;
+    top: 1.5rem;
+  }
+
+  .author__map {
+    width: 100%;
+    min-height: 220px;
   }
 
   .author-location-map {


### PR DESCRIPTION
## Summary
- move the author map widgets to a dedicated sidebar container positioned under the profile block
- update sidebar styles so the maps align horizontally on small screens and stack with sticky positioning on large screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d57c5078832d861d3157ea1fcec9