### PR TITLE
Adjust dark mode navigation styling

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -9,7 +9,7 @@ html.theme-dark {
   --selection-bg: rgba(191, 219, 254, 0.7);
   --selection-color: #0f172a;
   --masthead-toggle-bg: rgba(37, 99, 235, 0.25);
-  --masthead-toggle-color: #f8fafc;
+  --masthead-toggle-color: #93c5fd;
   --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.35);
   --masthead-hidden-links-bg: rgba(31, 41, 55, 0.95);
   --masthead-hidden-links-border: rgba(255, 255, 255, 0.12);

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -245,7 +245,7 @@ html.theme-dark {
 
   .masthead__actions .toggle-button,
   .masthead__menu-item--toggle .toggle-button {
-    color: #e2e8f0;
+    color: #93c5fd;
 
     &:hover,
     &:focus-visible {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -262,6 +262,8 @@
     background: var(--masthead-hidden-links-bg, #fff);
     box-shadow: var(--masthead-hidden-links-shadow, 0 0 10px rgba(0, 0, 0, 0.25));
     min-width: 12rem;
+    width: max-content;
+    max-width: min(20rem, calc(100vw - 2rem));
 
     a {
       display: block;


### PR DESCRIPTION
## Summary
- update dark theme masthead toggle color to align with the primary accent
- allow the collapsed navigation menu to size itself to its content while keeping reasonable bounds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa00cb488832d8ca527f311909274