### PR TITLE
Align citation modal styling with theme selections

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -146,6 +146,24 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   --publication-accent: #224b8d;
   --publication-accent-hover: #1a3a6d;
   --publication-accent-soft: rgba(34, 75, 141, 0.18);
+  --citation-modal-overlay: rgba(15, 23, 42, 0.45);
+  --citation-modal-dialog-bg: #fff;
+  --citation-modal-dialog-color: #0f172a;
+  --citation-modal-dialog-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  --citation-modal-close-color: #57606a;
+  --citation-modal-tab-bg: #f6f8fa;
+  --citation-modal-tab-border: #c1c7d0;
+  --citation-modal-tab-color: #24292f;
+  --citation-modal-tab-active-color: #fff;
+  --citation-modal-content-bg: #f6f8fa;
+  --citation-modal-content-color: #0f172a;
+  --citation-modal-feedback-color: var(--publication-accent);
+  --citation-modal-action-shadow: none;
+  --citation-modal-copy-bg: #fff;
+  --citation-modal-copy-border: var(--publication-accent);
+  --citation-modal-copy-color: var(--publication-accent);
+  --citation-modal-copy-hover-bg: var(--publication-accent-soft);
+  --citation-modal-download-hover-bg: var(--publication-accent-hover);
 }
 
 .publication-controls {
@@ -381,7 +399,7 @@ mark.publication-highlight {
 .citation-modal {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--citation-modal-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -392,10 +410,11 @@ mark.publication-highlight {
 .citation-modal__dialog {
   position: relative;
   width: min(640px, 100%);
-  background: #fff;
+  background: var(--citation-modal-dialog-bg);
   border-radius: 0.85rem;
+  color: var(--citation-modal-dialog-color, inherit);
   padding: 1.5rem;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--citation-modal-dialog-shadow);
 }
 
 .citation-modal__close {
@@ -407,7 +426,7 @@ mark.publication-highlight {
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
-  color: #57606a;
+  color: var(--citation-modal-close-color);
 }
 
 .citation-modal__tabs {
@@ -419,9 +438,9 @@ mark.publication-highlight {
 .citation-modal__tab {
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid #c1c7d0;
-  background: #f6f8fa;
-  color: #24292f;
+  border: 1px solid var(--citation-modal-tab-border);
+  background: var(--citation-modal-tab-bg);
+  color: var(--citation-modal-tab-color);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -434,11 +453,11 @@ mark.publication-highlight {
 .citation-modal__tab.is-active {
   background: var(--publication-accent);
   border-color: var(--publication-accent);
-  color: #fff;
+  color: var(--citation-modal-tab-active-color, #fff);
 }
 
 .citation-modal__content {
-  background: #f6f8fa;
+  background: var(--citation-modal-content-bg);
   border-radius: 0.65rem;
   padding: 1rem;
   max-height: 320px;
@@ -446,6 +465,7 @@ mark.publication-highlight {
   font-size: 0.92rem;
   line-height: 1.5;
   white-space: pre-wrap;
+  color: var(--citation-modal-content-color, inherit);
 }
 
 .citation-modal__actions {
@@ -460,7 +480,7 @@ mark.publication-highlight {
 .citation-modal__feedback {
   margin-right: auto;
   font-size: 0.85rem;
-  color: var(--publication-accent);
+  color: var(--citation-modal-feedback-color);
 }
 
 .citation-modal__feedback[hidden] {
@@ -477,19 +497,21 @@ mark.publication-highlight {
   font-size: 0.95rem;
   transition: background-color 0.2s ease, color 0.2s ease,
     box-shadow 0.2s ease;
+  box-shadow: var(--citation-modal-action-shadow, none);
 }
 
 .citation-modal__action[data-action="copy"] {
-  background: #fff;
-  color: var(--publication-accent);
+  background: var(--citation-modal-copy-bg);
+  color: var(--citation-modal-copy-color);
+  border-color: var(--citation-modal-copy-border);
 }
 
 .citation-modal__action[data-action="copy"]:hover {
-  background: var(--publication-accent-soft);
+  background: var(--citation-modal-copy-hover-bg);
 }
 
 .citation-modal__action[data-action="download"]:hover {
-  background: var(--publication-accent-hover);
+  background: var(--citation-modal-download-hover-bg);
 }
 
 .citation-modal__action:focus-visible {
@@ -498,52 +520,56 @@ mark.publication-highlight {
 }
 
 @media (prefers-color-scheme: dark) {
-  .citation-modal {
-    background: rgba(15, 23, 42, 0.75);
+  :root {
+    --publication-highlight: rgba(148, 163, 184, 0.35);
+    --publication-accent: #60a5fa;
+    --publication-accent-hover: #3b82f6;
+    --publication-accent-soft: rgba(96, 165, 250, 0.25);
+    --citation-modal-overlay: rgba(15, 23, 42, 0.75);
+    --citation-modal-dialog-bg: #0f172a;
+    --citation-modal-dialog-color: #e2e8f0;
+    --citation-modal-dialog-shadow: 0 24px 60px rgba(2, 6, 23, 0.6);
+    --citation-modal-close-color: #cbd5f5;
+    --citation-modal-tab-bg: rgba(30, 41, 59, 0.85);
+    --citation-modal-tab-border: rgba(148, 163, 184, 0.45);
+    --citation-modal-tab-color: #e2e8f0;
+    --citation-modal-tab-active-color: #0f172a;
+    --citation-modal-content-bg: rgba(15, 23, 42, 0.85);
+    --citation-modal-content-color: #e2e8f0;
+    --citation-modal-feedback-color: #bfdbfe;
+    --citation-modal-action-shadow: 0 10px 30px rgba(2, 6, 23, 0.45);
+    --citation-modal-copy-bg: rgba(148, 163, 184, 0.2);
+    --citation-modal-copy-border: rgba(148, 163, 184, 0.5);
+    --citation-modal-copy-color: #e2e8f0;
+    --citation-modal-copy-hover-bg: rgba(148, 163, 184, 0.32);
+    --citation-modal-download-hover-bg: var(--publication-accent-hover);
   }
+}
 
-  .citation-modal__dialog {
-    background: #0f172a;
-    color: #e2e8f0;
-    box-shadow: 0 24px 60px rgba(2, 6, 23, 0.6);
-  }
-
-  .citation-modal__close {
-    color: #cbd5f5;
-  }
-
-  .citation-modal__tab {
-    background: rgba(30, 41, 59, 0.85);
-    border-color: rgba(148, 163, 184, 0.45);
-    color: #e2e8f0;
-  }
-
-  .citation-modal__tab.is-active {
-    color: #0f172a;
-  }
-
-  .citation-modal__content {
-    background: rgba(15, 23, 42, 0.85);
-    color: #e2e8f0;
-  }
-
-  .citation-modal__feedback {
-    color: #bfdbfe;
-  }
-
-  .citation-modal__action {
-    box-shadow: 0 10px 30px rgba(2, 6, 23, 0.45);
-  }
-
-  .citation-modal__action[data-action="copy"] {
-    background: rgba(148, 163, 184, 0.2);
-    border-color: rgba(148, 163, 184, 0.5);
-    color: #e2e8f0;
-  }
-
-  .citation-modal__action[data-action="copy"]:hover {
-    background: rgba(148, 163, 184, 0.32);
-  }
+html.theme-dark,
+html[data-theme="dark"] {
+  --publication-highlight: rgba(148, 163, 184, 0.35);
+  --publication-accent: #60a5fa;
+  --publication-accent-hover: #3b82f6;
+  --publication-accent-soft: rgba(96, 165, 250, 0.25);
+  --citation-modal-overlay: rgba(15, 23, 42, 0.75);
+  --citation-modal-dialog-bg: #0f172a;
+  --citation-modal-dialog-color: #e2e8f0;
+  --citation-modal-dialog-shadow: 0 24px 60px rgba(2, 6, 23, 0.6);
+  --citation-modal-close-color: #cbd5f5;
+  --citation-modal-tab-bg: rgba(30, 41, 59, 0.85);
+  --citation-modal-tab-border: rgba(148, 163, 184, 0.45);
+  --citation-modal-tab-color: #e2e8f0;
+  --citation-modal-tab-active-color: #0f172a;
+  --citation-modal-content-bg: rgba(15, 23, 42, 0.85);
+  --citation-modal-content-color: #e2e8f0;
+  --citation-modal-feedback-color: #bfdbfe;
+  --citation-modal-action-shadow: 0 10px 30px rgba(2, 6, 23, 0.45);
+  --citation-modal-copy-bg: rgba(148, 163, 184, 0.2);
+  --citation-modal-copy-border: rgba(148, 163, 184, 0.5);
+  --citation-modal-copy-color: #e2e8f0;
+  --citation-modal-copy-hover-bg: rgba(148, 163, 184, 0.32);
+  --citation-modal-download-hover-bg: var(--publication-accent-hover);
 }
 
 @media (max-width: 600px) {
@@ -572,15 +598,6 @@ mark.publication-highlight {
     grid-column: 2;
     justify-self: flex-start;
     margin-top: 0.25rem;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --publication-highlight: rgba(148, 163, 184, 0.35);
-    --publication-accent: #60a5fa;
-    --publication-accent-hover: #3b82f6;
-    --publication-accent-soft: rgba(96, 165, 250, 0.25);
   }
 }
 


### PR DESCRIPTION
## Summary
- add theme-aware CSS custom properties for the citation modal to derive its colors from site variables
- update dark mode preferences and theme toggles to override the citation modal variables so the popup matches the active theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd5982900832da9c3e707f8355b33