### PR TITLE
Adjust publication control responsive layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -218,7 +218,7 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   width: auto;
 }
 
-@media (min-width: 64rem) {
+@media (min-width: 56rem) {
   .publication-controls {
     flex-wrap: nowrap;
     align-items: center;
@@ -232,6 +232,18 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   .publication-search {
     flex: 1 1 18rem;
     min-width: 12rem;
+  }
+}
+
+@media (max-width: 55.99rem) {
+  .publication-controls select {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .publication-controls .publication-sort {
+    flex: 0 0 auto;
+    padding-inline: 0.65rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- lower the breakpoint that keeps publication controls on a single line so they wrap later on smaller viewports
- ensure that when the controls wrap, the filter selects expand to share the row while the sort button stays compact

## Testing
- bundle install *(fails: 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b93dd680832d8ec2133f0d19a970