### PR TITLE
Add ARIA attributes to masthead greedy navigation

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -59,11 +59,13 @@
           data-nav-toggle
           aria-label="Toggle navigation menu"
           aria-expanded="false"
+          aria-controls="masthead-hidden-links"
+          aria-haspopup="true"
         >
           <span class="sr-only">Toggle navigation</span>
           <div class="navicon" aria-hidden="true"></div>
         </button>
-        <ul class="hidden-links hidden"></ul>
+        <ul class="hidden-links hidden" id="masthead-hidden-links" aria-hidden="true"></ul>
       </div>
     </div>
   </div>

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -39,6 +39,7 @@ function manageDocClickListener(shouldBind) {
 
 function setMenuOpen(isOpen) {
   $hlinks.toggleClass('hidden', !isOpen);
+  $hlinks.attr('aria-hidden', isOpen ? 'false' : 'true');
   $btn.toggleClass('close', isOpen);
   $btn.attr('aria-expanded', isOpen ? 'true' : 'false');
   manageDocClickListener(isOpen);
@@ -63,6 +64,7 @@ function updateNav() {
       $btn.removeClass('hidden');
       $btn.removeClass('close');
       $btn.attr('aria-expanded', 'false');
+      $hlinks.attr('aria-hidden', 'true');
     }
 
   // The visible list is not overflowing
@@ -85,6 +87,8 @@ function updateNav() {
     if(getHiddenItems().length < 1) {
       $btn.addClass('hidden');
       setMenuOpen(false);
+      $hlinks.attr('aria-hidden', 'true');
+      $btn.attr('aria-expanded', 'false');
       breaks = [];
     }
   }
@@ -108,6 +112,7 @@ $(window).resize(function() {
 $btn.on('click', function() {
   var isHidden = $hlinks.hasClass('hidden');
   setMenuOpen(isHidden);
+  $hlinks.attr('aria-hidden', isHidden ? 'false' : 'true');
 });
 
 $btn.on('keydown', function(event) {


### PR DESCRIPTION
## Summary
- add stable identifiers and ARIA metadata to the masthead hidden-links toggle
- synchronize the hidden links container and toggle button attributes when the menu opens or closes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e27b7e5554832d8768d4125d456b94