### PR TITLE
Adjust LinkedIn icon to match Font Awesome styling

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -90,7 +90,7 @@
         <li><a href="https://plus.google.com/+{{ author.google_plus }}"><i class="fab fa-fw fa-google-plus" aria-hidden="true"></i> Google+</a></li>
       {% endif %}
       {% if author.linkedin %}
-        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
+        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin-in" aria-hidden="true"></i> LinkedIn</a></li>
       {% endif %}
       {% if author.dblp %}
         <li><a href="{{ author.dblp }}"><i class="ai ai-dblp ai-fw" aria-hidden="true"></i> DBLP</a></li>
@@ -197,7 +197,7 @@
         <a href="https://plus.google.com/+{{ author.google_plus }}"><i class="fab fa-fw fa-google-plus" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.linkedin %}
-        <a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i></a>
+        <a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin-in" aria-hidden="true"></i></a>
       {% endif %}
       {% if author.dblp %}
         <a href="{{ author.dblp }}"><i class="ai ai-dblp ai-fw" aria-hidden="true"></i></a>

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -229,6 +229,7 @@ body:hover .visually-hidden button {
   }
 
   .fa-linkedin,
+  .fa-linkedin-in,
   .fa-linkedin-square {
     color: $linkedin-color;
   }


### PR DESCRIPTION
## Summary
- switch author profile LinkedIn icon markup to use the `fa-linkedin-in` brand glyph
- extend LinkedIn color utility styling to include the new icon class

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e08203d970832d9b3075e2f606e035