### PR TITLE
Adjust publication controls responsive layout

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -222,6 +222,18 @@ html.theme-dark .publication-controls select option {
   color: #0f172a;
 }
 
+html.theme-dark .publication-controls button,
+html[data-theme="dark"] .publication-controls button {
+  color: #0f172a;
+}
+
+html.theme-dark .publication-controls button:hover,
+html.theme-dark .publication-controls button:focus-visible,
+html[data-theme="dark"] .publication-controls button:hover,
+html[data-theme="dark"] .publication-controls button:focus-visible {
+  color: #0f172a;
+}
+
 html.theme-dark .publication-index,
 html.theme-dark .publication-year {
   color: #f8fafc;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -166,12 +166,14 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   --citation-modal-download-hover-bg: var(--publication-accent-hover);
 }
 
+
 .publication-controls {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.85rem;
-  align-items: stretch;
+  align-items: center;
   margin-bottom: 1.5rem;
+  width: 100%;
 }
 
 .publication-controls select,
@@ -192,7 +194,7 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 .publication-search {
   flex: 1 1 280px;
-  min-width: 120px;
+  min-width: 160px;
   display: flex;
   align-items: center;
   line-height: 1.2;
@@ -201,15 +203,16 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls select {
-  flex: 0 1 190px;
-  min-width: 100px;
+  flex: 0 0 auto;
+  min-width: 0;
+  width: auto;
 }
 
 .publication-controls button {
   cursor: pointer;
-  background-color: #e0e0e0;
-  color: #494e52;
-  border-color: #e0e0e0;
+  background-color: var(--publication-accent);
+  color: #fff;
+  border-color: var(--publication-accent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -221,13 +224,13 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls button:hover {
-  background-color: #d5d5d5;
-  border-color: #d5d5d5;
+  background-color: var(--publication-accent-hover);
+  border-color: var(--publication-accent-hover);
 }
 
 .publication-controls button:active {
-  background-color: #cbcbcb;
-  border-color: #cbcbcb;
+  background-color: var(--publication-accent);
+  border-color: var(--publication-accent);
 }
 
 .publication-controls select:hover,
@@ -544,6 +547,10 @@ mark.publication-highlight {
     --citation-modal-copy-hover-bg: rgba(148, 163, 184, 0.32);
     --citation-modal-download-hover-bg: var(--publication-accent-hover);
   }
+
+  .publication-controls button {
+    color: #0f172a;
+  }
 }
 
 html.theme-dark,
@@ -574,6 +581,7 @@ html[data-theme="dark"] {
 
 @media (max-width: 600px) {
   .publication-controls {
+    flex-direction: column;
     padding: 0.75rem 0.65rem;
     gap: 0.65rem;
   }
@@ -582,6 +590,7 @@ html[data-theme="dark"] {
   .publication-controls select,
   .publication-controls button {
     flex: 1 1 100%;
+    width: 100%;
     min-width: 0;
   }
 


### PR DESCRIPTION
## Summary
- make the publication controls stay on a single line on larger viewports while giving the search field primary space
- stack the controls vertically on small screens so each control spans the full width
- restyle the sort button to use the publication accent colors for better theme alignment

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de8071e120832dad9cf772ae279693