### PR TITLE
Fix visitor map height on narrow screens

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -394,10 +394,6 @@
     &::before {
       display: block;
       padding-bottom: 63.33%;
-
-      @supports (aspect-ratio: 1) {
-        display: none;
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the MapMyVisitors embed always keeps the 63.33% padding-based ratio so it fills its flex slot alongside Google Maps

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db62315000832dac4eef154754b488