### PR TITLE
Adjust author maps layout for narrow screens

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -341,6 +341,27 @@
   }
 }
 
+@media screen and (max-width: 768px) {
+  .author__maps {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .author__map {
+    flex: 0 0 48%;
+    width: 48%;
+    padding-bottom: 63.33%;
+    aspect-ratio: auto;
+  }
+
+  .author__map > * {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+
 .author__map-sidebar--inline {
   .author__maps {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- update the author maps container to wrap and evenly distribute maps on narrow viewports
- apply percentage-based sizing and absolute positioning so both maps retain the same aspect ratio

## Testing
- not run (missing `jekyll` executable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68db464e4190832d866ab1738940a205