### PR TITLE
Adjust mobile placement of author maps

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,6 +4,7 @@
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/map-placement.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -287,7 +287,7 @@
   }
 }
 
-.author__map {
+.author__map { 
   flex: 1 1 0;
   display: flex;
   flex-direction: column;
@@ -299,6 +299,20 @@
 
   iframe {
     width: 100%;
+  }
+}
+
+.author__map-sidebar--after-content {
+  @include breakpoint(max-width $medium) {
+    margin-top: 2em;
+
+    .author__maps {
+      flex-direction: column;
+    }
+
+    .author__map {
+      min-height: 220px;
+    }
   }
 }
 

--- a/assets/js/map-placement.js
+++ b/assets/js/map-placement.js
@@ -1,0 +1,91 @@
+(function () {
+  var excludedPaths = ['/publications/', '/news/', '/awards/', '/services/'];
+
+  function normalizePath(path) {
+    if (!path) {
+      return '/';
+    }
+
+    var hashIndex = path.indexOf('#');
+    if (hashIndex !== -1) {
+      path = path.slice(0, hashIndex);
+    }
+
+    var queryIndex = path.indexOf('?');
+    if (queryIndex !== -1) {
+      path = path.slice(0, queryIndex);
+    }
+
+    if (path.length > 1 && path.slice(-1) !== '/') {
+      path += '/';
+    }
+
+    return path;
+  }
+
+  var currentPath = normalizePath(window.location.pathname);
+
+  if (excludedPaths.indexOf(currentPath) !== -1) {
+    return;
+  }
+
+  function onReady(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  onReady(function () {
+    var mapSidebar = document.querySelector('.sidebar .author__map-sidebar');
+    if (!mapSidebar) {
+      return;
+    }
+
+    var sidebar = document.querySelector('.sidebar');
+    var pageContent = document.querySelector('.page__inner-wrap .page__content');
+    if (!sidebar || !pageContent || !mapSidebar.parentNode) {
+      return;
+    }
+
+    var placeholder = document.createElement('div');
+    placeholder.className = 'author__map-sidebar-placeholder';
+    placeholder.style.display = 'none';
+    mapSidebar.parentNode.insertBefore(placeholder, mapSidebar);
+
+    var matchMediaQuery = window.matchMedia('(max-width: 768px)');
+
+    function moveMapAfterContent() {
+      if (!pageContent || !mapSidebar) {
+        return;
+      }
+      pageContent.insertAdjacentElement('afterend', mapSidebar);
+      mapSidebar.classList.add('author__map-sidebar--after-content');
+    }
+
+    function moveMapBackToSidebar() {
+      if (!placeholder.parentNode) {
+        return;
+      }
+      placeholder.parentNode.insertBefore(mapSidebar, placeholder.nextSibling);
+      mapSidebar.classList.remove('author__map-sidebar--after-content');
+    }
+
+    function applyPlacement(e) {
+      if (e.matches) {
+        moveMapAfterContent();
+      } else {
+        moveMapBackToSidebar();
+      }
+    }
+
+    applyPlacement(matchMediaQuery);
+
+    if (typeof matchMediaQuery.addEventListener === 'function') {
+      matchMediaQuery.addEventListener('change', applyPlacement);
+    } else if (typeof matchMediaQuery.addListener === 'function') {
+      matchMediaQuery.addListener(applyPlacement);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a small-screen script that moves the sidebar map section after the main content except on key listing pages
- update sidebar styles so relocated maps stack vertically and retain comfortable spacing on narrow viewports
- load the new placement script site-wide

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e2c0d7a8832d98680b5131f1689a