### PR TITLE
Refine masthead menu colors for theme consistency

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -8,6 +8,15 @@ html.theme-dark {
   color-scheme: dark;
   --selection-bg: rgba(191, 219, 254, 0.7);
   --selection-color: #0f172a;
+  --masthead-toggle-bg: #2563eb;
+  --masthead-toggle-color: #f8fafc;
+  --masthead-toggle-hover-bg: #1d4ed8;
+  --masthead-hidden-links-bg: #1f2937;
+  --masthead-hidden-links-border: rgba(255, 255, 255, 0.12);
+  --masthead-hidden-links-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  --masthead-hidden-link-color: #e2e8f0;
+  --masthead-hidden-link-hover-color: #bfdbfe;
+  --masthead-hidden-link-hover-bg: rgba(59, 130, 246, 0.2);
 }
 
 html.theme-dark body {
@@ -30,26 +39,6 @@ html.theme-dark .masthead__menu a:hover {
 
 html.theme-dark .greedy-nav {
   background: transparent;
-}
-
-html.theme-dark .greedy-nav__toggle {
-  background-color: #2563eb;
-  color: #f8fafc;
-}
-
-html.theme-dark .greedy-nav__more .hidden-links {
-  background: #1f2937;
-  border-color: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
-}
-
-html.theme-dark .greedy-nav__more .hidden-links a {
-  color: #e2e8f0;
-}
-
-html.theme-dark .greedy-nav__more .hidden-links a:hover {
-  color: #bfdbfe;
-  background: rgba(59, 130, 246, 0.2);
 }
 
 html.theme-dark .greedy-nav .visible-links a {

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -5,7 +5,16 @@
 :root {
   --masthead-toggle-hover-color: #{$masthead-link-color-hover};
   --masthead-toggle-underline-bg: #{mix(#fff, $primary-color, 50%)};
-  --masthead-toggle-focus-shadow: rgba(59, 130, 246, 0.3);
+  --masthead-toggle-focus-shadow: rgba($primary-color, 0.35);
+  --masthead-toggle-bg: #{$primary-color};
+  --masthead-toggle-color: #fff;
+  --masthead-toggle-hover-bg: #{mix(#000, $primary-color, 15%)};
+  --masthead-hidden-links-bg: #fff;
+  --masthead-hidden-links-border: #{$border-color};
+  --masthead-hidden-links-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+  --masthead-hidden-link-color: #{$masthead-link-color};
+  --masthead-hidden-link-hover-color: #{$masthead-link-color-hover};
+  --masthead-hidden-link-hover-bg: #{mix(#fff, $primary-color, 75%)};
 }
 
 .masthead {
@@ -180,20 +189,21 @@
   padding: 0.35rem 0.75rem;
   border: 0;
   border-radius: $border-radius;
-  background-color: $primary-color;
-  color: #fff;
+  background-color: var(--masthead-toggle-bg);
+  color: var(--masthead-toggle-color);
   cursor: pointer;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   min-height: 2.25rem;
 
   &:hover,
   &:focus-visible {
-    background-color: mix(#000, $primary-color, 15%);
+    background-color: var(--masthead-toggle-hover-bg);
+    color: var(--masthead-toggle-color);
   }
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px rgba($primary-color, 0.35);
+    box-shadow: 0 0 0 2px var(--masthead-toggle-focus-shadow);
   }
 
   &:focus:not(:focus-visible) {
@@ -208,7 +218,7 @@
   .navicon,
   .navicon::before,
   .navicon::after {
-    background: #fff;
+    background: currentColor;
   }
 }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -257,19 +257,21 @@
     right: 0;
     margin-top: 0;
     padding: 0.5rem;
-    border: 1px solid $border-color;
+    border: 1px solid var(--masthead-hidden-links-border, #{$border-color});
     border-radius: $border-radius;
-    background: #fff;
-    box-shadow: 0 0 10px rgba(#000, 0.25);
+    background: var(--masthead-hidden-links-bg, #fff);
+    box-shadow: var(--masthead-hidden-links-shadow, 0 0 10px rgba(0, 0, 0, 0.25));
 
     a {
       margin: 0;
       padding: 0.625rem 1.25rem;
       font-size: $type-size-5;
+      color: var(--masthead-hidden-link-color, #{$masthead-link-color});
+      transition: background-color 0.2s ease, color 0.2s ease;
 
       &:hover {
-        color: $masthead-link-color-hover;
-        background: mix(#fff, $primary-color, 75%);
+        color: var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
+        background: var(--masthead-hidden-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
       }
     }
 


### PR DESCRIPTION
## Summary
- drive masthead toggle button styling from shared CSS custom properties for better theme alignment
- restyle the hidden navigation menu using the same variables and update the dark theme overrides

## Testing
- ⚠️ `bundle exec jekyll serve --host 0.0.0.0 --port 4000` *(fails: jekyll executable missing in environment)*
- ⚠️ `bundle install` *(fails: unable to download gems due to 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68df924b22ec832d96327fad451b8553