### PR TITLE
Ensure visitor stats map fills its aspect ratio

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -387,6 +387,84 @@
   margin-top: 0;
 }
 
+.author__map--visitors {
+  .author__map-frame--ratio {
+    aspect-ratio: 1 / 0.6333;
+
+    &::before {
+      display: block;
+      padding-bottom: 63.33%;
+
+      @supports (aspect-ratio: 1) {
+        display: none;
+      }
+    }
+  }
+
+  .author__map-embed {
+    align-items: stretch;
+
+    > * {
+      display: flex;
+      flex: 1 1 auto;
+      min-height: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    #mapmyvisitors-widget {
+      display: flex !important;
+      flex: 1 1 auto !important;
+      flex-direction: column !important;
+      width: 100% !important;
+      height: 100% !important;
+      min-height: 100% !important;
+      max-width: none !important;
+      margin: 0 !important;
+
+      > * {
+        flex: 1 1 auto;
+        min-height: 0;
+        width: 100% !important;
+      }
+
+      > * > * {
+        flex: 1 1 auto;
+        min-height: 0;
+        width: 100% !important;
+        height: 100% !important;
+      }
+    }
+
+    #mapmyvisitors-widget .mapmyvisitors-map-container {
+      display: flex !important;
+      flex-direction: column;
+      flex: 1 1 auto !important;
+      height: 100% !important;
+      min-height: 100% !important;
+    }
+
+    #mapmyvisitors-widget .mapmyvisitors-map {
+      flex: 1 1 auto;
+      height: 100% !important;
+      min-height: 100% !important;
+      width: 100% !important;
+      background-size: cover;
+    }
+
+    iframe,
+    canvas,
+    object,
+    embed,
+    img {
+      flex: 1 1 auto;
+      width: 100% !important;
+      height: 100% !important;
+      min-height: 100% !important;
+    }
+  }
+}
+
 .author-location-map {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- override the MapMyVisitors widget markup so it stretches to the full height and width of the 63.33% ratio frame
- keep nested map containers flexible so the generated map canvas covers the entire card beside Google Maps on narrow screens

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68db5075524c832d8ab2d08c812e4568