### PR TITLE
Align LinkedIn icon color with theme

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -272,6 +272,11 @@
       background: none;
     }
   }
+
+  .fa-linkedin,
+  .fa-linkedin-square {
+    color: inherit;
+  }
 }
 
 .author__urls_sm{
@@ -284,6 +289,10 @@
     &:hover {
       text-decoration: none;
     }
+  }
+  .fa-linkedin,
+  .fa-linkedin-square {
+    color: inherit;
   }
   @include breakpoint($large) {
     display: none;


### PR DESCRIPTION
## Summary
- update the sidebar LinkedIn icons to inherit the surrounding text color so they match other Font Awesome icons across themes

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e09312f5c4832d969f95b2efa40deb