### PR TITLE
Fix visitor stats map aspect ratio on narrow screens

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -387,6 +387,45 @@
   margin-top: 0;
 }
 
+.author__map--visitors {
+  .author__map-frame--ratio {
+    aspect-ratio: 1 / 0.6333;
+
+    &::before {
+      display: block;
+      padding-bottom: 63.33%;
+
+      @supports (aspect-ratio: 1) {
+        display: none;
+      }
+    }
+  }
+
+  .author__map-embed {
+    align-items: stretch;
+
+    > *,
+    > * > * {
+      display: flex;
+      flex: 1 1 auto;
+      width: 100% !important;
+      height: 100% !important;
+      min-height: 100% !important;
+    }
+
+    iframe,
+    canvas,
+    object,
+    embed,
+    img {
+      flex: 1 1 auto;
+      width: 100% !important;
+      height: 100% !important;
+      min-height: 100% !important;
+    }
+  }
+}
+
 .author-location-map {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- ensure the visitor statistics map container keeps the intended aspect ratio with modern browsers
- force generated visitor map content to stretch to the full height and width of the frame

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*


------
https://chatgpt.com/codex/tasks/task_e_68db5075524c832d8ab2d08c812e4568