### PR TITLE
Adjust sidebar map spacing

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -316,6 +316,12 @@
 .author__maps--sidebar {
   flex-direction: column;
   align-items: stretch;
+  gap: 0.75rem;
+}
+
+.author__maps--sidebar .author__map {
+  flex: 0 0 auto;
+  width: 100%;
 }
 
 .author__map {


### PR DESCRIPTION
## Summary
- reduce the vertical gap between stacked author maps in the sidebar layout
- prevent sidebar author maps from stretching so their heights collapse to their embedded content

## Testing
- not run (bundle install fails with 403 from rubygems.org)


------
https://chatgpt.com/codex/tasks/task_e_68db4c0a7cac832d9ff8d1423ef4a8cc