### PR TITLE
Refine publication controls layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -168,10 +168,10 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 
 .publication-controls {
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) repeat(3, max-content);
   gap: 0.85rem;
-  align-items: center;
+  align-items: stretch;
   margin-bottom: 1.5rem;
   width: 100%;
 }
@@ -190,57 +190,21 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   min-height: var(--publication-control-height);
   box-sizing: border-box;
   outline: none;
-}
-
-@media (max-width: 900px) {
-  .publication-controls {
-    flex-wrap: wrap;
-  }
-
-  .publication-search,
-  .publication-controls select {
-    flex: 1 1 220px;
-    min-width: 0;
-  }
-
-  .publication-controls button {
-    flex: 0 0 auto;
-    white-space: nowrap;
-  }
-}
-
-@media (max-width: 600px) {
-  .publication-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .publication-search,
-  .publication-controls select,
-  .publication-controls button {
-    flex: 1 1 100%;
-    width: 100%;
-  }
-
-  .publication-controls button {
-    white-space: normal;
-  }
+  width: 100%;
 }
 
 .publication-search {
-  flex: 1 1 220px;
-  min-width: 120px;
-  display: flex;
-  align-items: center;
+  min-width: 0;
+  display: block;
   line-height: 1.2;
   -webkit-appearance: none;
   appearance: none;
 }
 
-.publication-controls select {
-  flex: 0 0 auto;
-  min-width: 0;
+.publication-controls select,
+.publication-controls button {
   width: auto;
+  justify-self: start;
 }
 
 .publication-controls button {
@@ -248,10 +212,26 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   background-color: #fff;
   color: #4b5563;
   border-color: #c1c7d0;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  height: var(--publication-control-height);
+}
+
+@media (max-width: 800px) {
+  .publication-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .publication-controls select,
+  .publication-controls button {
+    width: 100%;
+    min-width: 0;
+    justify-self: stretch;
+  }
+
+  .publication-controls button {
+    white-space: normal;
+  }
 }
 
 .publication-search::-webkit-search-decoration,
@@ -626,7 +606,6 @@ html[data-theme="dark"] {
 
 @media (max-width: 600px) {
   .publication-controls {
-    flex-direction: column;
     padding: 0.75rem 0.65rem;
     gap: 0.65rem;
   }
@@ -634,9 +613,9 @@ html[data-theme="dark"] {
   .publication-search,
   .publication-controls select,
   .publication-controls button {
-    flex: 1 1 100%;
     width: 100%;
     min-width: 0;
+    justify-self: stretch;
   }
 
   ol.publication-list > li {


### PR DESCRIPTION
## Summary
- let the publication controls grid reserve auto-width tracks for the filter selects and sort button while letting the search input fill the remaining space
- stack all controls full-width on narrow screens to prevent the search input from overflowing the viewport and keep consistent spacing

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when fetching from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68df4edfe2c4832daf447821dabbc5ad