### PR TITLE
Refine publication controls responsive layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -168,9 +168,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 .publication-controls {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-  align-items: stretch;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  align-items: center;
   margin-bottom: 1.5rem;
 }
 
@@ -191,8 +191,8 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-search {
-  flex: 1 1 280px;
-  min-width: 120px;
+  flex: 1 1 26rem;
+  min-width: 12rem;
   display: flex;
   align-items: center;
   line-height: 1.2;
@@ -201,8 +201,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls select {
-  flex: 0 1 190px;
-  min-width: 100px;
+  flex: 0 0 14rem;
+  min-width: 10rem;
+  max-width: 18rem;
 }
 
 .publication-controls button {
@@ -213,6 +214,27 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: 0 0.65rem;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .publication-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .publication-controls select,
+  .publication-controls button,
+  .publication-search {
+    width: 100%;
+    flex: 0 0 auto;
+  }
+
+  .publication-controls button {
+    justify-content: center;
+  }
 }
 
 .publication-search::-webkit-search-decoration,
@@ -572,17 +594,45 @@ html[data-theme="dark"] {
   --citation-modal-download-hover-bg: var(--publication-accent-hover);
 }
 
+@media (max-width: 1024px) {
+  .publication-controls {
+    flex-wrap: nowrap;
+    gap: 0.65rem;
+  }
+
+  .publication-search {
+    flex: 1 1 55%;
+    min-width: 0;
+  }
+
+  .publication-controls select {
+    flex: 1 1 28%;
+    min-width: 0;
+  }
+
+  .publication-controls button {
+    flex: 0 0 auto;
+  }
+}
+
 @media (max-width: 600px) {
   .publication-controls {
+    flex-direction: column;
+    align-items: stretch;
     padding: 0.75rem 0.65rem;
-    gap: 0.65rem;
+    gap: 0.75rem;
   }
 
   .publication-search,
   .publication-controls select,
   .publication-controls button {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
     min-width: 0;
+    width: 100%;
+  }
+
+  .publication-controls button {
+    justify-content: center;
   }
 
   ol.publication-list > li {


### PR DESCRIPTION
## Summary
- balance publication controls so the search input flexes to occupy lead space while the dropdown stays moderate and the action button remains compact on wide screens
- add a mobile breakpoint that stacks the controls vertically with full-width elements on narrow viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de782cec68832da5a6bf005f006f55