### PR TITLE
Fix author location icon color in dark mode

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -100,6 +100,7 @@ html.theme-dark .author__urls {
   background: #1f2937;
   border-color: rgba(255, 255, 255, 0.1);
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
 }
 
 html.theme-dark .author__urls a {
@@ -211,6 +212,10 @@ html.theme-dark .author__urls {
   background: transparent;
   border-color: rgba(255, 255, 255, 0.12);
   box-shadow: none;
+}
+
+html.theme-dark .author__item > i {
+  color: inherit;
 }
 
 html.theme-dark .author__urls:before,


### PR DESCRIPTION
## Summary
- ensure the author profile location icon inherits the light foreground color in dark mode
- keep dark theme icon colors consistent with other social icons

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68da222effa4832dadbe01242518e893