### PR TITLE
Align Google Maps location map with visitor map widget

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -328,7 +328,9 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
+  width: var(--author-map-width, auto);
+  max-width: 100%;
+  height: var(--author-map-height, clamp(220px, 45vw, 320px));
 
   > * {
     flex: 1 1 auto;
@@ -348,7 +350,10 @@
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
+  min-height: var(
+    --author-location-map-min-height,
+    clamp(200px, 45vw, 320px)
+  );
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -387,8 +392,8 @@
   }
 
   .author__map {
-    width: 100%;
-    height: clamp(240px, 40vh, 360px);
+    width: var(--author-map-width, 100%);
+    height: var(--author-map-height, clamp(240px, 40vh, 360px));
   }
 }
 

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -22,6 +22,7 @@
     fallback.style.display = '';
     fallback.removeAttribute('aria-hidden');
     mapContainer.classList.add('author-location-map--showing-fallback');
+    ensureLocationMapSize(5);
   }
 
   function hideFallback(mapContainer) {
@@ -37,6 +38,7 @@
     fallback.style.display = 'none';
     fallback.setAttribute('aria-hidden', 'true');
     mapContainer.classList.remove('author-location-map--showing-fallback');
+    ensureLocationMapSize(5);
   }
 
   function hasMapError(mapContainer) {
@@ -77,6 +79,102 @@
         }
       }
     };
+  }
+
+  function resetLocationMapSize() {
+    var locationWrapper = document.querySelector('.author__map--location');
+    if (!locationWrapper) {
+      return;
+    }
+
+    locationWrapper.style.removeProperty('--author-map-width');
+    locationWrapper.style.removeProperty('--author-map-height');
+
+    var locationMap = locationWrapper.querySelector('.author-location-map');
+    if (locationMap) {
+      locationMap.style.removeProperty('--author-location-map-min-height');
+    }
+  }
+
+  function applyLocationMapSize(width, height) {
+    var locationWrapper = document.querySelector('.author__map--location');
+    if (!locationWrapper) {
+      return false;
+    }
+
+    if (width) {
+      locationWrapper.style.setProperty('--author-map-width', width + 'px');
+    }
+
+    if (height) {
+      locationWrapper.style.setProperty('--author-map-height', height + 'px');
+    }
+
+    var locationMap = locationWrapper.querySelector('.author-location-map');
+    if (locationMap && height) {
+      locationMap.style.setProperty('--author-location-map-min-height', height + 'px');
+    }
+
+    return Boolean(width && height);
+  }
+
+  function syncLocationMapSize() {
+    var visitorsWrapper = document.querySelector('.author__map--visitors');
+    var locationWrapper = document.querySelector('.author__map--location');
+
+    if (!locationWrapper) {
+      return false;
+    }
+
+    if (!visitorsWrapper) {
+      resetLocationMapSize();
+      return false;
+    }
+
+    var referenceElement = visitorsWrapper.firstElementChild;
+    while (referenceElement && referenceElement.tagName === 'SCRIPT') {
+      referenceElement = referenceElement.nextElementSibling;
+    }
+
+    if (!referenceElement) {
+      referenceElement = visitorsWrapper;
+    }
+
+    var rect = referenceElement.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return false;
+    }
+
+    var width = Math.round(rect.width);
+    var height = Math.round(rect.height);
+
+    return applyLocationMapSize(width, height);
+  }
+
+  function ensureLocationMapSize(attempts) {
+    if (syncLocationMapSize()) {
+      return;
+    }
+
+    if (!attempts) {
+      return;
+    }
+
+    window.setTimeout(function () {
+      ensureLocationMapSize(attempts - 1);
+    }, 200);
+  }
+
+  function initializeLocationMapSizeSync() {
+    ensureLocationMapSize(10);
+
+    window.addEventListener('load', function () {
+      ensureLocationMapSize(10);
+    });
+
+    window.addEventListener('resize', function () {
+      ensureLocationMapSize(2);
+    });
   }
 
   function createInitializer(mapContainer, lat, lng, zoom, title) {
@@ -120,7 +218,7 @@
           showFallback(mapContainer);
         }
       }, 4000);
-      }
+      ensureLocationMapSize(5);
     };
   }
 
@@ -192,11 +290,17 @@
     }
 
     loadMapScript(apiKey, language);
+    ensureLocationMapSize(5);
+  }
+
+  function startAuthorMaps() {
+    init();
+    initializeLocationMapSizeSync();
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('DOMContentLoaded', startAuthorMaps);
   } else {
-    init();
+    startAuthorMaps();
   }
 })();


### PR DESCRIPTION
## Summary
- allow the sidebar map containers to honour CSS custom properties so their dimensions can be driven externally
- add logic that synchronises the Google Maps location widget size with the MapMyVisitors embed, including fallback handling and resize support

## Testing
- bundle install *(fails: 403 Forbidden while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68da3479b80c832da3da21d6c99e545d