### PR TITLE
Debounce greedy navigation resize handling

### DIFF
--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -10,6 +10,7 @@ var $btn = $('[data-nav-toggle]');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('.greedy-nav__more .hidden-links');
 var docClickHandler = null;
+var resizeTimer;
 
 function getVisibleItems() {
   return $vlinks.children();
@@ -101,8 +102,15 @@ function updateNav() {
 
 // Window listeners
 
-$(window).resize(function() {
-  updateNav();
+$(window).on('resize', function() {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(function() {
+    if(typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(updateNav);
+    } else {
+      updateNav();
+    }
+  }, 150);
 });
 
 $btn.on('click', function() {


### PR DESCRIPTION
## Summary
- add a resize timer handle for the greedy navigation plugin
- debounce resize-triggered updates using setTimeout and requestAnimationFrame while keeping the initial layout update

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27a735d0c832dbca61489d929f048