### PR TITLE
Adjust publication controls layout on mobile

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -209,6 +209,24 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   }
 }
 
+@media (max-width: 600px) {
+  .publication-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .publication-search,
+  .publication-controls select,
+  .publication-controls button {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .publication-controls button {
+    white-space: normal;
+  }
+}
+
 .publication-search {
   flex: 1 1 220px;
   min-width: 120px;


### PR DESCRIPTION
## Summary
- ensure publication search, filter, and sort controls stack vertically on narrow screens
- make the controls span the full width on mobile while keeping consistent heights

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68df49a3dfe0832d9c0d8b164fc78f55