### PR TITLE
Revert "Add divider above inline map on narrow layouts"

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -302,8 +302,6 @@
 .author__map-sidebar--inline {
   display: block;
   margin: 2em 0 0;
-  padding-top: 1.5em;
-  border-top: 1px solid $border-color;
   width: 100%;
 }
 


### PR DESCRIPTION
Reverts wtwu95/wtwu95.github.io#258