### PR TITLE
Adjust light mode collapsed nav toggle color

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -7,7 +7,7 @@
   --masthead-toggle-underline-bg: #{mix(#fff, $primary-color, 50%)};
   --masthead-toggle-focus-shadow: rgba($primary-color, 0.35);
   --masthead-toggle-bg: #{$primary-color};
-  --masthead-toggle-color: #fff;
+  --masthead-toggle-color: #{$masthead-link-color};
   --masthead-toggle-hover-bg: #{mix(#000, $primary-color, 15%)};
   --masthead-hidden-links-bg: #fff;
   --masthead-hidden-links-border: #{$border-color};


### PR DESCRIPTION
## Summary
- align the collapsed navigation toggle color in light mode with the masthead toggle button color so it stands out against the background

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfc3842fcc832d8a03e6a3a085b5e6