### PR TITLE
Hide sidebar maps on narrow screens for key pages

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -218,7 +218,7 @@
 </div>
 
 <div class="author__map-sidebar">
-  <div class="author__maps">
+  <div class="author__maps{% if page.hide_author_maps_on_mobile %} author__maps--mobile-hidden{% endif %}">
     <div class="author__map author__map--visitors">
       <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
     </div>

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -3,6 +3,7 @@ layout: default
 permalink: /awards/
 title: ""
 author_profile: true
+hide_author_maps_on_mobile: true
 ---
 
 <span class='anchor' id='-awards'></span>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -3,6 +3,7 @@ layout: default
 permalink: /news/
 title: "News"
 author_profile: true
+hide_author_maps_on_mobile: true
 ---
 
 {% include_relative includes/news.md %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -3,6 +3,7 @@ layout: default
 permalink: /publications/
 title: ""
 author_profile: true
+hide_author_maps_on_mobile: true
 ---
 
 <span class='anchor' id='-publications'></span>

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -3,6 +3,7 @@ layout: default
 permalink: /services/
 title: ""
 author_profile: true
+hide_author_maps_on_mobile: true
 ---
 
 <span class='anchor' id='-professional-services'></span>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -281,6 +281,12 @@
   align-items: stretch;
 }
 
+.author__maps--mobile-hidden {
+  @include breakpoint(max-width $medium) {
+    display: none;
+  }
+}
+
 .author__map {
   flex: 1 1 0;
   display: flex;


### PR DESCRIPTION
## Summary
- add a front matter flag to the publications, news, awards, and services pages so the author maps can be hidden on small screens
- add a conditional class in the author profile include to respect the new flag
- extend the sidebar styles to hide the author maps below the medium breakpoint when the flag is set

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in the environment)*
- bundle install *(fails: rubygems.org returned HTTP 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d8dab26d4c832d9913c839ca1f8187