### PR TITLE
Adjust dark theme news action button text color

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -153,7 +153,7 @@ html.theme-dark .news-actions .btn {
   background: none !important;
   border-color: transparent !important;
   box-shadow: none !important;
-  color: var(--masthead-toggle-hover-color) !important;
+  color: #e2e8f0 !important;
 }
 
 html.theme-dark .btn:hover,


### PR DESCRIPTION
## Summary
- update the dark theme news action buttons so their default text color matches the requested #e2e8f0 value

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000 *(fails: jekyll executable missing in the environment)*
- bundle install *(fails: rubygems.org returned 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2bb58a7c832d9ffcd3a856e6b432