### PR TITLE
Adjust masthead toggle underline width

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -130,13 +130,14 @@
   white-space: nowrap;
   font-size: 1rem;
   transition: color 0.2s ease, box-shadow 0.2s ease;
+  --toggle-icon-size: 1.5rem;
 
   &::after {
     content: "";
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 100%;
+    width: var(--toggle-icon-size);
     height: 4px;
     background: var(--masthead-toggle-underline-bg);
     transform: translateX(-50%) scaleX(0);
@@ -169,8 +170,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
+    width: var(--toggle-icon-size);
+    height: var(--toggle-icon-size);
     font-size: 1.1rem;
 
     i {


### PR DESCRIPTION
## Summary
- match the language and theme toggle underline width to the icon width for visual alignment
- introduce a shared CSS variable so the underline and icon stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfac9def78832da3043d972f9caa42