### PR TITLE
Improve dark mode button styling

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -127,27 +127,51 @@ html.theme-dark .page__footer a:hover {
 }
 
 html.theme-dark .btn {
-  color: #f9fafb !important;
-  background-color: rgba(#111827, 0.7);
+  color: var(--dark-btn-color, #f9fafb) !important;
+  background: var(--dark-btn-bg, rgba(#111827, 0.7));
   border-color: transparent;
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
+  box-shadow: var(--dark-btn-shadow, 0 6px 18px rgba(#000, 0.35));
 }
 
 html.theme-dark .btn:hover,
 html.theme-dark .btn:focus-visible {
-  background-color: rgba(#1f2937, 0.92);
-  border-color: rgba(#60a5fa, 0.45);
-  color: #f9fafb !important;
-  box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+  background: var(--dark-btn-bg-hover, rgba(#1f2937, 0.92));
+  border-color: var(
+    --dark-btn-border-hover,
+    rgba(#60a5fa, 0.45)
+  );
+  color: var(
+      --dark-btn-color-hover,
+      var(--dark-btn-color, #f9fafb)
+    )
+    !important;
+  box-shadow: var(
+    --dark-btn-shadow-hover,
+    0 10px 24px rgba(#1e3a8a, 0.35)
+  );
 }
 
 html.theme-dark .btn:focus-visible {
   outline: none;
+  box-shadow: var(
+    --dark-btn-focus-shadow,
+    var(--dark-btn-shadow-hover, 0 10px 24px rgba(#1e3a8a, 0.35))
+  );
 }
 
 html.theme-dark .btn:focus:not(:focus-visible) {
-  box-shadow: 0 6px 18px rgba(#000, 0.35);
+  box-shadow: var(--dark-btn-shadow, 0 6px 18px rgba(#000, 0.35));
   border-color: transparent;
+}
+
+html.theme-dark .page__content .news-actions .btn {
+  --dark-btn-bg: var(--cta-button-bg);
+  --dark-btn-color: var(--cta-button-text);
+  --dark-btn-shadow: var(--cta-button-shadow);
+  --dark-btn-bg-hover: var(--cta-button-hover-bg);
+  --dark-btn-color-hover: var(--cta-button-hover-text);
+  --dark-btn-shadow-hover: var(--cta-button-shadow-hover);
+  --dark-btn-border-hover: transparent;
 }
 
 html.theme-dark table,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -26,6 +26,13 @@
   --language-toggle-text-inactive: #{mix(#000, $primary-color, 70%)};
   --language-toggle-shadow-strong: 0 8px 18px rgba($primary-color, 0.22);
   --language-toggle-shadow-soft: 0 4px 12px rgba($primary-color, 0.12);
+  --cta-button-bg: var(--theme-toggle-sun-active-bg);
+  --cta-button-text: var(--theme-toggle-sun-icon-color);
+  --cta-button-hover-bg: var(--theme-toggle-inactive-bg);
+  --cta-button-hover-text: var(--theme-toggle-icon-inactive);
+  --cta-button-shadow: var(--theme-toggle-shadow-strong);
+  --cta-button-shadow-hover: var(--theme-toggle-shadow-soft);
+  --cta-button-focus-ring: rgba($primary-color, 0.25);
 
 
 }
@@ -322,26 +329,29 @@
 }
 
 html.theme-dark {
-  --masthead-toggle-underline: rgba(191, 219, 254, 0.85);
-  --toggle-base-panel-bg: rgba(148, 163, 184, 0.28);
+  --masthead-toggle-underline: rgba(191, 219, 254, 0.9);
+  --toggle-base-panel-bg: rgba(#1f2937, 0.62);
   --theme-toggle-track-bg: var(--toggle-base-panel-bg);
-  --theme-toggle-inactive-bg: var(--language-toggle-inactive-bg);
-  --theme-toggle-icon-inactive: var(--language-toggle-text-inactive);
-  --theme-toggle-sun-icon-color: var(--language-toggle-text-inactive);
-  --theme-toggle-moon-active-bg: var(--language-toggle-active-bg);
-  --theme-toggle-moon-icon-color: var(--language-toggle-text-active);
-  --theme-toggle-shadow-strong: 0 12px 26px rgba(15, 23, 42, 0.48);
-  --theme-toggle-shadow-soft: 0 8px 18px rgba(15, 23, 42, 0.3);
-  --language-toggle-active-bg: linear-gradient(
-    135deg,
-    #{mix(#fff, $primary-color, 12%)},
-    #{mix(#000, $primary-color, 60%)}
-  );
-  --language-toggle-inactive-bg: #{mix(#000, $primary-color, 65%)};
+  --language-toggle-active-bg: linear-gradient(135deg, #60a5fa, #2563eb);
+  --language-toggle-inactive-bg: rgba(#111827, 0.78);
   --language-toggle-text-active: #f8fafc;
-  --language-toggle-text-inactive: #{mix(#fff, $primary-color, 75%)};
-  --language-toggle-shadow-strong: 0 12px 26px rgba(15, 23, 42, 0.48);
-  --language-toggle-shadow-soft: 0 8px 18px rgba(15, 23, 42, 0.3);
+  --language-toggle-text-inactive: rgba(#dbeafe, 0.85);
+  --language-toggle-shadow-strong: 0 14px 32px rgba(#1e3a8a, 0.5);
+  --language-toggle-shadow-soft: 0 10px 24px rgba(#1e3a8a, 0.32);
+  --theme-toggle-inactive-bg: rgba(#111827, 0.82);
+  --theme-toggle-icon-inactive: rgba(#bfdbfe, 0.75);
+  --theme-toggle-sun-icon-color: rgba(#bfdbfe, 0.7);
+  --theme-toggle-moon-active-bg: linear-gradient(135deg, #60a5fa, #1d4ed8);
+  --theme-toggle-moon-icon-color: #f8fafc;
+  --theme-toggle-shadow-strong: 0 14px 32px rgba(#1e3a8a, 0.5);
+  --theme-toggle-shadow-soft: 0 10px 24px rgba(#1e3a8a, 0.32);
+  --cta-button-bg: linear-gradient(135deg, #60a5fa, #2563eb);
+  --cta-button-text: #f8fafc;
+  --cta-button-hover-bg: rgba(#2563eb, 0.88);
+  --cta-button-hover-text: #f8fafc;
+  --cta-button-shadow: 0 14px 32px rgba(#1e3a8a, 0.5);
+  --cta-button-shadow-hover: 0 12px 28px rgba(#1e3a8a, 0.35);
+  --cta-button-focus-ring: rgba(#60a5fa, 0.45);
 
   .masthead__actions {
     color: #e2e8f0;

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -132,40 +132,43 @@
 
     .btn {
       @include cta-button;
-      background: var(--theme-toggle-sun-active-bg);
-      color: var(--theme-toggle-sun-icon-color) !important;
+      background: var(--cta-button-bg);
+      color: var(--cta-button-text) !important;
       border-color: transparent !important;
+      box-shadow: var(--cta-button-shadow);
       transform: translateY(0);
       transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease,
-        transform 0.2s ease;
-    }
-
-    .btn:hover {
-      background: var(--theme-toggle-inactive-bg);
-      color: var(--theme-toggle-icon-inactive) !important;
-      border-color: transparent !important;
-      transform: translateY(-1px);
-      text-decoration: none;
+        box-shadow 0.3s ease, transform 0.2s ease;
     }
 
     .btn:active {
-      background: var(--theme-toggle-inactive-bg);
-      color: var(--theme-toggle-icon-inactive) !important;
+      background: var(--cta-button-bg);
+      color: var(--cta-button-text) !important;
       border-color: transparent !important;
       transform: translateY(0);
+      box-shadow: var(--cta-button-shadow);
     }
 
     .btn:hover,
     .btn:focus-visible {
       outline: none;
+      background: var(--cta-button-hover-bg);
+      color: var(--cta-button-hover-text) !important;
+      border-color: transparent !important;
+      transform: translateY(-1px);
+      text-decoration: none;
+      box-shadow: var(--cta-button-shadow-hover);
     }
 
     .btn:focus-visible {
-      box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
+      box-shadow: 0 0 0 3px var(--cta-button-focus-ring),
+        var(--cta-button-shadow-hover);
+      --dark-btn-focus-shadow: 0 0 0 3px var(--cta-button-focus-ring),
+        var(--cta-button-shadow-hover);
     }
 
     .btn:focus:not(:focus-visible) {
-      box-shadow: var(--theme-toggle-shadow-soft);
+      box-shadow: var(--cta-button-shadow);
     }
   }
 


### PR DESCRIPTION
## Summary
- align the dark mode theme toggle palette with a cohesive blue gradient and shared CSS custom properties
- update the "Read more news" call-to-action to consume the new color tokens for hover, focus, and active states in all themes
- add dark-mode specific button overrides via CSS variables to keep colors, shadows, and focus treatment consistent

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbf876a288832d98d213e741659404