### PR TITLE
Refine masthead navigation styling across themes

### DIFF
--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -2,22 +2,52 @@ html.theme-light {
   color-scheme: light;
   --selection-bg: #2563eb;
   --selection-color: #f8fafc;
+  --masthead-surface: rgba(255, 255, 255, 0.94);
+  --masthead-border-color: rgba(148, 163, 184, 0.22);
+  --masthead-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --masthead-backdrop: blur(22px);
+  --masthead-link-color: #1f2937;
+  --masthead-link-hover-color: #1d4ed8;
+  --masthead-link-hover-bg: rgba(37, 99, 235, 0.12);
+  --masthead-link-focus-ring: rgba(37, 99, 235, 0.35);
+  --masthead-link-underline-color: rgba(37, 99, 235, 0.75);
+  --masthead-toggle-bg: rgba(37, 99, 235, 0.05);
+  --masthead-toggle-color: #1f2937;
+  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.12);
+  --masthead-toggle-hover-color: #1d4ed8;
+  --masthead-hidden-links-bg: rgba(255, 255, 255, 0.95);
+  --masthead-hidden-links-border: rgba(148, 163, 184, 0.22);
+  --masthead-hidden-links-divider: rgba(148, 163, 184, 0.28);
+  --masthead-hidden-links-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
+  --masthead-hidden-link-color: #1f2937;
+  --masthead-hidden-link-hover-color: #1d4ed8;
+  --masthead-hidden-link-hover-bg: rgba(37, 99, 235, 0.12);
 }
 
 html.theme-dark {
   color-scheme: dark;
   --selection-bg: rgba(191, 219, 254, 0.7);
   --selection-color: #0c1117;
-  --masthead-toggle-bg: transparent;
+  --masthead-surface: rgba(12, 17, 23, 0.9);
+  --masthead-border-color: rgba(148, 163, 184, 0.18);
+  --masthead-shadow: 0 18px 45px rgba(2, 6, 23, 0.65);
+  --masthead-backdrop: blur(24px);
+  --masthead-link-color: #e2e8f0;
+  --masthead-link-hover-color: #bfdbfe;
+  --masthead-link-hover-bg: rgba(59, 130, 246, 0.2);
+  --masthead-link-focus-ring: rgba(96, 165, 250, 0.45);
+  --masthead-link-underline-color: rgba(191, 219, 254, 0.9);
+  --masthead-toggle-bg: rgba(37, 99, 235, 0.12);
   --masthead-toggle-color: #f8fafc;
-  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.35);
+  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.2);
+  --masthead-toggle-hover-color: #bfdbfe;
   --masthead-hidden-links-bg: rgba(31, 41, 55, 0.95);
   --masthead-hidden-links-border: rgba(255, 255, 255, 0.12);
   --masthead-hidden-links-divider: rgba(255, 255, 255, 0.12);
-  --masthead-hidden-links-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  --masthead-hidden-links-shadow: 0 20px 45px rgba(2, 6, 23, 0.55);
   --masthead-hidden-link-color: #e2e8f0;
   --masthead-hidden-link-hover-color: #bfdbfe;
-  --masthead-hidden-link-hover-bg: rgba(59, 130, 246, 0.2);
+  --masthead-hidden-link-hover-bg: rgba(59, 130, 246, 0.24);
 }
 
 html.theme-dark body {
@@ -26,16 +56,16 @@ html.theme-dark body {
 }
 
 html.theme-dark .masthead {
-  background-color: #0c1117;
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background-color: var(--masthead-surface, #0c1117);
+  border-bottom-color: var(--masthead-border-color, rgba(255, 255, 255, 0.08));
 }
 
 html.theme-dark .masthead__menu a {
-  color: #e2e8f0;
+  color: var(--masthead-link-color, #e2e8f0);
 }
 
 html.theme-dark .masthead__menu a:hover {
-  color: #bfdbfe;
+  color: var(--masthead-link-hover-color, #bfdbfe);
 }
 
 html.theme-dark .greedy-nav {
@@ -43,19 +73,19 @@ html.theme-dark .greedy-nav {
 }
 
 html.theme-dark .greedy-nav .visible-links a {
-  color: inherit;
+  color: var(--masthead-link-color, inherit);
 }
 
 html.theme-dark .greedy-nav .visible-links a:focus-visible {
-  color: #bfdbfe;
+  color: var(--masthead-link-hover-color, #bfdbfe);
 }
 
 html.theme-dark .greedy-nav .visible-links a:hover {
-  color: #bfdbfe;
+  color: var(--masthead-link-hover-color, #bfdbfe);
 }
 
 html.theme-dark .greedy-nav .visible-links a::before {
-  background: #bfdbfe;
+  background: var(--masthead-link-underline-color, #bfdbfe);
 }
 
 html.theme-dark .page__content {

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -3,26 +3,38 @@
    ========================================================================== */
 
 :root {
-  --masthead-toggle-hover-color: #{$masthead-link-color-hover};
-  --masthead-toggle-underline-bg: #{mix(#fff, $primary-color, 50%)};
-  --masthead-toggle-focus-shadow: rgba($primary-color, 0.35);
-  --masthead-toggle-bg: #{$primary-color};
-  --masthead-toggle-color: #{$masthead-link-color};
-  --masthead-toggle-hover-bg: #{mix(#000, $primary-color, 15%)};
+  --masthead-surface: #fff;
+  --masthead-border-color: #e5e7eb;
+  --masthead-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  --masthead-backdrop: blur(16px);
+  --masthead-link-color: #1f2937;
+  --masthead-link-hover-color: #1d4ed8;
+  --masthead-link-hover-bg: rgba(37, 99, 235, 0.08);
+  --masthead-link-focus-ring: rgba(37, 99, 235, 0.35);
+  --masthead-link-underline-color: rgba(37, 99, 235, 0.7);
+  --masthead-toggle-bg: transparent;
+  --masthead-toggle-color: var(--masthead-link-color);
+  --masthead-toggle-hover-bg: rgba(37, 99, 235, 0.1);
+  --masthead-toggle-hover-color: var(--masthead-link-hover-color);
+  --masthead-toggle-underline-bg: rgba(37, 99, 235, 0.35);
+  --masthead-toggle-focus-shadow: var(--masthead-link-focus-ring);
   --masthead-hidden-links-bg: #fff;
-  --masthead-hidden-links-border: #{$border-color};
-  --masthead-hidden-links-divider: #{$border-color};
-  --masthead-hidden-links-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
-  --masthead-hidden-link-color: #{$masthead-link-color};
-  --masthead-hidden-link-hover-color: #{$masthead-link-color-hover};
-  --masthead-hidden-link-hover-bg: #{mix(#fff, $primary-color, 75%)};
+  --masthead-hidden-links-border: rgba(15, 23, 42, 0.08);
+  --masthead-hidden-links-divider: rgba(148, 163, 184, 0.28);
+  --masthead-hidden-links-shadow: 0 20px 35px rgba(15, 23, 42, 0.12);
+  --masthead-hidden-link-color: var(--masthead-link-color);
+  --masthead-hidden-link-hover-color: var(--masthead-link-hover-color);
+  --masthead-hidden-link-hover-bg: rgba(37, 99, 235, 0.08);
 }
 
 .masthead {
   position: sticky;
   top: 0;
-  background-color: white;
-  border-bottom: 1px solid $border-color;
+  background-color: var(--masthead-surface, #fff);
+  border-bottom: 1px solid var(--masthead-border-color, $border-color);
+  box-shadow: var(--masthead-shadow, none);
+  -webkit-backdrop-filter: var(--masthead-backdrop, none);
+          backdrop-filter: var(--masthead-backdrop, none);
   -webkit-animation: intro 0.3s both;
           animation: intro 0.3s both;
   -webkit-animation-delay: 0.15s;
@@ -73,7 +85,7 @@
   flex: 0 0 auto;
   align-items: center;
   gap: 0.35rem;
-  color: $masthead-link-color;
+  color: var(--masthead-link-color, #{$masthead-link-color});
   margin-left: auto;
   margin-right: 0;
   white-space: nowrap;
@@ -123,13 +135,13 @@
   margin: 0;
   border: none;
   border-radius: 999px;
-  background-color: transparent;
-  color: inherit;
+  background-color: var(--masthead-toggle-bg, transparent);
+  color: var(--masthead-toggle-color, currentColor);
   cursor: pointer;
   line-height: 1;
   white-space: nowrap;
   font-size: 1rem;
-  transition: color 0.2s ease, box-shadow 0.2s ease;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
   --toggle-icon-size: 1.5rem;
 
   &::after {
@@ -148,7 +160,8 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--masthead-toggle-hover-color);
+    color: var(--masthead-toggle-hover-color, currentColor);
+    background-color: var(--masthead-toggle-hover-bg, transparent);
   }
 
   &:hover::after,
@@ -158,7 +171,7 @@
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--masthead-toggle-focus-shadow);
+    box-shadow: 0 0 0 3px var(--masthead-toggle-focus-shadow);
   }
 
   &:focus:not(:focus-visible) {
@@ -191,20 +204,21 @@
   padding: 0.35rem;
   border: 0;
   border-radius: 999px;
-  background-color: transparent;
-  color: var(--masthead-toggle-color);
+  background-color: var(--masthead-toggle-bg, transparent);
+  color: var(--masthead-toggle-color, currentColor);
   cursor: pointer;
-  transition: color 0.2s ease, box-shadow 0.2s ease;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
   min-height: 2.25rem;
 
   &:hover,
   &:focus-visible {
-    color: var(--masthead-toggle-hover-color);
+    color: var(--masthead-toggle-hover-color, currentColor);
+    background-color: var(--masthead-toggle-hover-bg, transparent);
   }
 
   &:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--masthead-toggle-focus-shadow);
+    box-shadow: 0 0 0 3px var(--masthead-toggle-focus-shadow);
   }
 
   &:focus:not(:focus-visible) {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -175,17 +175,20 @@
 .greedy-nav {
   position: relative;
   min-width: 250px;
-  background: $background-color;
+  background: transparent;
 
   a {
     display: block;
     margin: 0 1rem;
-    padding: 0.5rem 0;
-    color: $masthead-link-color;
+    padding: 0.625rem 0.25rem;
+    color: var(--masthead-link-color, #{$masthead-link-color});
     text-decoration: none;
+    border-radius: 0.75rem;
+    transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 
     &:hover {
-      color: $masthead-link-color-hover;
+      color: var(--masthead-link-hover-color, #{$masthead-link-color-hover});
+      background-color: var(--masthead-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
     }
   }
 
@@ -213,6 +216,13 @@
 
     a {
       position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      min-height: 2.5rem;
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
 
       &:before {
         content: "";
@@ -220,7 +230,7 @@
         left: 0;
         bottom: 0;
         height: 4px;
-        background: mix(#fff, $primary-color, 50%);
+        background: var(--masthead-link-underline-color, #{mix(#fff, $primary-color, 50%)});
         width: 100%;
         -webkit-transition: $global-transition;
         transition: $global-transition;
@@ -236,14 +246,20 @@
       }
 
       &:focus-visible {
-        color: $masthead-link-color-hover;
+        color: var(--masthead-link-hover-color, #{$masthead-link-color-hover});
         outline: none;
+        background-color: var(--masthead-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
+        box-shadow: 0 0 0 3px var(--masthead-link-focus-ring, rgba($primary-color, 0.35));
       }
 
       &:focus-visible:before {
         -webkit-transform: scaleX(1);
             -ms-transform: scaleX(1);
                 transform: scaleX(1); /* reveal*/
+      }
+
+      &:focus:not(:focus-visible) {
+        box-shadow: none;
       }
     }
   }


### PR DESCRIPTION
## Summary
- enrich masthead styling with shared CSS variables for surfaces, links, and toggle accents across light and dark themes
- update greedy navigation link hover and focus treatments for softer shapes and clearer visual feedback
- align dark-theme overrides to rely on the new variables so hidden menus and toggles share consistent colors

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e1202ef4d4832da995391212d77f5b