### PR TITLE
Fix publication search control widths on small screens

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -219,7 +219,8 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 @media (min-width: 48rem) {
   .publication-controls {
-    grid-template-columns: minmax(16rem, 1fr) repeat(3, max-content);
+    grid-template-columns: minmax(0, 2.25fr) repeat(2, minmax(0, 1fr))
+      max-content;
   }
 
   .publication-controls select,
@@ -227,6 +228,10 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
     width: auto;
     min-width: 0;
     justify-self: start;
+  }
+
+  .publication-search {
+    max-width: 100%;
   }
 }
 
@@ -600,7 +605,7 @@ html[data-theme="dark"] {
   --citation-modal-download-hover-bg: var(--publication-accent-hover);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 40rem) {
   .publication-controls {
     padding: 0.75rem 0.65rem;
     gap: 0.65rem;
@@ -617,6 +622,7 @@ html[data-theme="dark"] {
     width: 100%;
     min-width: 0;
     justify-self: stretch;
+    max-width: 100%;
   }
 
   ol.publication-list > li {


### PR DESCRIPTION
## Summary
- tweak the publication controls grid so the search input no longer clashes with the filter selects when they share a row
- extend the small-screen breakpoint to 40rem to ensure the controls span the full viewport width on narrow devices

## Testing
- Not run (Bundler installation blocked by 403 errors from rubygems.org)


------
https://chatgpt.com/codex/tasks/task_e_68df68894b30832d8604df001f6152ef