### PR TITLE
Adjust news action button text color

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -153,7 +153,7 @@ html.theme-dark .news-actions .btn {
   background: none !important;
   border-color: transparent !important;
   box-shadow: none !important;
-  color: var(--masthead-toggle-hover-color) !important;
+  color: #e2e8f0 !important;
 }
 
 html.theme-dark .btn:hover,

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -139,7 +139,7 @@
       border: none !important;
       border-radius: 999px;
       background: none !important;
-      color: var(--masthead-toggle-hover-color) !important;
+      color: #e2e8f0 !important;
       box-shadow: none !important;
       gap: 0.35rem;
       opacity: 0.85;


### PR DESCRIPTION
## Summary
- set the default text color of news action buttons like "Show Full List" to #e2e8f0 for consistency across themes
- ensure the dark theme override also uses the new default color while preserving existing hover/focus behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd27fa16e4832db9f1b3ba64807b8d