### PR TITLE
Align author maps layout and sizing

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -315,6 +315,7 @@
   gap: 1em;
   align-items: stretch;
   justify-content: center;
+  --author-map-shared-height: auto;
 }
 
 .author__maps--mobile-hidden {
@@ -328,11 +329,11 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
 
   > * {
     flex: 1 1 auto;
     min-height: 0;
+    width: 100%;
   }
 
   iframe {
@@ -343,12 +344,17 @@
 
 .author__map--location {
   margin-top: 0;
+  height: var(--author-map-shared-height, auto);
+}
+
+.author__map--location > * {
+  height: 100%;
 }
 
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
+  min-height: 0;
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -388,7 +394,6 @@
 
   .author__map {
     width: 100%;
-    height: clamp(240px, 40vh, 360px);
   }
 }
 

--- a/assets/js/map-reorder.js
+++ b/assets/js/map-reorder.js
@@ -41,6 +41,96 @@
     }
 
     var mediaQuery = window.matchMedia ? window.matchMedia(BREAKPOINT_MAX) : null;
+    var scheduleSharedHeightUpdate = function () {};
+
+    initSharedMapHeight();
+
+    function initSharedMapHeight() {
+      if (!mapsContainer) {
+        return;
+      }
+
+      var visitorsMap = mapsContainer.querySelector('.author__map--visitors');
+      var locationMap = mapsContainer.querySelector('.author__map--location');
+      if (!visitorsMap || !locationMap) {
+        return;
+      }
+
+      var requestFrame =
+        typeof window.requestAnimationFrame === 'function'
+          ? window.requestAnimationFrame.bind(window)
+          : function (callback) {
+              return window.setTimeout(callback, 16);
+            };
+      var rafId = null;
+      var ensureIntervalId = null;
+
+      function setSharedHeight(height) {
+        if (!mapsContainer) {
+          return;
+        }
+
+        if (height > 0) {
+          mapsContainer.style.setProperty('--author-map-shared-height', height + 'px');
+        }
+      }
+
+      function runUpdate() {
+        rafId = null;
+        if (!visitorsMap) {
+          return;
+        }
+
+        var rect = visitorsMap.getBoundingClientRect();
+        if (rect.height > 0) {
+          setSharedHeight(rect.height);
+        }
+      }
+
+      function scheduleUpdate() {
+        if (rafId !== null) {
+          return;
+        }
+
+        rafId = requestFrame(runUpdate);
+      }
+
+      scheduleSharedHeightUpdate = scheduleUpdate;
+
+      if (typeof ResizeObserver === 'function') {
+        var resizeObserver = new ResizeObserver(scheduleUpdate);
+        resizeObserver.observe(visitorsMap);
+      } else {
+        window.addEventListener('resize', scheduleUpdate);
+      }
+
+      if (typeof MutationObserver === 'function') {
+        var mutationObserver = new MutationObserver(scheduleUpdate);
+        mutationObserver.observe(visitorsMap, {
+          childList: true,
+          subtree: true,
+          attributes: true
+        });
+      }
+
+      var attempts = 0;
+      ensureIntervalId = window.setInterval(function () {
+        attempts += 1;
+        var rect = visitorsMap.getBoundingClientRect();
+        if (rect.height > 0 || attempts > 20) {
+          if (rect.height > 0) {
+            setSharedHeight(rect.height);
+          }
+          if (ensureIntervalId) {
+            window.clearInterval(ensureIntervalId);
+            ensureIntervalId = null;
+          }
+        }
+      }, 200);
+
+      window.addEventListener('load', scheduleUpdate);
+      scheduleUpdate();
+    }
 
     function shouldMoveToContent() {
       return mediaQuery ? mediaQuery.matches : window.innerWidth <= 924;
@@ -51,6 +141,7 @@
         pageInner.appendChild(mapSidebar);
       }
       mapSidebar.classList.add('author__map-sidebar--inline');
+      scheduleSharedHeightUpdate();
     }
 
     function moveToSidebar() {
@@ -58,6 +149,7 @@
         placeholder.parentNode.insertBefore(mapSidebar, placeholder);
       }
       mapSidebar.classList.remove('author__map-sidebar--inline');
+      scheduleSharedHeightUpdate();
     }
 
     function updatePlacement() {


### PR DESCRIPTION
## Summary
- update the author sidebar map styles so both embeds share a consistent width and responsive height
- sync the Google Maps height to the MapMyVisitors embed via a shared CSS custom property
- watch for visitor map changes so heights stay matched when layouts reorder on narrow screens

## Testing
- bundle exec jekyll build *(fails: `jekyll` gem unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da52b9394c832db1c2b1d3c0453992