### PR TITLE
Refine author map sizing responsiveness

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -290,31 +290,15 @@
 }
 
 .author__map-sidebar {
-  margin-top: 1.5em;
-}
-
-.author__map-sidebar--inline {
-  margin-top: 2em;
-  width: 100%;
-
-  .author__maps {
-    width: 100%;
-    gap: 1em;
-  }
-
-  .author__map {
-    flex: 1 1 0;
-    min-width: 0;
-  }
+  margin-top: 1.25em;
 }
 
 .author__maps {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 1em;
+  flex-direction: column;
   align-items: stretch;
-  justify-content: center;
+  width: 100%;
+  gap: 0.75em;
 }
 
 .author__maps--mobile-hidden {
@@ -324,31 +308,30 @@
 }
 
 .author__map {
-  flex: 1 1 280px;
-  display: flex;
-  flex-direction: column;
+  position: relative;
+  display: block;
+  width: 100%;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
-
-  > * {
-    flex: 1 1 auto;
-    min-height: 0;
-  }
-
-  iframe {
-    width: 100%;
-    height: 100%;
-  }
 }
 
 .author__map--location {
   margin-top: 0;
 }
 
+.author__map > * {
+  width: 100%;
+  height: 100%;
+}
+
+.author__map--visitors > * {
+  width: 100% !important;
+  height: 100% !important;
+}
+
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
+  min-height: 0;
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -374,21 +357,27 @@
 }
 
 @include breakpoint($large) {
-  .author__maps {
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
-    gap: 1.25em;
-  }
-
   .author__map-sidebar {
     position: sticky;
     top: 1.5rem;
   }
+}
+
+.author__map-sidebar--inline {
+  margin-top: 2em;
+  width: 100%;
+
+  .author__maps {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
+  }
 
   .author__map {
-    width: 100%;
-    height: clamp(240px, 40vh, 360px);
+    flex: 1 1 calc(50% - 0.75em);
+    max-width: calc(50% - 0.75em);
+    min-width: 240px;
   }
 }
 

--- a/assets/js/map-reorder.js
+++ b/assets/js/map-reorder.js
@@ -41,6 +41,164 @@
     }
 
     var mediaQuery = window.matchMedia ? window.matchMedia(BREAKPOINT_MAX) : null;
+    var scheduleMapSizeUpdate = function () {};
+
+    initResponsiveMapSizing();
+
+    function initResponsiveMapSizing() {
+      if (!mapsContainer) {
+        return;
+      }
+
+      var visitorsMap = mapsContainer.querySelector('.author__map--visitors');
+      var locationMap = mapsContainer.querySelector('.author__map--location');
+      if (!visitorsMap || !locationMap) {
+        return;
+      }
+
+      var requestFrame =
+        typeof window.requestAnimationFrame === 'function'
+          ? window.requestAnimationFrame.bind(window)
+          : function (callback) {
+              return window.setTimeout(callback, 16);
+            };
+      var aspectRatio = null;
+      var rafId = null;
+      var ensureIntervalId = null;
+
+      function findActiveChild(element) {
+        if (!element) {
+          return null;
+        }
+        var child = element.firstElementChild;
+        while (child && child.tagName === 'SCRIPT') {
+          child = child.nextElementSibling;
+        }
+        return child || null;
+      }
+
+      function applyChildFill(element) {
+        var child = findActiveChild(element);
+        if (!child) {
+          return;
+        }
+        child.style.setProperty('width', '100%', 'important');
+        child.style.setProperty('height', '100%', 'important');
+      }
+
+      function applyHeight(height) {
+        if (!(height > 0)) {
+          return;
+        }
+
+        [visitorsMap, locationMap].forEach(function (mapElement) {
+          if (!mapElement) {
+            return;
+          }
+
+          mapElement.style.height = height + 'px';
+          mapElement.style.minHeight = height + 'px';
+          mapElement.style.maxHeight = height + 'px';
+          applyChildFill(mapElement);
+        });
+      }
+
+      function captureAspectRatio() {
+        var reference = findActiveChild(visitorsMap) || visitorsMap;
+        if (!reference) {
+          return false;
+        }
+
+        var rect = reference.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          aspectRatio = rect.width / rect.height;
+          if (ensureIntervalId) {
+            window.clearInterval(ensureIntervalId);
+            ensureIntervalId = null;
+          }
+          return true;
+        }
+
+        return false;
+      }
+
+      function ensureAspectRatio() {
+        if (aspectRatio !== null) {
+          return;
+        }
+
+        if (captureAspectRatio()) {
+          scheduleUpdate();
+        }
+      }
+
+      function runUpdate() {
+        rafId = null;
+
+        if (aspectRatio === null && !captureAspectRatio()) {
+          return;
+        }
+
+        var width = visitorsMap.getBoundingClientRect().width;
+        if (!(width > 0) || !(aspectRatio > 0)) {
+          return;
+        }
+
+        var height = width / aspectRatio;
+        applyHeight(height);
+      }
+
+      function scheduleUpdate() {
+        if (rafId !== null) {
+          return;
+        }
+
+        rafId = requestFrame(runUpdate);
+      }
+
+      scheduleMapSizeUpdate = scheduleUpdate;
+
+      applyChildFill(visitorsMap);
+      applyChildFill(locationMap);
+
+      if (typeof ResizeObserver === 'function') {
+        var resizeObserver = new ResizeObserver(scheduleUpdate);
+        resizeObserver.observe(mapsContainer);
+      }
+
+      window.addEventListener('resize', scheduleUpdate);
+
+      if (typeof MutationObserver === 'function') {
+        var mutationObserver = new MutationObserver(function () {
+          ensureAspectRatio();
+          scheduleUpdate();
+        });
+        mutationObserver.observe(visitorsMap, {
+          childList: true,
+          subtree: true,
+          attributes: true
+        });
+      }
+
+      window.addEventListener('load', scheduleUpdate);
+
+      ensureIntervalId = window.setInterval(function () {
+        if (aspectRatio !== null) {
+          if (ensureIntervalId) {
+            window.clearInterval(ensureIntervalId);
+            ensureIntervalId = null;
+          }
+          return;
+        }
+
+        if (captureAspectRatio()) {
+          scheduleUpdate();
+        }
+      }, 200);
+
+      ensureAspectRatio();
+      scheduleUpdate();
+    }
 
     function shouldMoveToContent() {
       return mediaQuery ? mediaQuery.matches : window.innerWidth <= 924;
@@ -51,6 +209,7 @@
         pageInner.appendChild(mapSidebar);
       }
       mapSidebar.classList.add('author__map-sidebar--inline');
+      scheduleMapSizeUpdate();
     }
 
     function moveToSidebar() {
@@ -58,6 +217,7 @@
         placeholder.parentNode.insertBefore(mapSidebar, placeholder);
       }
       mapSidebar.classList.remove('author__map-sidebar--inline');
+      scheduleMapSizeUpdate();
     }
 
     function updatePlacement() {


### PR DESCRIPTION
## Summary
- refine the author map styles so embeds fill the sidebar width with reduced spacing and split into equal columns when moved below the content
- derive the visitor map's aspect ratio at runtime to drive shared responsive heights for both maps
- continue watching for layout changes and visitor map mutations so sizing stays synchronized on narrow screens

## Testing
- bundle exec jekyll build *(fails: `jekyll` gem unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da52b9394c832db1c2b1d3c0453992