### PR TITLE
Adjust dark theme navigation highlights

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -48,6 +48,18 @@ html.theme-dark .greedy-nav .hidden-links a:hover {
   background: rgba(59, 130, 246, 0.2);
 }
 
+html.theme-dark .greedy-nav .visible-links a {
+  color: inherit;
+}
+
+html.theme-dark .greedy-nav .visible-links a:focus-visible {
+  color: #bfdbfe;
+}
+
+html.theme-dark .greedy-nav .visible-links a::before {
+  background: currentColor;
+}
+
 html.theme-dark .page__content {
   color: inherit;
 }

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -193,7 +193,7 @@
 
 html.theme-dark {
   --masthead-toggle-hover-color: #bfdbfe;
-  --masthead-toggle-underline-bg: rgba(148, 197, 255, 0.8);
+  --masthead-toggle-underline-bg: currentColor;
   --masthead-toggle-focus-shadow: rgba(96, 165, 250, 0.45);
 
   .masthead__actions {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -246,6 +246,17 @@
             -ms-transform: scaleX(1);
                 transform: scaleX(1); /* reveal*/
       }
+
+      &:focus-visible {
+        color: $masthead-link-color-hover;
+        outline: none;
+      }
+
+      &:focus-visible:before {
+        -webkit-transform: scaleX(1);
+            -ms-transform: scaleX(1);
+                transform: scaleX(1); /* reveal*/
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- align dark mode navigation link underlines with the active text color
- add keyboard focus styling to primary navigation items
- reuse the link color for language and theme toggle underline animations in dark mode

## Testing
- ⚠️ `bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --force_polling` *(fails: `jekyll` executable missing)*
- ⚠️ `bundle install` *(fails: rubygems.org returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdb47148c832d896bf1b54086d04f