### PR TITLE
Improve author map layout responsiveness

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -291,9 +291,10 @@
 .author__maps {
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
-  gap: 0.75em;
+  flex-wrap: wrap;
+  gap: 1em;
   align-items: stretch;
+  justify-content: center;
 }
 
 .author__maps--mobile-hidden {
@@ -303,11 +304,11 @@
 }
 
 .author__map {
-  flex: 1 1 0;
+  flex: 1 1 280px;
   display: flex;
   flex-direction: column;
-  min-height: 200px;
   min-width: 0;
+  height: clamp(220px, 45vw, 320px);
 
   > * {
     flex: 1 1 auto;
@@ -326,7 +327,8 @@
 
 .author-location-map {
   width: 100%;
-  height: 200px;
+  height: 100%;
+  min-height: clamp(200px, 45vw, 320px);
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -356,6 +358,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
+    gap: 1.25em;
   }
 
   .author__map-sidebar {
@@ -365,11 +368,7 @@
 
   .author__map {
     width: 100%;
-    min-height: 220px;
-  }
-
-  .author-location-map {
-    height: 220px;
+    height: clamp(240px, 40vh, 360px);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust author map container spacing for better separation and centering
- scale map heights with responsive clamp values to adapt to viewport sizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d940508ab0832da872bf73e7d885a4