### PR TITLE
Fix author map sizing script output

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -275,7 +275,9 @@
 <div class="author__map-sidebar">
   <div class="author__maps{% if page.hide_author_maps_on_mobile %} author__maps--mobile-hidden{% endif %}">
     <div class="author__map author__map--visitors">
-      <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
+      <div class="author__map-frame">
+        <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
+      </div>
     </div>
     {% if site.google_maps %}
       <div class="author__map author__map--location">
@@ -285,24 +287,26 @@
           {% assign map_zoom = site.google_maps.zoom | default: 14 %}
           {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
           {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-          <div
-            class="author-location-map author-location-map--showing-fallback"
-            data-author-map
-            data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-            data-lat="{{ map_lat }}"
-            data-lng="{{ map_lng }}"
-            data-zoom="{{ map_zoom }}"
-            data-marker-title="{{ map_title | escape }}"
-            aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
-            <iframe
-              class="author-location-map__fallback"
-              data-author-map-fallback
-              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-              title="{{ map_title | escape }}"
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-              allowfullscreen>
-            </iframe>
+          <div class="author__map-frame">
+            <div
+              class="author-location-map author-location-map--showing-fallback"
+              data-author-map
+              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+              data-lat="{{ map_lat }}"
+              data-lng="{{ map_lng }}"
+              data-zoom="{{ map_zoom }}"
+              data-marker-title="{{ map_title | escape }}"
+              aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
+              <iframe
+                class="author-location-map__fallback"
+                data-author-map-fallback
+                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+                title="{{ map_title | escape }}"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                allowfullscreen>
+              </iframe>
+            </div>
           </div>
         {% else %}
           <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -312,9 +312,10 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: 1em;
+  gap: clamp(0.75em, 2vw, 1.5em);
   align-items: stretch;
   justify-content: center;
+  width: 100%;
 }
 
 .author__maps--mobile-hidden {
@@ -328,30 +329,66 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
-
-  > * {
-    flex: 1 1 auto;
-    min-height: 0;
-  }
-
-  iframe {
-    width: 100%;
-    height: 100%;
-  }
 }
 
 .author__map--location {
   margin-top: 0;
 }
 
-.author-location-map {
+.author__map-frame {
+  position: relative;
+  flex: 1 1 auto;
   width: 100%;
-  height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
+  overflow: hidden;
+}
+
+.author__map--visitors {
+  .author__map-frame {
+    display: block;
+  }
+
+  .author__map-frame > script {
+    display: none;
+  }
+
+  .author__map-frame > div,
+  .author__map-frame > iframe,
+  .author__map-frame > a,
+  .author__map-frame > img,
+  .author__map-frame > object {
+    width: 100% !important;
+    max-width: none !important;
+  }
+}
+
+.author__map--location {
+  .author__map-frame {
+    height: var(--author-location-map-height, clamp(220px, 45vw, 320px));
+    display: flex;
+  }
+
+  .author__map-frame > div,
+  .author__map-frame > iframe,
+  .author__map-frame > a,
+  .author__map-frame > img,
+  .author__map-frame > object {
+    flex: 1 1 auto;
+    width: 100%;
+    height: 100%;
+    max-width: none;
+  }
+}
+
+.author-location-map {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
   overflow: hidden;
   position: relative;
 }
@@ -360,17 +397,7 @@
   width: 100%;
   height: 100%;
   border: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
   display: block;
-}
-
-.author-location-map__fallback {
-  width: 100%;
-  height: 100%;
-  border: 0;
 }
 
 @include breakpoint($large) {
@@ -378,7 +405,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
-    gap: 1.25em;
+    gap: clamp(1em, 1.75vw, 1.5em);
   }
 
   .author__map-sidebar {
@@ -388,7 +415,6 @@
 
   .author__map {
     width: 100%;
-    height: clamp(240px, 40vh, 360px);
   }
 }
 

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -143,7 +143,7 @@
     return script;
   }
 
-  function init() {
+  function initLocationMap() {
     var mapContainer = document.querySelector('[data-author-map]');
     if (!mapContainer) {
       return;
@@ -192,6 +192,99 @@
     }
 
     loadMapScript(apiKey, language);
+  }
+
+  function initMapHeightSync() {
+    if (typeof window === 'undefined' || !window.document) {
+      return;
+    }
+
+    var mapGroups = document.querySelectorAll('.author__maps');
+    if (!mapGroups || !mapGroups.length) {
+      return;
+    }
+
+    var raf = window.requestAnimationFrame || function (callback) {
+      return window.setTimeout(callback, 16);
+    };
+
+    for (var i = 0; i < mapGroups.length; i += 1) {
+      (function (group) {
+        var visitorsFrame = group.querySelector('.author__map--visitors .author__map-frame');
+        var locationFrame = group.querySelector('.author__map--location .author__map-frame');
+
+        if (!visitorsFrame || !locationFrame) {
+          return;
+        }
+
+        var updateScheduled = false;
+
+        function applyHeight(height) {
+          if (!height || !isFinite(height)) {
+            return;
+          }
+
+          locationFrame.style.setProperty('--author-location-map-height', height + 'px');
+        }
+
+        function measureHeight() {
+          updateScheduled = false;
+
+          var height = visitorsFrame.getBoundingClientRect().height;
+
+          if (!height) {
+            var content = visitorsFrame.querySelector('div, iframe, object, img, embed');
+
+            if (content) {
+              height = content.getBoundingClientRect().height;
+            }
+          }
+
+          if (height) {
+            applyHeight(height);
+          }
+        }
+
+        function scheduleMeasure() {
+          if (updateScheduled) {
+            return;
+          }
+
+          updateScheduled = true;
+          raf(measureHeight);
+        }
+
+        if ('ResizeObserver' in window) {
+          var resizeObserver = new window.ResizeObserver(function () {
+            scheduleMeasure();
+          });
+
+          resizeObserver.observe(visitorsFrame);
+        }
+
+        if ('MutationObserver' in window) {
+          var mutationObserver = new window.MutationObserver(function () {
+            scheduleMeasure();
+          });
+
+          mutationObserver.observe(visitorsFrame, {
+            childList: true,
+            subtree: true,
+            attributes: true
+          });
+        }
+
+        window.addEventListener('resize', scheduleMeasure, { passive: true });
+        window.addEventListener('load', scheduleMeasure, { passive: true });
+
+        scheduleMeasure();
+      })(mapGroups[i]);
+    }
+  }
+
+  function init() {
+    initLocationMap();
+    initMapHeightSync();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- remove the inline author map height synchronizer from `_includes/author-profile.html` so no raw script text renders on the page
- move the visitor/location map height synchronization logic into `assets/js/author-map.js` alongside the existing author map bootstrap

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3a7c2f74832db96308c692c98638