### PR TITLE
Refine mobile map relocation behavior

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,6 +4,7 @@
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/map-reorder.js' | relative_url }}"></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -273,6 +273,19 @@
   margin-top: 1.5em;
 }
 
+.author__map-sidebar--inline {
+  margin-top: 2em;
+
+  .author__maps {
+    flex-direction: column;
+    gap: 1em;
+  }
+
+  .author__map {
+    width: 100%;
+  }
+}
+
 .author__maps {
   display: flex;
   flex-direction: row;

--- a/assets/js/map-reorder.js
+++ b/assets/js/map-reorder.js
@@ -1,0 +1,83 @@
+(function () {
+  'use strict';
+
+  var BREAKPOINT_MAX = '(max-width: 924px)';
+
+  function onReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback);
+    } else {
+      callback();
+    }
+  }
+
+  onReady(function () {
+    var mapSidebar = document.querySelector('.author__map-sidebar');
+    if (!mapSidebar) {
+      return;
+    }
+
+    var mapsContainer = mapSidebar.querySelector('.author__maps');
+    if (mapsContainer && mapsContainer.classList.contains('author__maps--mobile-hidden')) {
+      return;
+    }
+
+    var sidebar = mapSidebar.closest('.sidebar');
+    var main = document.getElementById('main');
+    if (!sidebar || !main) {
+      return;
+    }
+
+    var article = main.querySelector('article.page');
+    if (!article) {
+      return;
+    }
+
+    var pageInner = article.querySelector('.page__inner-wrap') || article;
+
+    var placeholder = document.createComment('author__map-sidebar placeholder');
+    if (mapSidebar.parentNode) {
+      mapSidebar.parentNode.insertBefore(placeholder, mapSidebar);
+    }
+
+    var mediaQuery = window.matchMedia ? window.matchMedia(BREAKPOINT_MAX) : null;
+
+    function shouldMoveToContent() {
+      return mediaQuery ? mediaQuery.matches : window.innerWidth <= 924;
+    }
+
+    function moveToContent() {
+      if (mapSidebar.parentNode !== pageInner) {
+        pageInner.appendChild(mapSidebar);
+      }
+      mapSidebar.classList.add('author__map-sidebar--inline');
+    }
+
+    function moveToSidebar() {
+      if (placeholder.parentNode && mapSidebar.parentNode !== placeholder.parentNode) {
+        placeholder.parentNode.insertBefore(mapSidebar, placeholder);
+      }
+      mapSidebar.classList.remove('author__map-sidebar--inline');
+    }
+
+    function updatePlacement() {
+      if (shouldMoveToContent()) {
+        moveToContent();
+      } else {
+        moveToSidebar();
+      }
+    }
+
+    updatePlacement();
+
+    if (mediaQuery) {
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', updatePlacement);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(updatePlacement);
+      }
+    } else {
+      window.addEventListener('resize', updatePlacement);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- update the map relocation helper to follow the site’s 925px breakpoint via matchMedia instead of relying on computed floats
- skip relocation on pages that already hide the author maps for mobile layouts while preserving the existing inline styling

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f5234bb4832dbda10f364170075d