### PR TITLE
Redesign language and theme toggles with Font Awesome icons

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -12,13 +12,17 @@
         class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-en"
         aria-hidden="true"
       >
-        EN
+        <i class="fas fa-globe toggle-button__symbol" aria-hidden="true"></i>
+        <span class="toggle-button__label toggle-button__label--language">EN</span>
       </span>
       <span
         class="toggle-button__icon toggle-button__icon--language toggle-button__icon--language-zh"
         aria-hidden="true"
       >
-        中
+        <i class="fas fa-globe toggle-button__symbol" aria-hidden="true"></i>
+        <span class="toggle-button__label toggle-button__label--language toggle-button__label--zh"
+          >中文</span
+        >
       </span>
     </button>
     {% endcapture %}
@@ -34,43 +38,13 @@
         class="toggle-button__icon toggle-button__icon--theme toggle-button__icon--sun"
         aria-hidden="true"
       >
-        <svg
-          class="toggle-icon"
-          viewBox="0 0 24 24"
-          role="presentation"
-          focusable="false"
-          aria-hidden="true"
-        >
-          <path
-            fill="none"
-            stroke="currentColor"
-            stroke-width="3"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M12 3.25v1.5m0 14.5v1.5m8.25-8.25h-1.5m-14.5 0h-1.5m15.157-7.093-1.06 1.06M7.031 16.657l-1.06 1.06m12.726 0-1.06-1.06M7.031 7.03l-1.06-1.06M12 8.75a3.25 3.25 0 1 1 0 6.5 3.25 3.25 0 0 1 0-6.5Z"
-          />
-        </svg>
+        <i class="fas fa-sun toggle-button__symbol" aria-hidden="true"></i>
       </span>
       <span
         class="toggle-button__icon toggle-button__icon--theme toggle-button__icon--moon"
         aria-hidden="true"
       >
-        <svg
-          class="toggle-icon"
-          viewBox="0 0 24 24"
-          role="presentation"
-          focusable="false"
-          aria-hidden="true"
-        >
-          <path
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M21 12.79A9 9 0 0 1 11.21 3 7.25 7.25 0 1 0 21 12.79Z"
-          />
-        </svg>
+        <i class="fas fa-moon toggle-button__symbol" aria-hidden="true"></i>
       </span>
     </button>
     {% endcapture %}

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -184,10 +184,38 @@
     width: 1.8rem;
     height: 1.8rem;
     font-size: 1.25rem;
+    gap: 0.35rem;
+    line-height: 1;
   }
 
   &__icon--sun {
     display: none;
+  }
+
+  &__symbol {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.05rem;
+    line-height: 1;
+  }
+
+  &__label {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__label--language {
+    font-family: $sans-serif-narrow;
+  }
+
+  &__label--zh {
+    font-size: 0.7rem;
+    letter-spacing: 0;
+    text-transform: none;
   }
 }
 
@@ -224,12 +252,8 @@
     border-radius: 0.65rem;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    font-family: $sans-serif-narrow;
-    font-size: 0.85rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    justify-content: space-between;
+    padding: 0 0.55rem;
     background: var(--language-toggle-inactive-bg);
     color: var(--language-toggle-text-inactive);
     box-shadow: var(--language-toggle-shadow-soft);
@@ -240,6 +264,14 @@
       box-shadow 0.35s ease;
     pointer-events: none;
     z-index: 1;
+  }
+
+  .toggle-button__icon--language .toggle-button__symbol {
+    font-size: 0.9rem;
+  }
+
+  .toggle-button__icon--language .toggle-button__label {
+    font-size: 0.7rem;
   }
 
   .toggle-button__icon--language-en {
@@ -284,6 +316,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
+    gap: 0;
     background: var(--theme-toggle-inactive-bg);
     color: var(--theme-toggle-icon-inactive);
     box-shadow: var(--theme-toggle-shadow-soft);
@@ -294,11 +328,10 @@
       box-shadow 0.35s ease;
     pointer-events: none;
     z-index: 1;
+  }
 
-    svg {
-      width: 1.15rem;
-      height: 1.15rem;
-    }
+  .toggle-button__icon--theme .toggle-button__symbol {
+    font-size: 1.15rem;
   }
 
   .toggle-button__icon--sun {


### PR DESCRIPTION
## Summary
- replace the language toggle text and theme SVGs with Font Awesome globe, sun, and moon icons
- update masthead toggle styling to accommodate the new icon layout and typography

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not available in the environment)*
- bundle install *(fails: network request for RubyGems returns 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68dcca113234832da7073b18e56d73cc