### PR TITLE
Remove hover background from sidebar links

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -125,7 +125,7 @@ html.theme-dark .author__urls a {
 
 html.theme-dark .author__urls a:hover {
   color: #bfdbfe;
-  background: rgba(59, 130, 246, 0.25);
+  background: none;
 }
 
 html.theme-dark .page__footer {

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -269,6 +269,7 @@
 
     &:hover {
       text-decoration: none;
+      background: none;
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the hover background from the sidebar author links so they stay transparent
- ensure the dark theme no longer applies a tinted background on hover for sidebar links

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68dd2b32a8f8832d98436a46385f9c5b