### PR TITLE
Refine dark mode button styling

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -29,8 +29,33 @@ html.theme-dark .greedy-nav {
 }
 
 html.theme-dark .greedy-nav button {
-  background-color: #2563eb;
-  color: #f8fafc;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.85rem;
+  background: var(--cta-button-bg);
+  color: var(--cta-button-text);
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  box-shadow: var(--cta-button-shadow);
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease,
+    transform 0.2s ease;
+}
+
+html.theme-dark .greedy-nav button:hover,
+html.theme-dark .greedy-nav button:focus-visible {
+  background: var(--cta-button-hover-bg);
+  color: var(--cta-button-hover-text);
+  box-shadow: var(--cta-button-shadow-hover);
+}
+
+html.theme-dark .greedy-nav button:focus-visible {
+  outline: 2px solid var(--cta-button-focus-ring);
+  outline-offset: 2px;
+}
+
+html.theme-dark .greedy-nav button:active {
+  transform: translateY(1px);
 }
 
 html.theme-dark .greedy-nav .hidden-links {

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -330,28 +330,28 @@
 
 html.theme-dark {
   --masthead-toggle-underline: rgba(191, 219, 254, 0.9);
-  --toggle-base-panel-bg: rgba(#1f2937, 0.62);
+  --toggle-base-panel-bg: rgba(#1e293b, 0.7);
   --theme-toggle-track-bg: var(--toggle-base-panel-bg);
-  --language-toggle-active-bg: linear-gradient(135deg, #60a5fa, #2563eb);
-  --language-toggle-inactive-bg: rgba(#111827, 0.78);
+  --language-toggle-active-bg: linear-gradient(135deg, #3b82f6, #2563eb);
+  --language-toggle-inactive-bg: rgba(#0f172a, 0.78);
   --language-toggle-text-active: #f8fafc;
-  --language-toggle-text-inactive: rgba(#dbeafe, 0.85);
-  --language-toggle-shadow-strong: 0 14px 32px rgba(#1e3a8a, 0.5);
-  --language-toggle-shadow-soft: 0 10px 24px rgba(#1e3a8a, 0.32);
-  --theme-toggle-inactive-bg: rgba(#111827, 0.82);
-  --theme-toggle-icon-inactive: rgba(#bfdbfe, 0.75);
-  --theme-toggle-sun-icon-color: rgba(#bfdbfe, 0.7);
-  --theme-toggle-moon-active-bg: linear-gradient(135deg, #60a5fa, #1d4ed8);
+  --language-toggle-text-inactive: rgba(#cbd5f5, 0.85);
+  --language-toggle-shadow-strong: 0 18px 38px rgba(#0f172a, 0.45);
+  --language-toggle-shadow-soft: 0 12px 28px rgba(#0f172a, 0.35);
+  --theme-toggle-inactive-bg: rgba(#0f172a, 0.82);
+  --theme-toggle-icon-inactive: rgba(#bfdbfe, 0.78);
+  --theme-toggle-sun-icon-color: rgba(#bfdbfe, 0.78);
+  --theme-toggle-moon-active-bg: linear-gradient(135deg, #3b82f6, #1d4ed8);
   --theme-toggle-moon-icon-color: #f8fafc;
-  --theme-toggle-shadow-strong: 0 14px 32px rgba(#1e3a8a, 0.5);
-  --theme-toggle-shadow-soft: 0 10px 24px rgba(#1e3a8a, 0.32);
-  --cta-button-bg: linear-gradient(135deg, #60a5fa, #2563eb);
+  --theme-toggle-shadow-strong: 0 18px 38px rgba(#0f172a, 0.45);
+  --theme-toggle-shadow-soft: 0 12px 28px rgba(#0f172a, 0.35);
+  --cta-button-bg: linear-gradient(135deg, #3b82f6, #2563eb);
   --cta-button-text: #f8fafc;
-  --cta-button-hover-bg: rgba(#2563eb, 0.88);
+  --cta-button-hover-bg: linear-gradient(135deg, #2563eb, #1d4ed8);
   --cta-button-hover-text: #f8fafc;
-  --cta-button-shadow: 0 14px 32px rgba(#1e3a8a, 0.5);
-  --cta-button-shadow-hover: 0 12px 28px rgba(#1e3a8a, 0.35);
-  --cta-button-focus-ring: rgba(#60a5fa, 0.45);
+  --cta-button-shadow: 0 18px 38px rgba(#0f172a, 0.45);
+  --cta-button-shadow-hover: 0 14px 32px rgba(#0f172a, 0.4);
+  --cta-button-focus-ring: rgba(#3b82f6, 0.55);
 
   .masthead__actions {
     color: #e2e8f0;


### PR DESCRIPTION
## Summary
- align dark mode toggle and CTA color variables on a shared gradient palette for improved cohesion
- restyle the greedy navigation collapse control in dark mode to reuse CTA colors, shadows, and focus indicators

## Testing
- bundle install *(fails: unable to download gems, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dc780879a4832d9c0ea828b1060dd5