### PR TITLE
Center author profile elements on large screens

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -89,6 +89,8 @@
     display: block;
     width: auto;
     height: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   img {
@@ -116,6 +118,7 @@
     width: 100%;
     padding-left: 0;
     padding-right: 0;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the author avatar within the profile panel at large breakpoints
- center-align the author text content so the name lines up with the avatar on wide screens

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68da30c775ac832d9b9d579559ecb2e8