### PR TITLE
Fix publication sort button alignment

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -210,6 +210,7 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   display: flex;
   align-items: center;
   justify-content: center;
+  line-height: 1;
 }
 
 .publication-controls select,
@@ -221,7 +222,7 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 @media (min-width: 40rem) {
   .publication-controls {
     flex-wrap: nowrap;
-    align-items: center;
+    align-items: stretch;
   }
 
   .publication-controls select,


### PR DESCRIPTION
## Summary
- ensure the publication sort button aligns with the other controls by stretching items on wide layouts
- normalize the sort button line-height so the icon sits centrally

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0be4468ec832d8b217a36dac8ae88