### PR TITLE
Adjust publication controls layout for consistent responsiveness

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -168,10 +168,10 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 
 .publication-controls {
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.85rem;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 1.5rem;
   width: 100%;
 }
@@ -190,57 +190,19 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   min-height: var(--publication-control-height);
   box-sizing: border-box;
   outline: none;
-}
-
-@media (max-width: 900px) {
-  .publication-controls {
-    flex-wrap: wrap;
-  }
-
-  .publication-search,
-  .publication-controls select {
-    flex: 1 1 220px;
-    min-width: 0;
-  }
-
-  .publication-controls button {
-    flex: 0 0 auto;
-    white-space: nowrap;
-  }
-}
-
-@media (max-width: 600px) {
-  .publication-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .publication-search,
-  .publication-controls select,
-  .publication-controls button {
-    flex: 1 1 100%;
-    width: 100%;
-  }
-
-  .publication-controls button {
-    white-space: normal;
-  }
+  width: 100%;
 }
 
 .publication-search {
-  flex: 1 1 220px;
-  min-width: 120px;
-  display: flex;
-  align-items: center;
+  min-width: 0;
+  display: block;
   line-height: 1.2;
   -webkit-appearance: none;
   appearance: none;
 }
 
 .publication-controls select {
-  flex: 0 0 auto;
   min-width: 0;
-  width: auto;
 }
 
 .publication-controls button {
@@ -248,10 +210,19 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   background-color: #fff;
   color: #4b5563;
   border-color: #c1c7d0;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  height: var(--publication-control-height);
+}
+
+@media (max-width: 800px) {
+  .publication-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .publication-controls button {
+    white-space: normal;
+  }
 }
 
 .publication-search::-webkit-search-decoration,


### PR DESCRIPTION
## Summary
- switch the publication controls container to a responsive grid so the search, filter, and sort inputs share height and width and fill a full row on wide screens
- ensure each control expands to full width on narrow screens so the four controls stack vertically for small viewports

## Testing
- `bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --livereload-port 35729` *(fails: `jekyll` executable not installed because `bundle install` cannot reach rubygems.org and returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68df4edfe2c4832daf447821dabbc5ad