### PR TITLE
Add divider above inline map on narrow layouts

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -302,6 +302,8 @@
 .author__map-sidebar--inline {
   display: block;
   margin: 2em 0 0;
+  padding-top: 1.5em;
+  border-top: 1px solid $border-color;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- add a top border and padding to the inline author map container so it is visually separated from main content on narrow screens

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing because bundle installation cannot access rubygems.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6a815074832daa5d8e9ecbecf957