### PR TITLE
Improve responsive layout for author maps

### DIFF
--- a/_includes/author-maps.html
+++ b/_includes/author-maps.html
@@ -13,11 +13,15 @@
 {% endif %}
 <div class="{{ author_map_classes }}">
   <div class="author__map author__map--visitors">
-    <script
-      type="text/javascript"
-      id="mapmyvisitors"
-      src="https://mapmyvisitors.com/map.js?cl=ffffff&w=a&t=tt&d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&co=919ba3&cmo=3acc3a&cmn=ff5353&ct=ffffff"
-    ></script>
+    <div class="author__map-frame author__map-frame--ratio">
+      <div class="author__map-embed">
+        <script
+          type="text/javascript"
+          id="mapmyvisitors"
+          src="https://mapmyvisitors.com/map.js?cl=ffffff&w=a&t=tt&d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&co=919ba3&cmo=3acc3a&cmn=ff5353&ct=ffffff"
+        ></script>
+      </div>
+    </div>
   </div>
   {% if site.google_maps %}
     <div class="author__map author__map--location">
@@ -27,32 +31,40 @@
         {% assign map_zoom = site.google_maps.zoom | default: 14 %}
         {% assign map_title = site.google_maps.location.title | default: map_author.location | default: 'Location' %}
         {% assign map_language = site.google_maps.language | default: page.lang | default: site.lang | default: site.locale %}
-        <div
-          class="author-location-map author-location-map--showing-fallback"
-          data-author-map
-          data-api-key="{{ site.google_maps.api_key | strip | escape }}"
-          data-lat="{{ map_lat }}"
-          data-lng="{{ map_lng }}"
-          data-zoom="{{ map_zoom }}"
-          data-marker-title="{{ map_title | escape }}"
-          aria-label="{{ map_title | escape }}"{% if map_language %}
-          data-language="{{ map_language | escape }}"{% endif %}
-        >
-          <iframe
-            class="author-location-map__fallback"
-            data-author-map-fallback
-            src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
-            title="{{ map_title | escape }}"
-            loading="lazy"
-            referrerpolicy="no-referrer-when-downgrade"
-            allowfullscreen
-          >
-          </iframe>
+        <div class="author__map-frame author__map-frame--ratio">
+          <div class="author__map-embed">
+            <div
+              class="author-location-map author-location-map--showing-fallback"
+              data-author-map
+              data-api-key="{{ site.google_maps.api_key | strip | escape }}"
+              data-lat="{{ map_lat }}"
+              data-lng="{{ map_lng }}"
+              data-zoom="{{ map_zoom }}"
+              data-marker-title="{{ map_title | escape }}"
+              aria-label="{{ map_title | escape }}"{% if map_language %}
+              data-language="{{ map_language | escape }}"{% endif %}
+            >
+              <iframe
+                class="author-location-map__fallback"
+                data-author-map-fallback
+                src="https://maps.google.com/maps?q={{ map_lat | escape }},{{ map_lng | escape }}&amp;z={{ map_zoom | escape }}&amp;output=embed{% if map_language %}&amp;hl={{ map_language | escape }}{% endif %}"
+                title="{{ map_title | escape }}"
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+                allowfullscreen
+              >
+              </iframe>
+            </div>
+          </div>
         </div>
       {% else %}
-        <p class="author-location-map__placeholder">
-          {{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}
-        </p>
+        <div class="author__map-frame">
+          <div class="author__map-embed">
+            <p class="author-location-map__placeholder">
+              {{ site.google_maps.placeholder | default: 'Set your Google Maps API key in _config.yml to display the location map.' }}
+            </p>
+          </div>
+        </div>
       {% endif %}
     </div>
   {% endif %}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -310,6 +310,7 @@
   gap: 1em;
   align-items: stretch;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .author__maps--sidebar {
@@ -319,17 +320,39 @@
 
 .author__map {
   flex: 1 1 280px;
+  min-width: 0;
+}
+
+.author__map-frame {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  min-width: 0;
-  height: clamp(220px, 45vw, 320px);
+}
+
+.author__map-frame--ratio {
+  position: relative;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-bottom: 63.33%;
+  }
+
+  .author__map-embed {
+    position: absolute;
+    inset: 0;
+  }
+}
+
+.author__map-embed {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   > * {
     flex: 1 1 auto;
     min-height: 0;
-  }
-
-  iframe {
     width: 100%;
     height: 100%;
   }
@@ -339,13 +362,18 @@
   .author__maps {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 1em;
+    justify-content: space-between;
+    gap: 4%;
   }
 
   .author__map {
-    flex: 1 1 50%;
-    min-width: min(320px, 100%);
-    height: clamp(220px, 60vw, 320px);
+    flex: 0 0 48%;
+    width: 48%;
+  }
+
+  .author__map:only-child {
+    flex-basis: 100%;
+    width: 100%;
   }
 }
 
@@ -356,12 +384,23 @@
 .author-location-map {
   width: 100%;
   height: 100%;
-  min-height: clamp(200px, 45vw, 320px);
   border: 1px solid $border-color;
   border-radius: $border-radius;
   background-color: $code-background-color;
   overflow: hidden;
   position: relative;
+}
+
+.author__map-frame--ratio {
+  .author-location-map {
+    min-height: 0;
+  }
+
+  .author-location-map,
+  .author-location-map__fallback {
+    position: absolute;
+    inset: 0;
+  }
 }
 
 .author-location-map__fallback {
@@ -394,7 +433,6 @@
 
   .author__map {
     width: 100%;
-    height: clamp(240px, 40vh, 360px);
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap author map embeds in a reusable frame that maintains a consistent aspect ratio
- adjust the inline author map layout so two maps sit side by side at 48% width on narrow screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db48b16628832d8b695761b67f5882