### PR TITLE
Adjust footer styling per design feedback

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -50,23 +50,29 @@ layout: compress
     {% endif %}
     {% assign last_updated = last_updated_source | date: '%Y-%m-%d' %}
 
-    <footer class="site-footer custom-license-footer">
+    <footer class="site-footer custom-license-footer" role="contentinfo">
       <div class="custom-license-footer__inner">
-        <p class="custom-license-footer__follow">
+        <p class="custom-license-footer__follow" aria-label="Follow this site">
           <span class="custom-license-footer__follow-label">Follow:</span>
           {% if github_url != '' %}
-            <a class="custom-license-footer__follow-link" href="{{ github_url }}" target="_blank" rel="noopener">
+            <a class="custom-license-footer__follow-link" href="{{ github_url }}" target="_blank" rel="noopener" aria-label="Open GitHub profile in a new tab">
               <svg class="custom-license-footer__icon" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
                 <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.09 3.29 9.4 7.86 10.93.58.11.79-.25.79-.56 0-.27-.01-1.17-.02-2.12-3.2.69-3.88-1.37-3.88-1.37-.52-1.32-1.26-1.67-1.26-1.67-1.03-.71.08-.7.08-.7 1.14.08 1.75 1.17 1.75 1.17 1.01 1.73 2.66 1.23 3.31.94.1-.73.39-1.23.71-1.51-2.55-.29-5.23-1.28-5.23-5.71 0-1.26.45-2.29 1.17-3.1-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.72.81 1.17 1.84 1.17 3.1 0 4.44-2.69 5.41-5.25 5.7.4.35.76 1.04.76 2.11 0 1.52-.01 2.74-.01 3.11 0 .31.21.68.8.56A10.52 10.52 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
               </svg>
               <span>GitHub</span>
             </a>
           {% else %}
-            <span class="custom-license-footer__follow-link">GitHub</span>
+            <span class="custom-license-footer__follow-link custom-license-footer__follow-link--disabled">GitHub</span>
           {% endif %}
+          <a class="custom-license-footer__follow-link custom-license-footer__follow-link--feed" href="{{ '/feed.xml' | relative_url }}" target="_blank" rel="noopener" aria-label="Open site RSS feed in a new tab">
+            <svg class="custom-license-footer__icon" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+              <path d="M5 16.5A2.5 2.5 0 1 0 7.5 19 2.5 2.5 0 0 0 5 16.5Zm-.75-5a1.25 1.25 0 0 0 1.25 1.25 7 7 0 0 1 7 7 1.25 1.25 0 0 0 2.5 0 9.5 9.5 0 0 0-9.5-9.5A1.25 1.25 0 0 0 4.25 11.5Zm0-5a1.25 1.25 0 0 0 1.25 1.25 12 12 0 0 1 12 12 1.25 1.25 0 0 0 2.5 0 14.5 14.5 0 0 0-14.5-14.5A1.25 1.25 0 0 0 4.25 6.5Z" />
+            </svg>
+            <span>Feed</span>
+          </a>
         </p>
-        <p>© {{ site.time | date: '%Y' }} {{ site.author.name | default: site.title }}, Powered by <a href="https://jekyllrb.com" target="_blank" rel="noopener">Jekyll</a> &amp; <a href="https://academicpages.github.io" target="_blank" rel="noopener">AcademicPages</a>.</p>
-        <p>Site last updated {{ last_updated }}</p>
+        <p class="custom-license-footer__meta">© {{ site.time | date: '%Y' }} {{ site.author.name | default: site.title }}, Powered by <a href="https://jekyllrb.com" target="_blank" rel="noopener">Jekyll</a> &amp; <a href="https://academicpages.github.io" target="_blank" rel="noopener">AcademicPages</a>.</p>
+        <p class="custom-license-footer__meta custom-license-footer__meta--muted">Site last updated {{ last_updated }}</p>
       </div>
     </footer>
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -695,55 +695,100 @@ html[data-theme="dark"] {
 }
 
 .custom-license-footer {
-  margin-top: 4rem;
-  background: #1f2937;
-  color: rgba(226, 232, 240, 0.85);
-  font-size: 0.75rem;
-  line-height: 1.7;
+  --footer-border: rgba(15, 23, 42, 0.08);
+  --footer-link: #2563eb;
+  --footer-link-hover: #1d4ed8;
+  margin-top: clamp(2.5rem, 7vw, 4rem);
+  border-top: 1px solid var(--footer-border);
+  background: transparent;
+  color: inherit;
+  font-size: 0.8125rem;
+  line-height: 1.5;
 }
 
 .custom-license-footer__inner {
-  max-width: 900px;
+  max-width: min(960px, 100%);
   margin: 0 auto;
-  padding: 2rem 1.5rem;
-  text-align: center;
+  padding: clamp(1.5rem, 3vw, 2.25rem) clamp(1rem, 4vw, 2.25rem);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .custom-license-footer__follow {
   display: flex;
-  justify-content: center;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: flex-start;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  gap: 0.6rem;
+  margin: 0;
 }
 
 .custom-license-footer__follow-label {
   font-weight: 600;
-  letter-spacing: 0.01em;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: inherit;
 }
 
 .custom-license-footer__follow-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.35rem;
   font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--footer-link);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.custom-license-footer__follow-link:hover,
+.custom-license-footer__follow-link:focus {
+  color: var(--footer-link-hover);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+.custom-license-footer__follow-link--feed {
+  color: var(--footer-link);
+}
+
+.custom-license-footer__follow-link--disabled {
+  color: rgba(100, 116, 139, 0.8);
+  cursor: not-allowed;
 }
 
 .custom-license-footer__icon {
   width: 1rem;
   height: 1rem;
   display: inline-block;
+  flex-shrink: 0;
   fill: currentColor;
 }
 
+.custom-license-footer__meta {
+  margin: 0;
+}
+
+.custom-license-footer__meta--muted {
+  color: rgba(71, 85, 105, 0.82);
+}
+
 .custom-license-footer a {
-  color: #60a5fa;
+  color: var(--footer-link);
+  font-weight: 600;
+  text-decoration: none;
 }
 
 .custom-license-footer a:hover,
 .custom-license-footer a:focus {
-  color: #bfdbfe;
+  color: var(--footer-link-hover);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
 
 .custom-license-footer__list {
@@ -753,18 +798,30 @@ html[data-theme="dark"] {
   text-align: left;
 }
 
+@media (max-width: 540px) {
+  .custom-license-footer__follow {
+    gap: 0.4rem;
+  }
+
+  .custom-license-footer__follow-label,
+  .custom-license-footer__follow-link {
+    font-size: 0.8125rem;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .custom-license-footer {
-    background: rgba(15, 23, 42, 0.95);
-    color: rgba(226, 232, 240, 0.9);
+    --footer-border: rgba(148, 163, 184, 0.18);
+    --footer-link: #93c5fd;
+    --footer-link-hover: #bfdbfe;
+    color: rgba(226, 232, 240, 0.88);
   }
 
-  .custom-license-footer a {
-    color: #93c5fd;
+  .custom-license-footer__follow-link--disabled {
+    color: rgba(148, 163, 184, 0.7);
   }
 
-  .custom-license-footer a:hover,
-  .custom-license-footer a:focus {
-    color: #bfdbfe;
+  .custom-license-footer__meta--muted {
+    color: rgba(148, 163, 184, 0.8);
   }
 }


### PR DESCRIPTION
## Summary
- align the footer follow section content to the left and update the label to the desired copy
- simplify the footer follow links by removing pill backgrounds while keeping GitHub and feed icons inline
- let the footer inherit the page background with tighter spacing and refreshed light/dark theme link colors

## Testing
- bundle exec jekyll build *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_68de0fe52c90832d95eba19c98904751