### PR TITLE
Ensure page layout stretches to full viewport height

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -11,6 +11,9 @@ body {
   margin: 0;
   padding: 0;
   padding-bottom: 0em;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   color: $text-color;
   font-family: $global-font-family;
   line-height: 1.5;

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -8,6 +8,8 @@
   margin-top: 1em;
   padding-left: 1em;
   padding-right: 1em;
+  flex: 1 0 auto;
+  width: 100%;
   animation: intro 0.3s both;
   animation-delay: 0.35s;
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -742,6 +742,7 @@ html[data-theme="dark"] {
   color: var(--footer-text);
   font-size: 0.8125rem;
   line-height: 1.5;
+  flex-shrink: 0;
 }
 
 .custom-license-footer__inner {


### PR DESCRIPTION
## Summary
- make the body act as a flex column that fills the viewport so the background covers the screen
- allow the main content area to grow and push the footer to the bottom while keeping the footer from shrinking

## Testing
- bundle exec jekyll build *(fails: bundler missing due to network-restricted gem install)*

------
https://chatgpt.com/codex/tasks/task_e_68e08a805680832d964781da6068806b