### PR TITLE
Rework dark theme with curated grayscale palette

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -7,21 +7,21 @@ html.theme-dark {
 }
 
 html.theme-dark body {
-  background-color: #0f172a;
-  color: #e2e8f0;
+  background-color: rgba(#11212D, 0.94);
+  color: #CCD0CF;
 }
 
 html.theme-dark .masthead {
-  background-color: #111827;
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(#253745, 0.95);
+  border-bottom-color: rgba(#4A5C6A, 0.35);
 }
 
 html.theme-dark .masthead__menu a {
-  color: #e2e8f0;
+  color: #CCD0CF;
 }
 
 html.theme-dark .masthead__menu a:hover {
-  color: #bfdbfe;
+  color: #9BA8AB;
 }
 
 html.theme-dark .greedy-nav {
@@ -29,23 +29,23 @@ html.theme-dark .greedy-nav {
 }
 
 html.theme-dark .greedy-nav button {
-  background-color: #2563eb;
-  color: #f8fafc;
+  background-color: #4A5C6A;
+  color: #CCD0CF;
 }
 
 html.theme-dark .greedy-nav .hidden-links {
-  background: #1f2937;
-  border-color: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  background: rgba(#11212D, 0.92);
+  border-color: rgba(#4A5C6A, 0.45);
+  box-shadow: 0 12px 30px rgba(#11212D, 0.65);
 }
 
 html.theme-dark .greedy-nav .hidden-links a {
-  color: #e2e8f0;
+  color: #CCD0CF;
 }
 
 html.theme-dark .greedy-nav .hidden-links a:hover {
-  color: #bfdbfe;
-  background: rgba(59, 130, 246, 0.2);
+  color: #9BA8AB;
+  background: rgba(#253745, 0.6);
 }
 
 html.theme-dark .page__content {
@@ -54,30 +54,30 @@ html.theme-dark .page__content {
 
 html.theme-dark .page__content h1,
 html.theme-dark .page__content hr {
-  border-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(#4A5C6A, 0.45);
 }
 
 html.theme-dark .page__content a {
-  color: #93c5fd;
+  color: #9BA8AB;
 }
 
 html.theme-dark .page__content a:hover,
 html.theme-dark .page__content a:focus {
-  color: #bfdbfe;
-  background-color: rgba(59, 130, 246, 0.12);
-  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
+  color: #CCD0CF;
+  background-color: rgba(#253745, 0.55);
+  box-shadow: 0 0 0 1px rgba(#4A5C6A, 0.6);
 }
 
 html.theme-dark .page__content code {
-  background: rgba(148, 163, 184, 0.18);
-  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(#253745, 0.6);
+  border-color: rgba(#4A5C6A, 0.65);
   box-shadow: none;
-  color: #e2e8f0;
+  color: #CCD0CF;
 }
 
 html.theme-dark blockquote {
-  border-left-color: rgba(59, 130, 246, 0.7);
-  background: rgba(30, 41, 59, 0.6);
+  border-left-color: rgba(#4A5C6A, 0.9);
+  background: rgba(#253745, 0.7);
 }
 
 html.theme-dark .sidebar {
@@ -85,60 +85,60 @@ html.theme-dark .sidebar {
 }
 
 html.theme-dark .sidebar a {
-  color: #93c5fd;
+  color: #9BA8AB;
 }
 
 html.theme-dark .sidebar a:hover {
-  color: #bfdbfe;
+  color: #CCD0CF;
 }
 
 html.theme-dark .author__avatar img {
-  border-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(#CCD0CF, 0.45);
 }
 
 html.theme-dark .author__urls {
-  background: #1f2937;
-  border-color: rgba(255, 255, 255, 0.1);
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
-  color: #e2e8f0;
+  background: rgba(#253745, 0.8);
+  border-color: rgba(#4A5C6A, 0.45);
+  box-shadow: 0 10px 25px rgba(#11212D, 0.55);
+  color: #CCD0CF;
 }
 
 html.theme-dark .author__urls a {
-  color: #e2e8f0;
+  color: #CCD0CF;
 }
 
 html.theme-dark .author__urls a:hover {
-  color: #bfdbfe;
-  background: rgba(59, 130, 246, 0.25);
+  color: #9BA8AB;
+  background: rgba(#11212D, 0.55);
 }
 
 html.theme-dark .page__footer {
-  background-color: #111827;
-  border-top-color: rgba(255, 255, 255, 0.08);
-  color: rgba(226, 232, 240, 0.85);
+  background-color: rgba(#11212D, 0.96);
+  border-top-color: rgba(#4A5C6A, 0.35);
+  color: rgba(#CCD0CF, 0.9);
 }
 
 html.theme-dark .page__footer a {
-  color: #e2e8f0;
+  color: #CCD0CF;
 }
 
 html.theme-dark .page__footer a:hover {
-  color: #bfdbfe;
+  color: #9BA8AB;
 }
 
 html.theme-dark .btn {
-  color: #f9fafb !important;
-  background-color: rgba(#111827, 0.7);
-  border-color: transparent;
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
+  color: #CCD0CF !important;
+  background-color: rgba(#253745, 0.85);
+  border-color: rgba(#4A5C6A, 0.5);
+  box-shadow: 0 6px 18px rgba(#11212D, 0.65);
 }
 
 html.theme-dark .btn:hover,
 html.theme-dark .btn:focus-visible {
-  background-color: rgba(#1f2937, 0.92);
-  border-color: rgba(#60a5fa, 0.45);
-  color: #f9fafb !important;
-  box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+  background-color: rgba(#4A5C6A, 0.9);
+  border-color: rgba(#9BA8AB, 0.65);
+  color: #CCD0CF !important;
+  box-shadow: 0 10px 24px rgba(#11212D, 0.75);
 }
 
 html.theme-dark .btn:focus-visible {
@@ -146,28 +146,28 @@ html.theme-dark .btn:focus-visible {
 }
 
 html.theme-dark .btn:focus:not(:focus-visible) {
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
-  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(#11212D, 0.55);
+  border-color: rgba(#4A5C6A, 0.45);
 }
 
 html.theme-dark table,
 html.theme-dark .page__content .news-list {
-  border-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(#4A5C6A, 0.45);
 }
 
 html.theme-dark .publication-controls input,
 html.theme-dark .publication-controls select {
-  background-color: #1f2937;
-  border-color: rgba(255, 255, 255, 0.12);
-  color: #e2e8f0;
+  background-color: rgba(#253745, 0.85);
+  border-color: rgba(#4A5C6A, 0.45);
+  color: #CCD0CF;
 }
 
 html.theme-dark .publication-controls input::placeholder {
-  color: rgba(226, 232, 240, 0.6);
+  color: rgba(#9BA8AB, 0.75);
 }
 
 html.theme-dark .publication-controls select option {
-  color: #0f172a;
+  color: #11212D;
 }
 
 html.theme-dark .publication-badge img,
@@ -176,23 +176,23 @@ html.theme-dark .publication-cite img {
 }
 
 html.theme-dark .cv-item {
-  border-bottom-color: rgba(255, 255, 255, 0.12);
+  border-bottom-color: rgba(#4A5C6A, 0.45);
 }
 
 html.theme-dark .cv-main {
-  color: rgba(226, 232, 240, 0.92);
+  color: rgba(#CCD0CF, 0.92);
 }
 
 html.theme-dark .cv-date {
-  color: rgba(226, 232, 240, 0.65);
+  color: rgba(#9BA8AB, 0.75);
 }
 
 html.theme-dark .cv-sub {
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(#9BA8AB, 0.82);
 }
 
 html.theme-dark .paper-box {
-  border-bottom-color: rgba(255, 255, 255, 0.12);
+  border-bottom-color: rgba(#4A5C6A, 0.45);
 }
 
 html.theme-dark .paper-box-text {
@@ -200,17 +200,11 @@ html.theme-dark .paper-box-text {
 }
 
 html.theme-dark .badge {
-  background-color: rgba(59, 130, 246, 0.85);
-  color: #0b1120;
+  background-color: rgba(#9BA8AB, 0.85);
+  color: #11212D;
 }
 
 html.theme-dark .publication-actions .btn {
-  box-shadow: none;
-}
-
-html.theme-dark .author__urls {
-  background: transparent;
-  border-color: rgba(255, 255, 255, 0.12);
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- retune dark mode backgrounds, borders, and text colors to use the requested grayscale palette
- update interactive states (links, buttons, blockquotes, etc.) to maintain contrast within the new scheme

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll; install missing gem executables with `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68db749b77f8832dbbb700c6bb507188