### PR TITLE
Fix mobile masthead toggle overlap

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -225,36 +225,19 @@ html.theme-dark {
   }
 
   .masthead__actions {
-    display: none;
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    padding-top: 0.5rem;
   }
 
   .greedy-nav {
-    .visible-links .masthead__menu-item--toggle {
-      display: table-cell;
-      text-align: right;
-    }
+    padding-bottom: 0.25rem;
 
+    .visible-links .masthead__menu-item--toggle,
     .hidden-links .masthead__menu-item--toggle {
-      display: block;
-      padding: 0;
-      text-align: center;
-
-      &:last-child {
-        border-bottom: none;
-      }
-
-      .toggle-button {
-        width: 100%;
-      }
+      display: none !important;
     }
-  }
-
-  .masthead__menu-item--toggle .toggle-button {
-    margin: 0;
-  }
-
-  .greedy-nav .visible-links .masthead__menu-item--toggle + .masthead__menu-item--toggle {
-    padding-left: 0.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- show the theme and language toggles below the navigation on small screens to avoid conflicts with the greedy-nav collapse button
- hide the duplicate toggle items that were previously rendered inside the greedy-nav menu on mobile widths

## Testing
- `bundle exec jekyll build` *(fails: bundler cannot install dependencies because rubygems.org responded with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd9186c1c832db1ae0a4c7ddb2c96