### PR TITLE
Style inline map divider for narrow layouts

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -1,3 +1,17 @@
+html {
+  --inline-map-divider-color: #{mix(#fff, $primary-color, 70%)};
+}
+
+html.theme-light,
+html[data-theme="light"] {
+  --inline-map-divider-color: #{mix(#fff, $primary-color, 70%)};
+}
+
+html.theme-dark,
+html[data-theme="dark"] {
+  --inline-map-divider-color: rgba(#bfdbfe, 0.6);
+}
+
 html.theme-light {
   color-scheme: light;
   --selection-bg: #2563eb;

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -300,9 +300,20 @@
 }
 
 .author__map-sidebar--inline {
+  $inline-map-divider-color: mix(#fff, $primary-color, 70%);
+
   display: block;
   margin: 2em 0 0;
+  padding-top: 1.75em;
+  border-top: 2px solid $inline-map-divider-color;
+  border-top-color: var(--inline-map-divider-color, $inline-map-divider-color);
   width: 100%;
+
+  @include breakpoint($large) {
+    margin-top: 1.5em;
+    padding-top: 0;
+    border-top: 0;
+  }
 }
 
 .author__maps {


### PR DESCRIPTION
## Summary
- add a theme-aware CSS variable for the inline map divider accent
- update the inline map block styling so the divider is thicker, spaced out, and removed on wide screens

## Testing
- bundle exec jekyll build *(fails: jekyll executable is unavailable because the required gems cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6a815074832daa5d8e9ecbecf957