### PR TITLE
Refine homepage action button underline animation

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -132,26 +132,49 @@
 
     .btn {
       @include cta-button;
-      background: var(--theme-toggle-sun-active-bg);
-      color: var(--theme-toggle-sun-icon-color) !important;
-      border-color: transparent !important;
+      position: relative;
+      height: auto;
+      min-height: 0;
+      padding: 0.6rem 1.4rem;
+      border: none !important;
+      border-radius: 999px;
+      background: none;
+      color: var(--masthead-toggle-hover-color) !important;
+      box-shadow: none;
+      gap: 0.35rem;
+      opacity: 0.85;
       transform: translateY(0);
-      transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease,
-        transform 0.2s ease;
+      transition: color 0.2s ease, opacity 0.2s ease, transform 0.2s ease,
+        box-shadow 0.2s ease;
+
+      &::after {
+        content: "";
+        position: absolute;
+        left: 50%;
+        bottom: 0.2rem;
+        width: calc(100% - 1.8rem);
+        height: 0.16rem;
+        border-radius: 999px;
+        background: var(--masthead-toggle-underline-bg);
+        transform: translateX(-50%) scaleX(0);
+        transform-origin: center;
+        transition: transform 0.2s ease;
+        pointer-events: none;
+      }
     }
 
     .btn:hover {
-      background: var(--theme-toggle-inactive-bg);
-      color: var(--theme-toggle-icon-inactive) !important;
-      border-color: transparent !important;
+      color: var(--masthead-toggle-hover-color) !important;
+      opacity: 1;
       transform: translateY(-1px);
       text-decoration: none;
     }
 
+    .btn:hover::after {
+      transform: translateX(-50%) scaleX(1);
+    }
+
     .btn:active {
-      background: var(--theme-toggle-inactive-bg);
-      color: var(--theme-toggle-icon-inactive) !important;
-      border-color: transparent !important;
       transform: translateY(0);
     }
 
@@ -161,11 +184,16 @@
     }
 
     .btn:focus-visible {
-      box-shadow: 0 0 0 3px rgba($primary-color, 0.25);
+      opacity: 1;
+      box-shadow: 0 0 0 2px var(--masthead-toggle-focus-shadow);
+    }
+
+    .btn:focus-visible::after {
+      transform: translateX(-50%) scaleX(1);
     }
 
     .btn:focus:not(:focus-visible) {
-      box-shadow: var(--theme-toggle-shadow-soft);
+      box-shadow: none;
     }
   }
 


### PR DESCRIPTION
## Summary
- restyle the homepage call-to-action buttons to inherit the pill styling from the masthead language and theme toggles
- adjust the hover and focus underline so it expands from the center with a thinner stroke and more spacing while keeping the toggle color cues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce4da0778832d80e4e3c87c0c98e5