### PR TITLE
Adjust visitor map layout for responsive ratio

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -318,34 +318,40 @@
 }
 
 .author__map {
-  flex: 1 1 280px;
-  display: flex;
-  flex-direction: column;
+  flex: 1 1 300px;
+  display: block;
+  position: relative;
   min-width: 0;
-  height: clamp(220px, 45vw, 320px);
+  width: 100%;
+  aspect-ratio: 300 / 190;
 
   > * {
-    flex: 1 1 auto;
-    min-height: 0;
-  }
-
-  iframe {
     width: 100%;
     height: 100%;
+  }
+
+  iframe,
+  img,
+  canvas,
+  #mapmyvisitors,
+  [id^='mapmyvisitors'] {
+    width: 100% !important;
+    height: 100% !important;
+    display: block;
   }
 }
 
 .author__map-sidebar--inline {
   .author__maps {
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    justify-content: space-between;
     gap: 1em;
   }
 
   .author__map {
-    flex: 1 1 50%;
-    min-width: min(320px, 100%);
-    height: clamp(220px, 60vw, 320px);
+    flex: 0 0 calc(50% - 0.75em);
+    max-width: calc(50% - 0.75em);
   }
 }
 
@@ -356,7 +362,6 @@
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
@@ -394,7 +399,7 @@
 
   .author__map {
     width: 100%;
-    height: clamp(240px, 40vh, 360px);
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- enforce a 300:190 aspect ratio for the MapMyVisitors and Google maps containers so they stay consistent
- tune inline sidebar layout so the two maps remain full-width in the sidebar and sit side-by-side below with spacing

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db3c06be74832db041f8db62edc452