### PR TITLE
Adjust dark mode accent colors for header and CTA buttons

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -35,17 +35,18 @@ html.theme-dark .greedy-nav button {
   padding: 0 0.85rem;
   background: var(--cta-button-bg);
   color: var(--cta-button-text);
-  border: 1px solid transparent;
+  border: 1px solid rgba(147, 197, 253, 0.35);
   border-radius: 0.75rem;
   box-shadow: var(--cta-button-shadow);
   transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease,
-    transform 0.2s ease;
+    transform 0.2s ease, border-color 0.3s ease;
 }
 
 html.theme-dark .greedy-nav button:hover,
 html.theme-dark .greedy-nav button:focus-visible {
   background: var(--cta-button-hover-bg);
   color: var(--cta-button-hover-text);
+  border-color: rgba(191, 219, 254, 0.55);
   box-shadow: var(--cta-button-shadow-hover);
 }
 
@@ -154,8 +155,9 @@ html.theme-dark .page__footer a:hover {
 html.theme-dark .btn {
   color: var(--dark-btn-color, #f9fafb) !important;
   background: var(--dark-btn-bg, rgba(#111827, 0.7));
-  border-color: transparent;
+  border-color: rgba(147, 197, 253, 0.35);
   box-shadow: var(--dark-btn-shadow, 0 6px 18px rgba(#000, 0.35));
+  --dark-btn-border-hover: rgba(191, 219, 254, 0.6);
 }
 
 html.theme-dark .btn:hover,
@@ -196,7 +198,7 @@ html.theme-dark .page__content .news-actions .btn {
   --dark-btn-bg-hover: var(--cta-button-hover-bg);
   --dark-btn-color-hover: var(--cta-button-hover-text);
   --dark-btn-shadow-hover: var(--cta-button-shadow-hover);
-  --dark-btn-border-hover: transparent;
+  --dark-btn-border-hover: rgba(191, 219, 254, 0.6);
 }
 
 html.theme-dark table,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -339,19 +339,19 @@ html.theme-dark {
   --language-toggle-shadow-strong: 0 18px 38px rgba(#0f172a, 0.45);
   --language-toggle-shadow-soft: 0 12px 28px rgba(#0f172a, 0.35);
   --theme-toggle-inactive-bg: rgba(#0f172a, 0.82);
-  --theme-toggle-icon-inactive: rgba(#bfdbfe, 0.78);
-  --theme-toggle-sun-icon-color: rgba(#bfdbfe, 0.78);
-  --theme-toggle-moon-active-bg: linear-gradient(135deg, #3b82f6, #1d4ed8);
-  --theme-toggle-moon-icon-color: #f8fafc;
+  --theme-toggle-icon-inactive: rgba(#93c5fd, 0.7);
+  --theme-toggle-sun-icon-color: rgba(#93c5fd, 0.7);
+  --theme-toggle-moon-active-bg: rgba(#93c5fd, 0.22);
+  --theme-toggle-moon-icon-color: #93c5fd;
   --theme-toggle-shadow-strong: 0 18px 38px rgba(#0f172a, 0.45);
-  --theme-toggle-shadow-soft: 0 12px 28px rgba(#0f172a, 0.35);
-  --cta-button-bg: linear-gradient(135deg, #3b82f6, #2563eb);
-  --cta-button-text: #f8fafc;
-  --cta-button-hover-bg: linear-gradient(135deg, #2563eb, #1d4ed8);
-  --cta-button-hover-text: #f8fafc;
-  --cta-button-shadow: 0 18px 38px rgba(#0f172a, 0.45);
-  --cta-button-shadow-hover: 0 14px 32px rgba(#0f172a, 0.4);
-  --cta-button-focus-ring: rgba(#3b82f6, 0.55);
+  --theme-toggle-shadow-soft: 0 12px 28px rgba(#0f172a, 0.32);
+  --cta-button-bg: rgba(#93c5fd, 0.14);
+  --cta-button-text: #93c5fd;
+  --cta-button-hover-bg: rgba(#bfdbfe, 0.22);
+  --cta-button-hover-text: #bfdbfe;
+  --cta-button-shadow: 0 16px 32px rgba(#0f172a, 0.35);
+  --cta-button-shadow-hover: 0 18px 36px rgba(#0f172a, 0.4);
+  --cta-button-focus-ring: rgba(#93c5fd, 0.5);
 
   .masthead__actions {
     color: #e2e8f0;


### PR DESCRIPTION
## Summary
- align the dark theme navigation toggle, theme switcher, and CTA buttons with the sidebar accent color
- refresh button borders and hover states to deliver more consistent contrast in dark mode

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68dc8d002608832db2b15d7c867e0d26