### PR TITLE
Align author maps responsively

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -5,6 +5,7 @@
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/map-reorder.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/map-size-sync.js' | relative_url }}" defer></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -299,22 +299,19 @@
 
   .author__maps {
     width: 100%;
-    gap: 1em;
   }
 
   .author__map {
-    flex: 1 1 0;
-    min-width: 0;
+    width: 100%;
   }
 }
 
 .author__maps {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1em;
   align-items: stretch;
-  justify-content: center;
+  width: 100%;
 }
 
 .author__maps--mobile-hidden {
@@ -324,11 +321,11 @@
 }
 
 .author__map {
-  flex: 1 1 280px;
   display: flex;
   flex-direction: column;
+  width: 100%;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
+  height: auto;
 
   > * {
     flex: 1 1 auto;
@@ -341,14 +338,32 @@
   }
 }
 
+.author__map--visitors {
+  position: relative;
+}
+
+.author__map--visitors > :not(script) {
+  width: 100%;
+  height: 100%;
+}
+
+.author__map--visitors iframe,
+.author__map--visitors img,
+.author__map--visitors canvas,
+.author__map--visitors svg,
+.author__map--visitors object,
+.author__map--visitors embed {
+  width: 100%;
+  height: 100%;
+}
+
 .author__map--location {
   margin-top: 0;
 }
 
 .author-location-map {
   width: 100%;
-  height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
+  min-height: 0;
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -375,9 +390,6 @@
 
 @include breakpoint($large) {
   .author__maps {
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
     gap: 1.25em;
   }
 
@@ -388,7 +400,6 @@
 
   .author__map {
     width: 100%;
-    height: clamp(240px, 40vh, 360px);
   }
 }
 

--- a/assets/js/map-size-sync.js
+++ b/assets/js/map-size-sync.js
@@ -1,0 +1,155 @@
+(function () {
+  'use strict';
+
+  var RESIZE_DEBOUNCE_MS = 50;
+
+  function onReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback);
+    } else {
+      callback();
+    }
+  }
+
+  function firstNonScriptChild(container) {
+    if (!container) {
+      return null;
+    }
+
+    var child = container.firstElementChild;
+    while (child && child.tagName === 'SCRIPT') {
+      child = child.nextElementSibling;
+    }
+
+    return child || null;
+  }
+
+  function getVisitorRatio(visitorsContainer) {
+    var content = firstNonScriptChild(visitorsContainer);
+    if (!content) {
+      return null;
+    }
+
+    var rect = content.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return null;
+    }
+
+    return rect.height / rect.width;
+  }
+
+  function stretchVisitorContent(visitorsContainer) {
+    var content = firstNonScriptChild(visitorsContainer);
+    if (!content) {
+      return;
+    }
+
+    content.style.width = '100%';
+    content.style.height = '100%';
+
+    var descendants = content.querySelectorAll('iframe, img, canvas, svg, object, embed');
+    for (var i = 0; i < descendants.length; i += 1) {
+      var element = descendants[i];
+      element.style.width = '100%';
+      element.style.height = '100%';
+    }
+  }
+
+  function applyMapHeights(ratio, visitorsContainer, googleMapContainer) {
+    if (!ratio || !visitorsContainer || !googleMapContainer) {
+      return;
+    }
+
+    var visitorsWidth = visitorsContainer.getBoundingClientRect().width;
+    if (!visitorsWidth) {
+      var parentRect = visitorsContainer.parentElement ? visitorsContainer.parentElement.getBoundingClientRect() : null;
+      visitorsWidth = parentRect ? parentRect.width : 0;
+    }
+
+    if (!visitorsWidth) {
+      return;
+    }
+
+    var desiredHeight = Math.round(visitorsWidth * ratio);
+
+    visitorsContainer.style.height = desiredHeight + 'px';
+    googleMapContainer.style.height = desiredHeight + 'px';
+
+    stretchVisitorContent(visitorsContainer);
+
+    var fallback = googleMapContainer.querySelector('.author-location-map__fallback');
+    if (fallback) {
+      fallback.style.height = '100%';
+    }
+  }
+
+  function setupObservers(updateFn, visitorsContainer, googleWrapper) {
+    if (typeof window.ResizeObserver === 'function') {
+      var resizeObserver = new window.ResizeObserver(function () {
+        updateFn();
+      });
+      resizeObserver.observe(visitorsContainer);
+      resizeObserver.observe(googleWrapper);
+    }
+
+    var observer = new MutationObserver(function () {
+      updateFn(true);
+    });
+
+    observer.observe(visitorsContainer, { childList: true, subtree: true });
+  }
+
+  function init() {
+    var visitorsContainer = document.querySelector('.author__map--visitors');
+    var googleWrapper = document.querySelector('.author__map--location');
+    var googleMapContainer = googleWrapper ? googleWrapper.querySelector('.author-location-map') : null;
+
+    if (!visitorsContainer || !googleMapContainer) {
+      return;
+    }
+
+    var ratio = null;
+    var scheduled = false;
+    var lastUpdate = 0;
+
+    function refreshRatio(force) {
+      if (!ratio || force) {
+        var newRatio = getVisitorRatio(visitorsContainer);
+        if (newRatio) {
+          ratio = newRatio;
+        }
+      }
+    }
+
+    function updateSizes(forceRatio) {
+      var now = Date.now();
+      if (scheduled && now - lastUpdate < RESIZE_DEBOUNCE_MS) {
+        return;
+      }
+
+      scheduled = true;
+      lastUpdate = now;
+
+      window.requestAnimationFrame(function () {
+        scheduled = false;
+        refreshRatio(forceRatio);
+        applyMapHeights(ratio, visitorsContainer, googleMapContainer);
+      });
+    }
+
+    setupObservers(function (force) {
+      updateSizes(force);
+    }, visitorsContainer, googleWrapper);
+
+    window.addEventListener('resize', function () {
+      updateSizes(false);
+    });
+
+    updateSizes(true);
+    window.setTimeout(function () {
+      updateSizes(true);
+    }, 600);
+  }
+
+  onReady(init);
+})();


### PR DESCRIPTION
## Summary
- adjust author map layout styles so both embeds fill the available sidebar or inline width consistently
- add a helper script that reads the MapMyVisitors aspect ratio and applies matching heights to the Google Maps iframe on load and resize
- register the new script in the global scripts include

## Testing
- bundle exec jekyll build *(fails: jekyll executable is not installed in the container)*
- bundle install *(fails: unable to download gems due to HTTP 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68da4bfffe24832d989d4b0703a4e0ad