### PR TITLE
Adjust author maps placement for scroll windows

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,6 +4,7 @@
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/map-placement.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -273,6 +273,10 @@
   margin-top: 1.5em;
 }
 
+.author__map-sidebar--after-content {
+  margin-top: 2em;
+}
+
 .author__maps {
   display: flex;
   flex-direction: row;
@@ -343,6 +347,11 @@
   .author__map-sidebar {
     position: sticky;
     top: 1.5rem;
+  }
+
+  .author__map-sidebar.author__map-sidebar--after-content {
+    position: static;
+    top: auto;
   }
 
   .author__map {

--- a/assets/js/map-placement.js
+++ b/assets/js/map-placement.js
@@ -1,0 +1,79 @@
+(function () {
+  'use strict';
+
+  var EXCLUDED_SLUGS = ['publications', 'news', 'awards', 'services'];
+
+  function getPathSegments(path) {
+    if (!path) {
+      return [];
+    }
+
+    var cleaned = path.split('?')[0].split('#')[0];
+    if (cleaned.length > 1 && cleaned.charAt(cleaned.length - 1) === '/') {
+      cleaned = cleaned.slice(0, -1);
+    }
+
+    return cleaned
+      .split('/')
+      .map(function (segment) {
+        return segment.trim();
+      })
+      .filter(function (segment) {
+        return Boolean(segment);
+      });
+  }
+
+  function shouldSkipPage() {
+    var segments = getPathSegments(window.location.pathname || '');
+    if (!segments.length) {
+      return false;
+    }
+
+    var lastSegment = segments[segments.length - 1];
+    return EXCLUDED_SLUGS.indexOf(lastSegment) !== -1;
+  }
+
+  function hasScrollWindow() {
+    return Boolean(
+      document.querySelector('[data-news-window].news-window--scroll') ||
+        document.querySelector('.news-window--scroll')
+    );
+  }
+
+  function moveMapsAfterContent() {
+    var mapSidebar = document.querySelector('.sidebar .author__map-sidebar');
+    if (!mapSidebar) {
+      return;
+    }
+
+    var content = document.querySelector('.page__content');
+    if (!content) {
+      return;
+    }
+
+    if (mapSidebar.parentElement === content) {
+      return;
+    }
+
+    content.appendChild(mapSidebar);
+    mapSidebar.classList.add('author__map-sidebar--after-content');
+  }
+
+  function init() {
+    if (shouldSkipPage()) {
+      return;
+    }
+
+    if (!hasScrollWindow()) {
+      return;
+    }
+
+    moveMapsAfterContent();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a client-side helper that relocates the author map block below the article when a scroll window is active, skipping the specified sections
- update sidebar styles so the relocated map is spaced correctly and no longer sticky after being moved
- load the new helper alongside the existing page scripts

## Testing
- not run (bundle install fails: `Gem::Net::HTTPClientException 403 "Forbidden"`)


------
https://chatgpt.com/codex/tasks/task_e_68d8ebff94cc832d8c8c63e2823b6c5a