### PR TITLE
Limit masthead changes to collapsible dropdown

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -256,28 +256,53 @@
     top: calc(100% + 0.5rem);
     right: 0;
     margin-top: 0;
-    padding: 0.5rem 0;
+    padding: 0.75rem;
     border: 1px solid var(--masthead-hidden-links-border, #{$border-color});
-    border-radius: $border-radius;
+    border-radius: 0.75rem;
     background: var(--masthead-hidden-links-bg, #fff);
     box-shadow: var(--masthead-hidden-links-shadow, 0 0 10px rgba(0, 0, 0, 0.25));
-    min-width: 10rem;
+    min-width: 12rem;
     width: max-content;
-    max-width: min(20rem, calc(100vw - 2rem));
+    max-width: min(22rem, calc(100vw - 2rem));
+    display: grid;
+    gap: 0.25rem;
+    overflow: hidden;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+
+    @supports ((-webkit-backdrop-filter: blur(14px)) or (backdrop-filter: blur(14px))) {
+      -webkit-backdrop-filter: blur(14px);
+              backdrop-filter: blur(14px);
+    }
 
     a {
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
       margin: 0;
-      padding: 0.625rem 1.25rem;
+      padding: 0.625rem 0.875rem;
       font-size: $type-size-5;
       color: var(--masthead-hidden-link-color, #{$masthead-link-color});
-      line-height: 1.5;
-      text-align: center;
-      transition: background-color 0.2s ease, color 0.2s ease;
+      line-height: 1.45;
+      text-align: left;
+      border-radius: 0.5rem;
+      transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
       &:hover {
         color: var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
         background: var(--masthead-hidden-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
+      }
+
+      &:focus-visible {
+        color: var(--masthead-hidden-link-hover-color, #{$masthead-link-color-hover});
+        outline: none;
+        background: var(--masthead-hidden-link-hover-bg, #{mix(#fff, $primary-color, 75%)});
+        box-shadow: 0 0 0 2px rgba($primary-color, 0.35);
+        transform: translateY(-1px);
+      }
+
+      &:focus:not(:focus-visible) {
+        box-shadow: none;
       }
     }
 
@@ -285,7 +310,7 @@
       content: "";
       position: absolute;
       top: -0.75rem;
-      right: 1rem;
+      right: 1.5rem;
       width: 0;
       border-style: solid;
       border-width: 0 0.5rem 0.5rem;
@@ -298,7 +323,7 @@
       content: "";
       position: absolute;
       top: calc(-0.75rem + 1px);
-      right: 1rem;
+      right: 1.5rem;
       width: 0;
       border-style: solid;
       border-width: 0 0.5rem 0.5rem;
@@ -309,11 +334,16 @@
 
     li {
       display: block;
-      border-bottom: 1px solid var(--masthead-hidden-links-divider, #{$border-color});
+      margin: 0;
 
-      &:last-child {
-        border-bottom: none;
+      & + li {
+        margin-top: 0.25rem;
       }
+    }
+
+    html.theme-dark & {
+      border-color: rgba(148, 163, 184, 0.2);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
     }
   }
 }


### PR DESCRIPTION
## Summary
- revert masthead and theme CSS tweaks so only the collapsible navigation dropdown is affected
- restyle the dropdown menu spacing, hover, and focus feedback with subtle shadows, blur support, and dark-theme borders

## Testing
- not run (bundler unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1202ef4d4832da995391212d77f5b