### PR TITLE
Align navigation and filter styling across themes

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -20,6 +20,33 @@ html.theme-dark {
   --masthead-hidden-link-hover-bg: rgba(59, 130, 246, 0.2);
 }
 
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --selection-bg: rgba(191, 219, 254, 0.7);
+  --selection-color: #0f172a;
+  --masthead-toggle-bg: transparent;
+  --masthead-toggle-color: #f8fafc;
+  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.35);
+  --masthead-hidden-links-bg: rgba(31, 41, 55, 0.95);
+  --masthead-hidden-links-border: rgba(255, 255, 255, 0.12);
+  --masthead-hidden-links-divider: rgba(255, 255, 255, 0.12);
+  --masthead-hidden-links-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  --masthead-hidden-link-color: #e2e8f0;
+  --masthead-hidden-link-hover-color: #bfdbfe;
+  --masthead-hidden-link-hover-bg: rgba(59, 130, 246, 0.2);
+}
+
+html.theme-dark,
+html[data-theme="dark"] {
+  --publication-control-bg: #1f2937;
+  --publication-control-color: #e2e8f0;
+  --publication-control-border: rgba(255, 255, 255, 0.12);
+  --publication-control-hover-bg: rgba(59, 130, 246, 0.16);
+  --publication-control-hover-color: #bfdbfe;
+  --publication-control-placeholder: rgba(226, 232, 240, 0.6);
+  --publication-control-option-color: #0f172a;
+}
+
 html.theme-dark body {
   background-color: #0f172a;
   color: #e2e8f0;
@@ -195,38 +222,6 @@ html.theme-dark .btn:focus:not(:focus-visible) {
 html.theme-dark table,
 html.theme-dark .page__content .news-list {
   border-color: rgba(255, 255, 255, 0.12);
-}
-
-html.theme-dark .publication-controls input,
-html.theme-dark .publication-controls select {
-  background-color: #1f2937;
-  border-color: rgba(255, 255, 255, 0.12);
-  color: #e2e8f0;
-}
-
-html.theme-dark .publication-controls input::placeholder {
-  color: rgba(226, 232, 240, 0.6);
-}
-
-html.theme-dark .publication-controls select option {
-  color: #0f172a;
-}
-
-html.theme-dark .publication-controls button,
-html[data-theme="dark"] .publication-controls button {
-  background-color: #1f2937;
-  border-color: rgba(255, 255, 255, 0.12);
-  color: #e2e8f0;
-}
-
-html.theme-dark .publication-controls button:hover,
-html.theme-dark .publication-controls button:focus-visible,
-html.theme-dark .publication-controls button:active,
-html[data-theme="dark"] .publication-controls button:hover,
-html[data-theme="dark"] .publication-controls button:focus-visible,
-html[data-theme="dark"] .publication-controls button:active {
-  background-color: #1f2937;
-  color: #bfdbfe;
 }
 
 html.theme-dark .publication-index,

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -6,7 +6,7 @@
   --masthead-toggle-hover-color: #{$masthead-link-color-hover};
   --masthead-toggle-underline-bg: #{mix(#fff, $primary-color, 50%)};
   --masthead-toggle-focus-shadow: rgba($primary-color, 0.35);
-  --masthead-toggle-bg: #{$primary-color};
+  --masthead-toggle-bg: transparent;
   --masthead-toggle-color: #{$masthead-link-color};
   --masthead-toggle-hover-bg: #{mix(#000, $primary-color, 15%)};
   --masthead-hidden-links-bg: #fff;
@@ -191,15 +191,17 @@
   padding: 0.35rem;
   border: 0;
   border-radius: 999px;
-  background-color: transparent;
+  background-color: var(--masthead-toggle-bg, transparent);
   color: var(--masthead-toggle-color);
   cursor: pointer;
-  transition: color 0.2s ease, box-shadow 0.2s ease;
+  transition: color 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease;
   min-height: 2.25rem;
 
   &:hover,
   &:focus-visible {
     color: var(--masthead-toggle-hover-color);
+    background-color: var(--masthead-toggle-hover-bg, transparent);
   }
 
   &:focus-visible {
@@ -210,6 +212,7 @@
   &:focus:not(:focus-visible) {
     outline: none;
     box-shadow: none;
+    background-color: var(--masthead-toggle-bg, transparent);
   }
 
   &.hidden {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -273,11 +273,25 @@
       color: var(--masthead-hidden-link-color, #{$masthead-link-color});
       line-height: 1.5;
       text-align: center;
-      transition: background-color 0.2s ease, color 0.2s ease;
+      transition: background-color 0.2s ease, color 0.2s ease,
+        box-shadow 0.2s ease;
 
       &:hover {
         color: var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
         background: var(--masthead-hidden-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
+      }
+
+      &:focus-visible {
+        color: var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
+        background: var(--masthead-hidden-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
+        outline: none;
+        box-shadow: inset 0 0 0 1px
+          var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
+      }
+
+      &:focus:not(:focus-visible) {
+        outline: none;
+        box-shadow: none;
       }
     }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -146,6 +146,13 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
   --publication-accent: #224b8d;
   --publication-accent-hover: #1a3a6d;
   --publication-accent-soft: rgba(34, 75, 141, 0.18);
+  --publication-control-bg: #fff;
+  --publication-control-color: #1f2937;
+  --publication-control-border: #c1c7d0;
+  --publication-control-hover-bg: #f1f5f9;
+  --publication-control-hover-color: var(--publication-accent);
+  --publication-control-placeholder: #6b7280;
+  --publication-control-option-color: #0f172a;
   --citation-modal-overlay: rgba(15, 23, 42, 0.45);
   --citation-modal-dialog-bg: #fff;
   --citation-modal-dialog-color: #0f172a;
@@ -181,8 +188,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 .publication-search {
   padding: 0 0.85rem;
   border-radius: 0.45rem;
-  border: 1px solid #c1c7d0;
-  background-color: #fff;
+  border: 1px solid var(--publication-control-border);
+  background-color: var(--publication-control-bg);
+  color: var(--publication-control-color);
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, color 0.2s ease;
@@ -204,9 +212,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 .publication-controls button {
   cursor: pointer;
-  background-color: #fff;
-  color: #4b5563;
-  border-color: #c1c7d0;
+  background-color: var(--publication-control-bg);
+  color: var(--publication-control-color);
+  border-color: var(--publication-control-border);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -264,13 +272,22 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 }
 
 .publication-controls button:hover {
-  background-color: inherit;
-  color: var(--publication-accent);
+  background-color: var(--publication-control-hover-bg);
+  color: var(--publication-control-hover-color);
 }
 
 .publication-controls button:active {
-  background-color: inherit;
-  color: var(--publication-accent);
+  background-color: var(--publication-control-hover-bg);
+  color: var(--publication-control-hover-color);
+}
+
+.publication-controls button:focus-visible {
+  color: var(--publication-control-hover-color);
+}
+
+.publication-controls button:focus:not(:focus-visible) {
+  color: var(--publication-control-color);
+  background-color: var(--publication-control-bg);
 }
 
 .publication-controls select:hover,
@@ -281,6 +298,16 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 .publication-search:focus-visible {
   border-color: var(--publication-accent);
   box-shadow: 0 0 0 3px var(--publication-accent-soft);
+  background-color: var(--publication-control-hover-bg);
+}
+
+.publication-search::placeholder {
+  color: var(--publication-control-placeholder);
+  transition: color 0.2s ease;
+}
+
+.publication-controls select option {
+  color: var(--publication-control-option-color);
 }
 
 ol.publication-list {


### PR DESCRIPTION
## Summary
- apply shared CSS variables so publication filter controls match the active theme
- adjust collapsed navigation toggle and hidden links to share hover and focus feedback across themes

## Testing
- not run (bundle install fails with 403 Forbidden from rubygems.org)


------
https://chatgpt.com/codex/tasks/task_e_68e0d6cc0aa0832d83e5ce20643b9f9e