### PR TITLE
Fix author sidebar employer icon and text wrapping

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -30,14 +30,19 @@
         </li>
       {% endif %}
       {% if author.location or author.location_zh %}
-        <li>
+        <li class="author__item author__item--location">
           <i class="fa fa-fw fa-map-marker" aria-hidden="true"></i>
-          {% if author.location %}<span data-lang="en">{{ author.location }}</span>{% endif %}
-          {% if author.location_zh %}<span data-lang="zh"{% if author.location %} hidden{% endif %}>{{ author.location_zh }}</span>{% endif %}
+          <div class="author__item-text">
+            {% if author.location %}<span data-lang="en">{{ author.location }}</span>{% endif %}
+            {% if author.location_zh %}<span data-lang="zh"{% if author.location %} hidden{% endif %}>{{ author.location_zh }}</span>{% endif %}
+          </div>
         </li>
       {% endif %}
       {% if author.employer %}
-        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ author.employer }}</li>
+        <li class="author__item author__item--employer">
+          <i class="fas fa-fw fa-briefcase" aria-hidden="true"></i>
+          <div class="author__item-text">{{ author.employer }}</div>
+        </li>
       {% endif %}
       {% if author.uri %}
         <li>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -234,7 +234,24 @@
   }
 
   li {
-    white-space: nowrap;
+    white-space: normal;
+  }
+
+  .author__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5em;
+  }
+
+  .author__item > i {
+    flex-shrink: 0;
+    margin-top: 0.2em;
+  }
+
+  .author__item-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   a {


### PR DESCRIPTION
## Summary
- use a briefcase icon for the employer row in the author sidebar to avoid duplicating the map marker
- wrap location and employer text in a dedicated container so long names stay within the sidebar width
- allow author sidebar list items to wrap and flex so multi-line content aligns with the icon

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing because gems could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e3f1d9f0832daaad7d61ab673369