### PR TITLE
Close desktop nav menu on pointer leave

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -9,6 +9,17 @@ var $nav = $('#site-nav');
 var $btn = $('[data-nav-toggle]');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('.greedy-nav__more .hidden-links');
+var $moreContainer = $('.greedy-nav__more');
+
+function isDesktopPointer() {
+  return window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+}
+
+function closeHiddenMenu() {
+  $hlinks.addClass('hidden');
+  $btn.removeClass('close');
+  $btn.attr('aria-expanded', 'false');
+}
 
 function getVisibleItems() {
   return $vlinks.children();
@@ -88,6 +99,21 @@ $btn.on('click', function() {
   $hlinks.toggleClass('hidden');
   $(this).toggleClass('close');
   $(this).attr('aria-expanded', isHidden ? 'true' : 'false');
+});
+
+$moreContainer.on('mouseleave', function(event) {
+  if(!isDesktopPointer()) {
+    return;
+  }
+
+  var related = event.relatedTarget;
+  if(related && (this === related || $.contains(this, related))) {
+    return;
+  }
+
+  if(!$hlinks.hasClass('hidden')) {
+    closeHiddenMenu();
+  }
 });
 
 updateNav();


### PR DESCRIPTION
## Summary
- ensure the greedy navigation dropdown closes when the cursor leaves the toggle area on desktop pointers
- reuse the existing toggle logic to reset the button state after auto-closing

## Testing
- not run (bundle install fails in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc7bdb834832db4bb375d2dccdfcc