### PR TITLE
Adjust dark masthead dropdown styling

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -8,11 +8,12 @@ html.theme-dark {
   color-scheme: dark;
   --selection-bg: rgba(191, 219, 254, 0.7);
   --selection-color: #0f172a;
-  --masthead-toggle-bg: #2563eb;
+  --masthead-toggle-bg: rgba(37, 99, 235, 0.25);
   --masthead-toggle-color: #f8fafc;
-  --masthead-toggle-hover-bg: #1d4ed8;
-  --masthead-hidden-links-bg: #1f2937;
+  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.35);
+  --masthead-hidden-links-bg: rgba(31, 41, 55, 0.95);
   --masthead-hidden-links-border: rgba(255, 255, 255, 0.12);
+  --masthead-hidden-links-divider: rgba(255, 255, 255, 0.12);
   --masthead-hidden-links-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
   --masthead-hidden-link-color: #e2e8f0;
   --masthead-hidden-link-hover-color: #bfdbfe;

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -11,6 +11,7 @@
   --masthead-toggle-hover-bg: #{mix(#000, $primary-color, 15%)};
   --masthead-hidden-links-bg: #fff;
   --masthead-hidden-links-border: #{$border-color};
+  --masthead-hidden-links-divider: #{$border-color};
   --masthead-hidden-links-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
   --masthead-hidden-link-color: #{$masthead-link-color};
   --masthead-hidden-link-hover-color: #{$masthead-link-color-hover};

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -256,17 +256,21 @@
     top: calc(100% + 0.5rem);
     right: 0;
     margin-top: 0;
-    padding: 0.5rem;
+    padding: 0.5rem 0;
     border: 1px solid var(--masthead-hidden-links-border, #{$border-color});
     border-radius: $border-radius;
     background: var(--masthead-hidden-links-bg, #fff);
     box-shadow: var(--masthead-hidden-links-shadow, 0 0 10px rgba(0, 0, 0, 0.25));
+    min-width: 12rem;
 
     a {
+      display: block;
       margin: 0;
       padding: 0.625rem 1.25rem;
       font-size: $type-size-5;
       color: var(--masthead-hidden-link-color, #{$masthead-link-color});
+      line-height: 1.5;
+      text-align: center;
       transition: background-color 0.2s ease, color 0.2s ease;
 
       &:hover {
@@ -283,7 +287,7 @@
       width: 0;
       border-style: solid;
       border-width: 0 0.5rem 0.5rem;
-      border-color: $border-color transparent;
+      border-color: var(--masthead-hidden-links-border, #{$border-color}) transparent;
       display: block;
       z-index: 0;
     }
@@ -296,14 +300,14 @@
       width: 0;
       border-style: solid;
       border-width: 0 0.5rem 0.5rem;
-      border-color: #fff transparent;
+      border-color: var(--masthead-hidden-links-bg, #fff) transparent;
       display: block;
       z-index: 1;
     }
 
     li {
       display: block;
-      border-bottom: 1px solid $border-color;
+      border-bottom: 1px solid var(--masthead-hidden-links-divider, #{$border-color});
 
       &:last-child {
         border-bottom: none;


### PR DESCRIPTION
## Summary
- rebalance the dark theme masthead toggle colors to reuse the existing palette
- align the hidden navigation dropdown background, border, and shadow with dark mode styling
- center the collapsed menu text, unify line-height, and match divider colors with the site separators

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68df97ea41a4832dad830c5dd0abe610