### PR TITLE
Improve citation modal readability in dark mode

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -530,6 +530,26 @@ mark.publication-highlight {
   :root {
     --publication-highlight: rgba(148, 163, 184, 0.35);
   }
+
+  .citation-modal__dialog {
+    background: #f8fafc;
+    color: #0f172a;
+  }
+
+  .citation-modal__dialog h4 {
+    color: inherit;
+  }
+
+  .citation-modal__content {
+    background: #e2e8f0;
+    color: #0f172a;
+  }
+
+  .citation-modal__tab {
+    background: #e2e8f0;
+    color: #1f2937;
+    border-color: #cbd5f5;
+  }
 }
 
 .contact-location {


### PR DESCRIPTION
## Summary
- adjust the citation modal colors in dark mode so that dialog headings, tabs, and content use high-contrast text on light surfaces

## Testing
- Failed: bundle install (403 Forbidden from rubygems)


------
https://chatgpt.com/codex/tasks/task_e_68db928f9700832d943c27b1f122eb05