### PR TITLE
Update greedy nav toggle styling

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -188,19 +188,18 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.75rem;
+  padding: 0.35rem;
   border: 0;
-  border-radius: $border-radius;
-  background-color: var(--masthead-toggle-bg);
+  border-radius: 999px;
+  background-color: transparent;
   color: var(--masthead-toggle-color);
   cursor: pointer;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  transition: color 0.2s ease, box-shadow 0.2s ease;
   min-height: 2.25rem;
 
   &:hover,
   &:focus-visible {
-    background-color: var(--masthead-toggle-hover-bg);
-    color: var(--masthead-toggle-color);
+    color: var(--masthead-toggle-hover-color);
   }
 
   &:focus-visible {


### PR DESCRIPTION
## Summary
- remove the background from the responsive navigation toggle so only the icon remains and matches other header toggle colors

## Testing
- Not run (bundle install fails with `Gem::Net::HTTPClientException 403 "Forbidden"` when attempting to fetch gems)


------
https://chatgpt.com/codex/tasks/task_e_68dfb5aac350832d82b7d67658f4e8b0