### PR TITLE
Reduce spacing between masthead action buttons

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -72,7 +72,7 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.35rem;
   color: $masthead-link-color;
   margin-left: auto;
   margin-right: 0;


### PR DESCRIPTION
## Summary
- decrease the flex gap between language toggle, theme toggle, and menu toggle within the masthead actions area to tighten their spacing

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000 *(fails: jekyll executable missing)*
- bundle install *(fails: rubygems.org access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc0061700832da13806b3f5161885