### PR TITLE
Add responsive sidebar maps container

### DIFF
--- a/_includes/author-maps.html
+++ b/_includes/author-maps.html
@@ -1,4 +1,9 @@
 {% assign variant = include.variant | default: 'sidebar' %}
+{% assign mobile_hidden = include.mobile_hidden | default: false %}
+{% assign author_map_classes = 'author__maps author__maps--' | append: variant %}
+{% if mobile_hidden %}
+  {% assign author_map_classes = author_map_classes | append: ' author__maps--mobile-hidden' %}
+{% endif %}
 {% if author %}
   {% assign map_author = author %}
 {% elsif page.author and site.data.authors[page.author] %}
@@ -6,7 +11,7 @@
 {% else %}
   {% assign map_author = site.author %}
 {% endif %}
-<div class="author__maps author__maps--{{ variant }}">
+<div class="{{ author_map_classes }}">
   <div class="author__map author__map--visitors">
     <script
       type="text/javascript"

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -271,7 +271,3 @@
     </div>
   </div>
 </div>
-
-<div class="author__map-sidebar">
-  {% include author-maps.html variant="sidebar" %}
-</div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,18 @@
 {% if page.author_profile or layout.author_profile or page.sidebar %}
   <div class="sidebar sticky">
-  {% if page.author_profile or layout.author_profile %}{% include author-profile.html %}{% endif %}
+  {% if page.author_profile or layout.author_profile %}
+    {% assign hide_author_maps_on_mobile = false %}
+    {% if page.hide_author_maps_on_mobile %}
+      {% assign hide_author_maps_on_mobile = true %}
+    {% endif %}
+    {% if layout.hide_author_maps_on_mobile %}
+      {% assign hide_author_maps_on_mobile = true %}
+    {% endif %}
+    {% include author-profile.html %}
+    <div class="author__map-sidebar">
+      {% include author-maps.html variant="sidebar" mobile_hidden=hide_author_maps_on_mobile %}
+    </div>
+  {% endif %}
   {% if page.sidebar %}
     {% for s in page.sidebar %}
       {% if s.image %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,13 +24,6 @@ layout: compress
           <section class="page__content" itemprop="text">
             {{ content }}
           </section>
-          {% if page.author_profile or layout.author_profile %}
-            {% unless page.hide_author_maps_on_mobile or layout.hide_author_maps_on_mobile %}
-              <aside class="page__author-maps">
-                {% include author-maps.html variant="inline" %}
-              </aside>
-            {% endunless %}
-          {% endif %}
         </div>
       </article>
     </div>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -298,13 +298,10 @@
   }
 }
 
-.page__author-maps {
-  margin-top: 2em;
+.author__map-sidebar--inline {
   display: block;
-
-  @include breakpoint($large) {
-    display: none;
-  }
+  margin: 2em 0 0;
+  width: 100%;
 }
 
 .author__maps {
@@ -318,22 +315,6 @@
 .author__maps--sidebar {
   flex-direction: column;
   align-items: stretch;
-}
-
-.author__maps--inline {
-  display: none;
-
-  @include breakpoint(max-width $large) {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
-}
-
-.page__author-maps .author__map {
-  @include breakpoint(max-width $large) {
-    flex: 1 1 50%;
-  }
 }
 
 .author__map {
@@ -351,6 +332,20 @@
   iframe {
     width: 100%;
     height: 100%;
+  }
+}
+
+.author__map-sidebar--inline {
+  .author__maps {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1em;
+  }
+
+  .author__map {
+    flex: 1 1 50%;
+    min-width: min(320px, 100%);
+    height: clamp(220px, 60vw, 320px);
   }
 }
 


### PR DESCRIPTION
## Summary
- move the author map container directly below the sidebar author profile and respect the mobile hide flag
- allow the author-maps include to add a mobile-hidden class and drop the duplicate inline aside
- adjust sidebar styles so the maps stack vertically on wide screens and align horizontally after being moved below the content on small screens

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68da87819700832db8508c3aed3896fb