### PR TITLE
Adjust dark theme nav and toggle hover colors

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -48,6 +48,22 @@ html.theme-dark .greedy-nav .hidden-links a:hover {
   background: rgba(59, 130, 246, 0.2);
 }
 
+html.theme-dark .greedy-nav .visible-links a {
+  color: inherit;
+}
+
+html.theme-dark .greedy-nav .visible-links a:focus-visible {
+  color: #bfdbfe;
+}
+
+html.theme-dark .greedy-nav .visible-links a:hover {
+  color: #bfdbfe;
+}
+
+html.theme-dark .greedy-nav .visible-links a::before {
+  background: #bfdbfe;
+}
+
 html.theme-dark .page__content {
   color: inherit;
 }

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -193,7 +193,7 @@
 
 html.theme-dark {
   --masthead-toggle-hover-color: #bfdbfe;
-  --masthead-toggle-underline-bg: rgba(148, 197, 255, 0.8);
+  --masthead-toggle-underline-bg: #bfdbfe;
   --masthead-toggle-focus-shadow: rgba(96, 165, 250, 0.45);
 
   .masthead__actions {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -246,6 +246,17 @@
             -ms-transform: scaleX(1);
                 transform: scaleX(1); /* reveal*/
       }
+
+      &:focus-visible {
+        color: $masthead-link-color-hover;
+        outline: none;
+      }
+
+      &:focus-visible:before {
+        -webkit-transform: scaleX(1);
+            -ms-transform: scaleX(1);
+                transform: scaleX(1); /* reveal*/
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- set the dark mode navigation underline hover color to #bfdbfe for consistency
- update the dark theme toggle underline accent to reuse the #bfdbfe highlight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcdb47148c832d896bf1b54086d04f