### PR TITLE
Fix author map layout and duplication issues

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -289,8 +289,16 @@
   }
 }
 
+:root {
+  --author-map-aspect: 1;
+}
+
 .author__map-sidebar {
   margin-top: 1.5em;
+
+  .author__maps {
+    width: 100%;
+  }
 }
 
 .author__map-sidebar--inline {
@@ -298,23 +306,26 @@
   width: 100%;
 
   .author__maps {
-    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
     gap: 1em;
   }
 
   .author__map {
-    flex: 1 1 0;
-    min-width: 0;
+    width: auto;
+    flex: 1 1 50%;
+    max-width: 50%;
+    min-width: 220px;
   }
 }
 
 .author__maps {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 1em;
   align-items: stretch;
-  justify-content: center;
 }
 
 .author__maps--mobile-hidden {
@@ -324,18 +335,23 @@
 }
 
 .author__map {
-  flex: 1 1 280px;
   display: flex;
   flex-direction: column;
+  width: 100%;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
+  aspect-ratio: var(--author-map-aspect);
 
   > * {
     flex: 1 1 auto;
     min-height: 0;
   }
 
-  iframe {
+  iframe,
+  object,
+  embed,
+  .author-location-map,
+  .mapmyvisitors,
+  [data-map-embed] {
     width: 100%;
     height: 100%;
   }
@@ -348,7 +364,8 @@
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
+  min-height: 0;
+  max-height: none;
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -367,12 +384,6 @@
   display: block;
 }
 
-.author-location-map__fallback {
-  width: 100%;
-  height: 100%;
-  border: 0;
-}
-
 @include breakpoint($large) {
   .author__maps {
     flex-direction: column;
@@ -384,11 +395,6 @@
   .author__map-sidebar {
     position: sticky;
     top: 1.5rem;
-  }
-
-  .author__map {
-    width: 100%;
-    height: clamp(240px, 40vh, 360px);
   }
 }
 

--- a/assets/js/map-reorder.js
+++ b/assets/js/map-reorder.js
@@ -2,6 +2,192 @@
   'use strict';
 
   var BREAKPOINT_MAX = '(max-width: 924px)';
+  var MAP_VISITORS_CLASS = 'author__map--visitors';
+  var MAP_ASPECT_PROPERTY = '--author-map-aspect';
+  var DEFAULT_ASPECT = 1;
+
+  function schedule(callback) {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(callback);
+    } else {
+      window.setTimeout(callback, 0);
+    }
+  }
+
+  function setRootAspectRatio(ratio) {
+    if (!ratio || !isFinite(ratio)) {
+      return;
+    }
+
+    var value = Math.max(0.25, Math.min(ratio, 5));
+    document.documentElement.style.setProperty(MAP_ASPECT_PROPERTY, value.toString());
+  }
+
+  function elementChildren(parent) {
+    if (!parent) {
+      return [];
+    }
+
+    return Array.prototype.filter.call(parent.children || [], function (child) {
+      return child.nodeType === 1 && child.tagName !== 'SCRIPT';
+    });
+  }
+
+  function removeDuplicateVisitorMaps(container) {
+    var children = elementChildren(container);
+    if (children.length <= 1) {
+      return children[0] || null;
+    }
+
+    for (var i = 0; i < children.length - 1; i += 1) {
+      if (children[i] && children[i].parentNode) {
+        children[i].parentNode.removeChild(children[i]);
+      }
+    }
+
+    return children[children.length - 1] || null;
+  }
+
+  function normaliseDimensions(element) {
+    if (!element || element.nodeType !== 1) {
+      return;
+    }
+
+    if (element.hasAttribute('width')) {
+      element.removeAttribute('width');
+    }
+
+    if (element.hasAttribute('height')) {
+      element.removeAttribute('height');
+    }
+
+    var tagName = element.tagName ? element.tagName.toLowerCase() : '';
+    var canStretch = tagName === 'div' ||
+      tagName === 'span' ||
+      tagName === 'iframe' ||
+      tagName === 'object' ||
+      tagName === 'embed' ||
+      tagName === 'img' ||
+      tagName === 'svg' ||
+      tagName === 'canvas';
+
+    if (canStretch && element.style) {
+      if (element.style.width && element.style.width !== 'auto') {
+        element.style.width = '100%';
+      }
+
+      if (element.style.height && element.style.height !== 'auto') {
+        element.style.height = '100%';
+      }
+    }
+  }
+
+  function normaliseVisitorTree(element) {
+    if (!element || element.nodeType !== 1) {
+      return;
+    }
+
+    normaliseDimensions(element);
+
+    var children = element.children;
+    for (var i = 0; i < children.length; i += 1) {
+      normaliseVisitorTree(children[i]);
+    }
+  }
+
+  function findVisualElement(root) {
+    if (!root || root.nodeType !== 1) {
+      return null;
+    }
+
+    var selectors = 'iframe, object, embed, img, svg, canvas';
+    var candidate = root.querySelector(selectors);
+    return candidate || root;
+  }
+
+  function extractAspectRatio(element) {
+    if (!element || element.nodeType !== 1) {
+      return null;
+    }
+
+    var width = parseFloat(element.getAttribute('width'));
+    var height = parseFloat(element.getAttribute('height'));
+
+    if (!(width > 0 && height > 0)) {
+      var rect = element.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+    }
+
+    if (!(width > 0 && height > 0)) {
+      return null;
+    }
+
+    return width / height;
+  }
+
+  function setupVisitorMapSizing(mapSidebar) {
+    if (!mapSidebar) {
+      return;
+    }
+
+    var visitorsContainer = mapSidebar.querySelector('.' + MAP_VISITORS_CLASS);
+    if (!visitorsContainer) {
+      return;
+    }
+
+    var lastRatio = DEFAULT_ASPECT;
+
+    function applySizing() {
+      var root = removeDuplicateVisitorMaps(visitorsContainer);
+      if (!root) {
+        return;
+      }
+
+      normaliseVisitorTree(root);
+
+      var embedElements = root.querySelectorAll('iframe, object, embed');
+      if (embedElements.length > 1) {
+        for (var i = 0; i < embedElements.length - 1; i += 1) {
+          var embed = embedElements[i];
+          if (embed && embed.parentNode) {
+            embed.parentNode.removeChild(embed);
+          }
+        }
+      }
+
+      var visualElement = findVisualElement(root);
+      if (visualElement && visualElement !== root) {
+        normaliseVisitorTree(visualElement);
+      }
+
+      var ratio = extractAspectRatio(visualElement || root);
+      if (ratio && Math.abs(ratio - lastRatio) > 0.01) {
+        lastRatio = ratio;
+        setRootAspectRatio(ratio);
+      }
+    }
+
+    applySizing();
+
+    if (typeof MutationObserver === 'function') {
+      var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i += 1) {
+          var mutation = mutations[i];
+          if (mutation.type === 'childList' && mutation.addedNodes && mutation.addedNodes.length > 0) {
+            schedule(applySizing);
+            return;
+          }
+        }
+      });
+
+      observer.observe(visitorsContainer, { childList: true, subtree: true });
+    }
+
+    window.addEventListener('resize', function () {
+      schedule(applySizing);
+    });
+  }
 
   function onReady(callback) {
     if (document.readyState === 'loading') {
@@ -21,6 +207,8 @@
     if (mapsContainer && mapsContainer.classList.contains('author__maps--mobile-hidden')) {
       return;
     }
+
+    setupVisitorMapSizing(mapSidebar);
 
     var sidebar = mapSidebar.closest('.sidebar');
     var main = document.getElementById('main');


### PR DESCRIPTION
## Summary
- restyle the author map containers so the Google and MapMyVisitors embeds share the same responsive width and aspect ratio in both sidebar and inline layouts
- add client-side sizing logic that removes duplicate MapMyVisitors renders, normalises embed dimensions and synchronises the Google map height with the visitor map ratio
- ensure the inline (narrow viewport) layout presents the two maps side by side at half-width for consistent spacing

## Testing
- Unable to run `bundle exec jekyll build` (rubygems.org returned HTTP 403 while installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68da73ac7258832d98cff11aefda1ac8