### PR TITLE
Ensure greedy nav toggle resets to hamburger

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -37,6 +37,7 @@ function updateNav() {
     // Show the dropdown btn
     if($btn.hasClass('hidden')) {
       $btn.removeClass('hidden');
+      $btn.removeClass('close');
       $btn.attr('aria-expanded', 'false');
     }
 
@@ -61,6 +62,7 @@ function updateNav() {
       $btn.addClass('hidden');
       $hlinks.addClass('hidden');
       breaks = [];
+      $btn.removeClass('close');
       $btn.attr('aria-expanded', 'false');
     }
   }


### PR DESCRIPTION
## Summary
- reset the greedy navigation toggle button to its hamburger state whenever it reappears
- clear any stale close class when the hidden menu empties so aria-expanded stays false

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df8a7a8bb4832da5245c4c297a91f1