### PR TITLE
Fix navigation folding after language switch

### DIFF
--- a/assets/js/toggles.js
+++ b/assets/js/toggles.js
@@ -134,6 +134,26 @@
 
     applyTheme(html.getAttribute('data-theme') || 'light', { persist: false });
 
+    if (typeof window !== 'undefined') {
+      const triggerNavUpdate = function () {
+        if (typeof window.updateNav === 'function') {
+          window.updateNav();
+        } else {
+          try {
+            window.dispatchEvent(new Event('resize'));
+          } catch (error) {
+            /* ignore */
+          }
+        }
+      };
+
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(triggerNavUpdate);
+      } else {
+        triggerNavUpdate();
+      }
+    }
+
     if (settings.persist) {
       try {
         window.localStorage.setItem(STORAGE_KEYS.language, normalized);


### PR DESCRIPTION
## Summary
- ensure the greedy navigation menu recalculates its layout after switching languages
- trigger the recalculation on the next animation frame, falling back to a resize event if the helper is unavailable

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df87a59ab8832daf2150e8266b3f5b