### PR TITLE
Refactor embedded maps for responsive layout

### DIFF
--- a/_includes/author-maps.html
+++ b/_includes/author-maps.html
@@ -1,0 +1,54 @@
+{% assign variant = include.variant | default: 'sidebar' %}
+{% if author %}
+  {% assign map_author = author %}
+{% elsif page.author and site.data.authors[page.author] %}
+  {% assign map_author = site.data.authors[page.author] %}
+{% else %}
+  {% assign map_author = site.author %}
+{% endif %}
+<div class="author__maps author__maps--{{ variant }}">
+  <div class="author__map author__map--visitors">
+    <script
+      type="text/javascript"
+      id="mapmyvisitors-{{ variant }}"
+      src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"
+    ></script>
+  </div>
+  {% if site.google_maps %}
+    <div class="author__map author__map--location">
+      {% if site.google_maps.api_key %}
+        {% assign map_lat = site.google_maps.location.lat | default: 0 %}
+        {% assign map_lng = site.google_maps.location.lng | default: 0 %}
+        {% assign map_zoom = site.google_maps.zoom | default: 14 %}
+        {% assign map_title = site.google_maps.location.title | default: map_author.location | default: 'Location' %}
+        {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
+        <div
+          class="author-location-map author-location-map--showing-fallback"
+          data-author-map
+          data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+          data-lat="{{ map_lat }}"
+          data-lng="{{ map_lng }}"
+          data-zoom="{{ map_zoom }}"
+          data-marker-title="{{ map_title | escape }}"
+          aria-label="{{ map_title | escape }}"{% if map_language %}
+          data-language="{{ map_language | escape }}"{% endif %}
+        >
+          <iframe
+            class="author-location-map__fallback"
+            data-author-map-fallback
+            src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+            title="{{ map_title | escape }}"
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
+            allowfullscreen
+          >
+          </iframe>
+        </div>
+      {% else %}
+        <p class="author-location-map__placeholder">
+          {{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}
+        </p>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -273,41 +273,5 @@
 </div>
 
 <div class="author__map-sidebar">
-  <div class="author__maps{% if page.hide_author_maps_on_mobile %} author__maps--mobile-hidden{% endif %}">
-    <div class="author__map author__map--visitors">
-      <script type="text/javascript" id="mapmyvisitors" src="//mapmyvisitors.com/map.js?d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&cl=ffffff&w=a"></script>
-    </div>
-    {% if site.google_maps %}
-      <div class="author__map author__map--location">
-        {% if site.google_maps.api_key %}
-          {% assign map_lat = site.google_maps.location.lat | default: 0 %}
-          {% assign map_lng = site.google_maps.location.lng | default: 0 %}
-          {% assign map_zoom = site.google_maps.zoom | default: 14 %}
-          {% assign map_title = site.google_maps.location.title | default: author.location | default: 'Location' %}
-          {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-          <div
-            class="author-location-map author-location-map--showing-fallback"
-            data-author-map
-            data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-            data-lat="{{ map_lat }}"
-            data-lng="{{ map_lng }}"
-            data-zoom="{{ map_zoom }}"
-            data-marker-title="{{ map_title | escape }}"
-            aria-label="{{ map_title | escape }}"{% if map_language %} data-language="{{ map_language | escape }}"{% endif %}>
-            <iframe
-              class="author-location-map__fallback"
-              data-author-map-fallback
-              src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-              title="{{ map_title | escape }}"
-              loading="lazy"
-              referrerpolicy="no-referrer-when-downgrade"
-              allowfullscreen>
-            </iframe>
-          </div>
-        {% else %}
-          <p class="author-location-map__placeholder">{{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}</p>
-        {% endif %}
-      </div>
-    {% endif %}
-  </div>
+  {% include author-maps.html variant="sidebar" %}
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,13 @@ layout: compress
           <section class="page__content" itemprop="text">
             {{ content }}
           </section>
+          {% if page.author_profile or layout.author_profile %}
+            {% unless page.hide_author_maps_on_mobile or layout.hide_author_maps_on_mobile %}
+              <aside class="page__author-maps">
+                {% include author-maps.html variant="inline" %}
+              </aside>
+            {% endunless %}
+          {% endif %}
         </div>
       </article>
     </div>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -291,35 +291,48 @@
 
 .author__map-sidebar {
   margin-top: 1.5em;
+  display: none;
+
+  @include breakpoint($large) {
+    display: block;
+  }
 }
 
-.author__map-sidebar--inline {
+.page__author-maps {
   margin-top: 2em;
-  width: 100%;
+  display: block;
 
-  .author__maps {
-    width: 100%;
-    gap: 1em;
-  }
-
-  .author__map {
-    flex: 1 1 0;
-    min-width: 0;
+  @include breakpoint($large) {
+    display: none;
   }
 }
 
 .author__maps {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  width: 100%;
   gap: 1em;
   align-items: stretch;
   justify-content: center;
 }
 
-.author__maps--mobile-hidden {
-  @include breakpoint(max-width $medium) {
-    display: none;
+.author__maps--sidebar {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.author__maps--inline {
+  display: none;
+
+  @include breakpoint(max-width $large) {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.page__author-maps .author__map {
+  @include breakpoint(max-width $large) {
+    flex: 1 1 50%;
   }
 }
 
@@ -374,10 +387,8 @@
 }
 
 @include breakpoint($large) {
-  .author__maps {
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
+  .author__maps--sidebar {
+    justify-content: flex-start;
     gap: 1.25em;
   }
 


### PR DESCRIPTION
## Summary
- extract the map embeds into a reusable include and simplify the sidebar markup
- render the maps beneath the main page content on narrow screens while keeping them in the sidebar on wide screens
- update map styling to align sizing and spacing for the sidebar and inline layouts

## Testing
- bundle exec jekyll build *(fails: jekyll executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da7cde19a4832d8d6418474eb0fe53