### PR TITLE
Keep masthead toggles visible on mobile

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -31,7 +31,6 @@
     {% endcapture %}
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
-        <button><div class="navicon"></div></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg masthead__menu-home-item">
             <a href="{{ '/' | relative_url }}#about-me" target="_self">
@@ -54,6 +53,9 @@
             {{ theme_toggle | strip }}
           </li>
         </ul>
+        <button class="greedy-nav__toggle hidden">
+          <div class="navicon"></div>
+        </button>
         <ul class="hidden-links hidden">
           <li
             class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language masthead__menu-item--toggle-clone"
@@ -69,10 +71,6 @@
           </li>
         </ul>
       </nav>
-    </div>
-    <div class="masthead__actions" role="presentation">
-      {{ language_toggle | strip }}
-      {{ theme_toggle | strip }}
     </div>
   </div>
 </div>

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -67,21 +67,6 @@
   }
 }
 
-.masthead__actions {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 1.25rem;
-  color: $masthead-link-color;
-  margin-left: auto;
-  white-space: nowrap;
-
-  @media (min-width: 641px) {
-    justify-content: flex-end;
-    flex-wrap: nowrap;
-  }
-}
-
 .masthead__menu-home-item {
   @include breakpoint($medium) {
     display: block !important;
@@ -90,7 +75,9 @@
 }
 
 .masthead__menu-item {
-  display: block;
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
   list-style-type: none;
   white-space: nowrap;
 
@@ -102,11 +89,22 @@
 
 
 .masthead__menu-item--toggle {
-  display: none;
+  display: flex;
+  align-items: center;
   color: $masthead-link-color;
 
   .toggle-button {
-    margin: 0 1rem;
+    margin: 0 0.5rem;
+  }
+}
+
+.masthead__menu-item--toggle-language {
+  margin-left: auto;
+}
+
+.masthead__menu-item--toggle-theme {
+  .toggle-button {
+    margin-right: 0;
   }
 }
 
@@ -186,21 +184,11 @@
   }
 }
 
-.masthead__actions .toggle-button {
-  margin: 0;
-  flex-shrink: 0;
-}
-
 html.theme-dark {
   --masthead-toggle-hover-color: #bfdbfe;
   --masthead-toggle-underline-bg: #bfdbfe;
   --masthead-toggle-focus-shadow: rgba(96, 165, 250, 0.45);
 
-  .masthead__actions {
-    color: #e2e8f0;
-  }
-
-  .masthead__actions .toggle-button,
   .masthead__menu-item--toggle .toggle-button {
     color: #e2e8f0;
 
@@ -231,20 +219,12 @@ html.theme-dark {
     flex: 1 1 100%;
   }
 
-  .masthead__actions {
-    display: flex;
-    width: 100%;
-    justify-content: flex-end;
-    padding-top: 0.5rem;
-  }
-
   .greedy-nav {
     padding-bottom: 0.25rem;
+  }
 
-    .visible-links .masthead__menu-item--toggle,
-    .hidden-links .masthead__menu-item--toggle {
-      display: none !important;
-    }
+  .masthead__menu-item--toggle .toggle-button {
+    margin: 0 0.5rem;
   }
 }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -172,8 +172,11 @@
    Priority plus navigation
    ========================================================================== */
 
+
 .greedy-nav {
   position: relative;
+  display: flex;
+  align-items: center;
   min-width: 250px;
   background: $background-color;
 
@@ -189,24 +192,37 @@
     }
   }
 
-  button {
-    position: absolute;
-    height: 100%;
-    right: 0;
-    padding: 0 0.5rem;
+  .greedy-nav__toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: auto;
+    flex: 0 0 auto;
+    margin-left: 0.25rem;
+    padding: 0.5rem;
     border: 0;
+    border-radius: $border-radius;
     outline: none;
     background-color: $primary-color;
     color: #fff;
     cursor: pointer;
+
+    &.hidden {
+      display: none;
+    }
   }
 
   .visible-links {
-    display: table;
+    display: flex;
+    align-items: center;
+    flex: 1 1 auto;
+    min-width: 0;
+    flex-wrap: nowrap;
 
     li {
-      display: table-cell;
-      vertical-align: middle;
+      display: flex;
+      align-items: center;
 
       &:first-child {
         font-weight: bold;

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -6,17 +6,23 @@
 */
 
 var $nav = $('#site-nav');
-var $btn = $('#site-nav button');
+var $btn = $('#site-nav .greedy-nav__toggle');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('#site-nav .hidden-links');
 var $toggleClones = $hlinks.find('.masthead__menu-item--toggle-clone');
 
 function getVisibleItems() {
-  return $vlinks.children().not('.masthead__menu-item--toggle-clone');
+  return $vlinks
+    .children()
+    .not('.masthead__menu-item--toggle')
+    .not('.masthead__menu-item--toggle-clone');
 }
 
 function getHiddenItems() {
-  return $hlinks.children().not('.masthead__menu-item--toggle-clone');
+  return $hlinks
+    .children()
+    .not('.masthead__menu-item--toggle')
+    .not('.masthead__menu-item--toggle-clone');
 }
 
 function syncToggleClones() {
@@ -30,11 +36,13 @@ function syncToggleClones() {
       ? '.masthead__menu-item--toggle-language'
       : '.masthead__menu-item--toggle-theme';
 
-    var hasOriginal = $hlinks
-      .children(selector)
-      .not($clone)
-      .filter(':not(.masthead__menu-item--toggle-clone)')
-      .length > 0;
+    var hasOriginal =
+      $vlinks.children(selector).filter(':not(.masthead__menu-item--toggle-clone)').length > 0 ||
+      $hlinks
+        .children(selector)
+        .not($clone)
+        .filter(':not(.masthead__menu-item--toggle-clone)')
+        .length > 0;
 
     if (hasOriginal) {
       $clone.attr('hidden', true);


### PR DESCRIPTION
## Summary
- keep the language and theme toggle buttons inside the masthead navigation so they stay aligned to the right on all viewports
- keep the navigation collapse control hidden until links overflow and position it directly beside the toggle buttons
- update the greedy navigation helper to operate on the dedicated collapse button so the language and theme toggles remain visible

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de86213080832dae33cbc1a9ac3a0e