### PR TITLE
Adjust selection styling to match theme

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -1,9 +1,13 @@
 html.theme-light {
   color-scheme: light;
+  --selection-bg: #2563eb;
+  --selection-color: #f8fafc;
 }
 
 html.theme-dark {
   color-scheme: dark;
+  --selection-bg: rgba(191, 219, 254, 0.7);
+  --selection-color: #0f172a;
 }
 
 html.theme-dark body {

--- a/_sass/_reset.scss
+++ b/_sass/_reset.scss
@@ -9,6 +9,8 @@ html {
   box-sizing: border-box;
   background-color: $background-color;
   font-size: 15px;
+  --selection-bg: #2563eb;
+  --selection-color: #f8fafc;
 
   // @include breakpoint($medium) {
   //   font-size: 18px;
@@ -26,12 +28,16 @@ body { margin: 0; }
 
 ::-moz-selection {
   color: #fff;
-  background: #000;
+  color: var(--selection-color);
+  background: #2563eb;
+  background: var(--selection-bg);
 }
 
 ::selection {
   color: #fff;
-  background: #000;
+  color: var(--selection-color);
+  background: #2563eb;
+  background: var(--selection-bg);
 }
 
 /* Display HTML5 elements in IE6-9 and FF3 */


### PR DESCRIPTION
## Summary
- update global text selection colors to use the site's blue accent and improved contrast
- add light and dark theme specific selection variables for consistent highlighting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de19c2eda0832da1e581112658b0f2