### PR TITLE
Adjust inline author map layout for mobile viewports

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -275,14 +275,16 @@
 
 .author__map-sidebar--inline {
   margin-top: 2em;
+  width: 100%;
 
   .author__maps {
-    flex-direction: column;
+    width: 100%;
     gap: 1em;
   }
 
   .author__map {
-    width: 100%;
+    flex: 1 1 0;
+    min-width: 0;
   }
 }
 
@@ -305,13 +307,16 @@
   display: flex;
   flex-direction: column;
   min-height: 200px;
+  min-width: 0;
 
   > * {
     flex: 1 1 auto;
+    min-height: 0;
   }
 
   iframe {
     width: 100%;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the author map sidebar full-width when moved into the page content on narrow viewports
- ensure both map tiles remain horizontally aligned and stretch to equal heights

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d928fec364832d8d35751ab5ebfc4a