### PR TITLE
Add Chinese localization for employer information

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ author:
   location         : "Hong Kong"
   location_zh      : "香港"
   employer         : "The Hong Kong Polytechnic University"
+  employer_zh      : "香港理工大学"
   pubmed           : 
   googlescholar    : "https://scholar.google.com/citations?user=e2ban1wAAAAJ"
   email            : "wtwu95@gmail.com"

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -38,10 +38,13 @@
           </div>
         </li>
       {% endif %}
-      {% if author.employer %}
+      {% if author.employer or author.employer_zh %}
         <li class="author__item author__item--employer">
           <i class="fas fa-fw fa-university" aria-hidden="true"></i>
-          <div class="author__item-text">{{ author.employer }}</div>
+          <div class="author__item-text">
+            {% if author.employer %}<span data-lang="en">{{ author.employer }}</span>{% endif %}
+            {% if author.employer_zh %}<span data-lang="zh"{% if author.employer %} hidden{% endif %}>{{ author.employer_zh }}</span>{% endif %}
+          </div>
         </li>
       {% endif %}
       {% if author.uri %}


### PR DESCRIPTION
## Summary
- add a Chinese translation for the employer field in the site configuration
- update the author profile include to show localized employer text based on the selected language

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da26a73ae0832d8d396fb944033b91