### PR TITLE
Adjust masthead navigation layout for single-row responsiveness

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -47,12 +47,6 @@
               </a>
             </li>
           {% endfor %}
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-language">
-            {{ language_toggle | strip }}
-          </li>
-          <li class="masthead__menu-item masthead__menu-item--toggle masthead__menu-item--toggle-theme">
-            {{ theme_toggle | strip }}
-          </li>
         </ul>
         <ul class="hidden-links hidden">
           <li

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -24,9 +24,9 @@
     @include clearfix;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 1rem;
+    flex-wrap: nowrap;
     padding: .5em;
     font-family: $sans-serif-narrow;
 
@@ -36,17 +36,8 @@
 
     nav {
       width: 100%;
+      min-width: 0;
       z-index: 10;
-    }
-
-    @media (min-width: 641px) {
-      flex-wrap: nowrap;
-
-      nav {
-        width: auto;
-        flex: 1 1 auto;
-        min-width: 0;
-      }
     }
 
     a {
@@ -58,6 +49,10 @@
 .masthead__menu {
   flex: 1 1 auto;
   min-width: 0;
+
+  nav {
+    width: 100%;
+  }
 
   ul {
     margin: 0;
@@ -71,14 +66,26 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 1.25rem;
+  gap: 0.75rem;
   color: $masthead-link-color;
   margin-left: auto;
+  margin-right: 0;
   white-space: nowrap;
+  flex-shrink: 0;
 
   @media (min-width: 641px) {
     justify-content: flex-end;
     flex-wrap: nowrap;
+  }
+}
+
+.masthead__inner-wrap--has-dropdown {
+  .masthead__actions {
+    margin-right: 3rem;
+  }
+
+  .greedy-nav {
+    padding-right: 2.75rem;
   }
 }
 
@@ -106,8 +113,19 @@
   color: $masthead-link-color;
 
   .toggle-button {
-    margin: 0 1rem;
+    margin: 0;
   }
+}
+
+.greedy-nav .hidden-links .masthead__menu-item--toggle {
+  display: block;
+}
+
+.greedy-nav .hidden-links .masthead__menu-item--toggle .toggle-button {
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
 }
 
 
@@ -117,7 +135,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem;
-  margin: 0 1rem;
+  margin: 0;
   border: none;
   border-radius: 999px;
   background-color: transparent;
@@ -177,7 +195,7 @@
 }
 
 .toggle-button--language {
-  margin: 0 0.5rem;
+  margin: 0;
 }
 
 .toggle-button--theme {
@@ -224,27 +242,11 @@ html.theme-dark {
 
 @media (max-width: 640px) {
   .masthead__inner-wrap {
-    align-items: center;
-  }
-
-  .masthead__menu {
-    flex: 1 1 100%;
+    gap: 0.5rem;
   }
 
   .masthead__actions {
-    display: flex;
-    width: 100%;
-    justify-content: flex-end;
-    padding-top: 0.5rem;
-  }
-
-  .greedy-nav {
-    padding-bottom: 0.25rem;
-
-    .visible-links .masthead__menu-item--toggle,
-    .hidden-links .masthead__menu-item--toggle {
-      display: none !important;
-    }
+    gap: 0.5rem;
   }
 }
 

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -10,6 +10,7 @@ var $btn = $('#site-nav button');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('#site-nav .hidden-links');
 var $toggleClones = $hlinks.find('.masthead__menu-item--toggle-clone');
+var $mastheadWrap = $('.masthead__inner-wrap');
 
 function getVisibleItems() {
   return $vlinks.children().not('.masthead__menu-item--toggle-clone');
@@ -98,6 +99,10 @@ function updateNav() {
   }
 
   syncToggleClones();
+
+  if ($mastheadWrap.length) {
+    $mastheadWrap.toggleClass('masthead__inner-wrap--has-dropdown', !$btn.hasClass('hidden'));
+  }
 }
 
 // Window listeners


### PR DESCRIPTION
## Summary
- keep the masthead navigation and action buttons in a single flex row with the toggle buttons fixed to the right
- ensure overflowing navigation links move into the greedy menu while cloned toggle actions remain accessible in the hidden list
- shift the toggle button group left whenever the greedy dropdown button is visible to avoid overlap

## Testing
- `bundle exec jekyll build` *(fails: jekyll gem not installed in environment)*
- `bundle install` *(fails: RubyGems returns HTTP 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68df67700574832d9ce0aeb07a410cc2