### PR TITLE
Adjust button styles and toggle underline animation

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -149,12 +149,27 @@ html.theme-dark .btn {
   box-shadow: 0 6px 18px rgba(#000, 0.35);
 }
 
+html.theme-dark .news-actions .btn {
+  background: none !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+  color: var(--masthead-toggle-hover-color) !important;
+}
+
 html.theme-dark .btn:hover,
 html.theme-dark .btn:focus-visible {
   background-color: rgba(#1f2937, 0.92);
   border-color: rgba(#60a5fa, 0.45);
   color: #f9fafb !important;
   box-shadow: 0 10px 24px rgba(#1e3a8a, 0.35);
+}
+
+html.theme-dark .news-actions .btn:hover,
+html.theme-dark .news-actions .btn:focus-visible {
+  background: none !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+  color: var(--masthead-toggle-hover-color) !important;
 }
 
 html.theme-dark .btn:focus-visible {

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -131,13 +131,13 @@
   &::after {
     content: "";
     position: absolute;
-    left: 0;
+    left: 50%;
     bottom: 0;
     width: 100%;
     height: 4px;
     background: var(--masthead-toggle-underline-bg);
-    transform: scaleX(0);
-    transform-origin: left;
+    transform: translateX(-50%) scaleX(0);
+    transform-origin: center;
     transition: transform 0.2s ease;
     pointer-events: none;
   }
@@ -149,7 +149,7 @@
 
   &:hover::after,
   &:focus-visible::after {
-    transform: scaleX(1);
+    transform: translateX(-50%) scaleX(1);
   }
 
   &:focus-visible {

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -138,14 +138,13 @@
       padding: 0.6rem 1.4rem;
       border: none !important;
       border-radius: 999px;
-      background: none;
+      background: none !important;
       color: var(--masthead-toggle-hover-color) !important;
-      box-shadow: none;
+      box-shadow: none !important;
       gap: 0.35rem;
       opacity: 0.85;
       transform: translateY(0);
-      transition: color 0.2s ease, opacity 0.2s ease, transform 0.2s ease,
-        box-shadow 0.2s ease;
+      transition: color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
 
       &::after {
         content: "";
@@ -164,6 +163,9 @@
     }
 
     .btn:hover {
+      background: none !important;
+      border-color: transparent !important;
+      box-shadow: none !important;
       color: var(--masthead-toggle-hover-color) !important;
       opacity: 1;
       transform: translateY(-1px);
@@ -184,8 +186,10 @@
     }
 
     .btn:focus-visible {
+      background: none !important;
+      border-color: transparent !important;
+      box-shadow: none !important;
       opacity: 1;
-      box-shadow: 0 0 0 2px var(--masthead-toggle-focus-shadow);
     }
 
     .btn:focus-visible::after {
@@ -193,7 +197,7 @@
     }
 
     .btn:focus:not(:focus-visible) {
-      box-shadow: none;
+      box-shadow: none !important;
     }
   }
 


### PR DESCRIPTION
## Summary
- remove hover and focus backgrounds/borders from news action buttons so they stay minimal in light and dark themes
- update the language and theme toggle underline animation to expand outward from the center

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dceb879e74832da982da18f6f8386a