### PR TITLE
Replace publication sort arrows with SVG icon

### DIFF
--- a/_pages/includes/pub.md
+++ b/_pages/includes/pub.md
@@ -26,7 +26,22 @@
     aria-label="Sort by newest"
     data-aria-label-en="Sort by newest"
     data-aria-label-zh="按最新排序"
-  >⬇</button>
+  >
+    <svg
+      class="publication-sort-icon"
+      viewBox="0 0 1025 1024"
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M754.012 538a59.832 59.832 0 0 1 40.055 15.402c24.663 22.223 26.722 60.323 4.6 85.097L557.154 908.976a60.125 60.125 0 0 1-4.6 4.621c-24.661 22.223-62.587 20.154-84.709-4.62L226.332 638.498A60.418 60.418 0 0 1 211 598.261C211 564.98 237.857 538 270.987 538h483.025zM557.155 117.024L798.668 387.5A60.418 60.418 0 0 1 814 427.739C814 461.02 787.143 488 754.013 488H270.988a59.832 59.832 0 0 1-40.055-15.402c-24.663-22.223-26.722-60.323-4.6-85.097l241.513-270.477a60.125 60.125 0 0 1 4.6-4.621c24.661-22.223 62.587-20.154 84.709 4.62z"
+        fill="currentColor"
+      />
+    </svg>
+  </button>
 </div>
 
 <ol id="publication-list" class="publication-list"></ol>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -213,6 +213,16 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   line-height: 1;
 }
 
+.publication-sort-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  transition: transform 0.2s ease;
+}
+
+.publication-sort-icon--asc {
+  transform: rotate(180deg);
+}
+
 .publication-controls select,
 .publication-controls button {
   flex: 0 1 auto;

--- a/assets/js/publications.js
+++ b/assets/js/publications.js
@@ -151,6 +151,18 @@
     updateYearOptions();
 
     var sortOrder = 'desc';
+    var sortIconSvg = '' +
+      '<svg class="publication-sort-icon" viewBox="0 0 1025 1024" xmlns="http://www.w3.org/2000/svg" width="20" height="20" aria-hidden="true" focusable="false">' +
+      '<path d="M754.012 538a59.832 59.832 0 0 1 40.055 15.402c24.663 22.223 26.722 60.323 4.6 85.097L557.154 908.976a60.125 60.125 0 0 1-4.6 4.621c-24.661 22.223-62.587 20.154-84.709-4.62L226.332 638.498A60.418 60.418 0 0 1 211 598.261C211 564.98 237.857 538 270.987 538h483.025zM557.155 117.024L798.668 387.5A60.418 60.418 0 0 1 814 427.739C814 461.02 787.143 488 754.013 488H270.988a59.832 59.832 0 0 1-40.055-15.402c-24.663-22.223-26.722-60.323-4.6-85.097l241.513-270.477a60.125 60.125 0 0 1 4.6-4.621c24.661-22.223 62.587-20.154 84.709 4.62z" fill="currentColor"></path>' +
+      '</svg>';
+
+    function updateSortButtonIcon() {
+      sortButton.innerHTML = sortIconSvg;
+      var icon = sortButton.querySelector('svg');
+      if (icon) {
+        icon.classList.toggle('publication-sort-icon--asc', sortOrder === 'asc');
+      }
+    }
 
     function normalizeDate(dateStr, year) {
       if (!dateStr) {
@@ -332,10 +344,11 @@
 
     typeSelect.addEventListener('change', render);
     yearSelect.addEventListener('change', render);
+    updateSortButtonIcon();
+
     sortButton.addEventListener('click', function () {
       sortOrder = sortOrder === 'desc' ? 'asc' : 'desc';
-      sortButton.textContent = sortOrder === 'desc' ? '⏬️'
-    : '⏫️';
+      updateSortButtonIcon();
       render();
     });
 


### PR DESCRIPTION
## Summary
- replace the publication year sort control text arrows with the provided SVG icon
- update the JavaScript sort toggle to render the SVG and rotate it for ascending order
- add styles to size the icon consistently within the existing button layout

## Testing
- not run (jekyll dependencies could not be installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e0ca82c728832da2c68d12c8de728c