### PR TITLE
Improve narrow screen map sizing

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -362,6 +362,19 @@
     width: 100%;
     height: 100%;
   }
+
+  iframe,
+  img,
+  canvas,
+  object {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  img {
+    object-fit: cover;
+  }
 }
 
 .author__map-sidebar--inline {


### PR DESCRIPTION
## Summary
- ensure embedded visitor maps stretch to fill their container on narrow screens
- let visitor map images cover the available space for a consistent appearance

## Testing
- not run (environment could not install Jekyll dependencies due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68db6a9a64c0832d8e810045657bd95a