### PR TITLE
Improve publications controls responsiveness

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -168,8 +168,8 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 
 .publication-controls {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.85rem;
   align-items: stretch;
   margin-bottom: 1.5rem;
@@ -190,7 +190,6 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   min-height: var(--publication-control-height);
   box-sizing: border-box;
   outline: none;
-  width: 100%;
 }
 
 .publication-search {
@@ -199,29 +198,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   line-height: 1.2;
   -webkit-appearance: none;
   appearance: none;
+  flex: 1 1 100%;
 }
 
-
-#publication-type-filter {
-  grid-column: 1 / span 1;
-}
-
-#publication-year-filter {
-  grid-column: 2 / span 1;
-}
-
-#publication-year-sort {
-  grid-column: 3 / span 1;
-}
-
-.publication-controls select,
-.publication-controls button {
-  justify-self: stretch;
-}
-
-.publication-search {
-  grid-column: 1 / -1;
-}
 
 .publication-controls button {
   cursor: pointer;
@@ -233,32 +212,26 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   justify-content: center;
 }
 
+.publication-controls select,
+.publication-controls button {
+  flex: 0 1 auto;
+  width: auto;
+}
+
 @media (min-width: 64rem) {
   .publication-controls {
-    grid-template-columns: minmax(18rem, 4fr) repeat(3, max-content);
+    flex-wrap: nowrap;
     align-items: center;
-  }
-
-  .publication-search {
-    grid-column: 1 / span 1;
-  }
-
-  #publication-type-filter {
-    grid-column: 2 / span 1;
-  }
-
-  #publication-year-filter {
-    grid-column: 3 / span 1;
-  }
-
-  #publication-year-sort {
-    grid-column: 4 / span 1;
   }
 
   .publication-controls select,
   .publication-controls button {
-    width: auto;
-    justify-self: start;
+    flex: 0 0 auto;
+  }
+
+  .publication-search {
+    flex: 1 1 18rem;
+    min-width: 12rem;
   }
 }
 
@@ -638,17 +611,8 @@ html[data-theme="dark"] {
     gap: 0.65rem;
   }
 
-  .publication-controls select,
-  .publication-controls button {
-    justify-self: stretch;
-  }
-
-  .publication-search,
-  .publication-controls select,
-  .publication-controls button {
-    width: 100%;
-    min-width: 0;
-    justify-self: stretch;
+  .publication-search {
+    flex-basis: 100%;
   }
 
   ol.publication-list > li {


### PR DESCRIPTION
## Summary
- replace the publication filter grid with a flexible layout so the search field and filters resize without overlapping
- refine responsive rules so the search input occupies its own row on small screens while controls stay on a single line on desktop

## Testing
- bundle exec jekyll serve --livereload --host 0.0.0.0 *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e0b1e26b8c832dad5007b9e3bfe426