### PR TITLE
Adjust dark mode toggle hover color

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -203,6 +203,11 @@ html.theme-dark {
   .masthead__actions .toggle-button,
   .masthead__menu-item--toggle .toggle-button {
     color: #e2e8f0;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--masthead-toggle-hover-color);
+    }
   }
 
   .toggle-button--theme {


### PR DESCRIPTION
## Summary
- align the language and theme toggle hover colors in dark mode with the underline accent using the shared masthead variable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dce0e118f0832db6c5214809788834