### PR TITLE
Adjust publication filter layout widths

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -235,7 +235,8 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 @media (min-width: 64rem) {
   .publication-controls {
-    grid-template-columns: minmax(18rem, 3fr) repeat(3, minmax(10rem, 1fr));
+    grid-template-columns: minmax(18rem, 4fr) repeat(3, max-content);
+    align-items: center;
   }
 
   .publication-search {
@@ -252,6 +253,12 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
   #publication-year-sort {
     grid-column: 4 / span 1;
+  }
+
+  .publication-controls select,
+  .publication-controls button {
+    width: auto;
+    justify-self: start;
   }
 }
 


### PR DESCRIPTION
## Summary
- auto-size the publication filter controls on wide screens so the search input can share a row with appropriate spacing
- keep the mobile layout with the search control on its own row and the remaining filters grouped together

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: bundler could not be installed due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ae910f74832d9bccdfd618bcd5e6