### PR TITLE
Adjust publication metadata colors in dark mode

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -170,6 +170,11 @@ html.theme-dark .publication-controls select option {
   color: #0f172a;
 }
 
+html.theme-dark .publication-index,
+html.theme-dark .publication-year {
+  color: #f8fafc;
+}
+
 html.theme-dark .publication-badge img,
 html.theme-dark .publication-cite img {
   filter: brightness(0.95) saturate(1.1);


### PR DESCRIPTION
## Summary
- update the dark theme styles so publication indexes and years render in white for better contrast

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload *(fails: missing jekyll executable due to bundler installation restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc41dc48832d8f4fb9295133832c