### PR TITLE
Move masthead toggles into navigation

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -47,32 +47,13 @@
               </a>
             </li>
           {% endfor %}
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language">
-            {{ language_toggle | strip }}
-          </li>
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme">
-            {{ theme_toggle | strip }}
-          </li>
         </ul>
-        <ul class="hidden-links hidden">
-          <li
-            class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language masthead__menu-item--toggle-clone"
-            hidden
-          >
-            {{ language_toggle | strip }}
-          </li>
-          <li
-            class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme masthead__menu-item--toggle-clone"
-            hidden
-          >
-            {{ theme_toggle | strip }}
-          </li>
-        </ul>
+        <div class="masthead__actions" role="presentation">
+          {{ language_toggle | strip }}
+          {{ theme_toggle | strip }}
+        </div>
+        <ul class="hidden-links hidden"></ul>
       </nav>
-    </div>
-    <div class="masthead__actions" role="presentation">
-      {{ language_toggle | strip }}
-      {{ theme_toggle | strip }}
     </div>
   </div>
 </div>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -69,17 +69,12 @@
 
 .masthead__actions {
   display: inline-flex;
-  flex: 0 0 auto;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.75rem;
   color: $masthead-link-color;
   margin-left: auto;
   white-space: nowrap;
-
-  @media (min-width: 641px) {
-    justify-content: flex-end;
-    flex-wrap: nowrap;
-  }
+  flex: 0 0 auto;
 }
 
 .masthead__menu-home-item {
@@ -101,23 +96,13 @@
 }
 
 
-.masthead__menu-item--toggle {
-  display: none;
-  color: $masthead-link-color;
-
-  .toggle-button {
-    margin: 0 1rem;
-  }
-}
-
-
 .toggle-button {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0.5rem;
-  margin: 0 1rem;
+  margin: 0 0.5rem;
   border: none;
   border-radius: 999px;
   background-color: transparent;
@@ -231,20 +216,10 @@ html.theme-dark {
     flex: 1 1 100%;
   }
 
-  .masthead__actions {
-    display: flex;
-    width: 100%;
-    justify-content: flex-end;
-    padding-top: 0.5rem;
-  }
-
   .greedy-nav {
-    padding-bottom: 0.25rem;
-
-    .visible-links .masthead__menu-item--toggle,
-    .hidden-links .masthead__menu-item--toggle {
-      display: none !important;
-    }
+    width: 100%;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
   }
 }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -174,8 +174,13 @@
 
 .greedy-nav {
   position: relative;
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
   min-width: 250px;
+  width: 100%;
   background: $background-color;
+  gap: 0.5rem;
 
   a {
     display: block;
@@ -190,23 +195,27 @@
   }
 
   button {
-    position: absolute;
+    order: 3;
+    position: relative;
     height: 100%;
-    right: 0;
-    padding: 0 0.5rem;
+    padding: 0 0.75rem;
     border: 0;
     outline: none;
     background-color: $primary-color;
     color: #fff;
     cursor: pointer;
+    flex: 0 0 auto;
   }
 
   .visible-links {
-    display: table;
+    display: flex;
+    align-items: center;
+    flex: 1 1 auto;
+    min-width: 0;
 
     li {
-      display: table-cell;
-      vertical-align: middle;
+      display: flex;
+      align-items: center;
 
       &:first-child {
         font-weight: bold;
@@ -258,6 +267,12 @@
                 transform: scaleX(1); /* reveal*/
       }
     }
+  }
+
+  .masthead__actions {
+    order: 2;
+    padding-left: 0.5rem;
+    flex: 0 0 auto;
   }
 
   .hidden-links {


### PR DESCRIPTION
## Summary
- move the language and theme toggles into the navigation bar and remove the duplicate masthead actions wrapper
- update masthead and greedy navigation styles to use flex layouts so the controls align to the right across viewports

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68dd2d851a04832d9b39b2b0fc6e8756