### PR TITLE
Refine publication filters responsive layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -217,16 +217,30 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   justify-content: center;
 }
 
+@media (min-width: 40rem) {
+  .publication-controls {
+    grid-template-columns: repeat(2, minmax(11rem, 1fr));
+  }
+
+  .publication-search {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (min-width: 48rem) {
   .publication-controls {
-    grid-template-columns: minmax(16rem, 1fr) repeat(3, max-content);
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
   }
 
   .publication-controls select,
   .publication-controls button {
-    width: auto;
+    width: 100%;
     min-width: 0;
-    justify-self: start;
+    justify-self: stretch;
+  }
+
+  .publication-search {
+    grid-column: 1 / -1;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a medium-width breakpoint so publication filter dropdowns can sit side-by-side while keeping the search input full width
- rework the wide-screen grid to use auto-fitting columns so controls stay evenly sized and aligned

## Testing
- ⚠️ `bundle install` *(fails with Gem::Net::HTTPClientException 403 "Forbidden" when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e0982e1024832db508d7d6b8a99928