### PR TITLE
Fix greedy navigation close animation

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -267,7 +267,27 @@
     display: grid;
     gap: 0.25rem;
     overflow: hidden;
-    transition: box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+    opacity: 0;
+    transform: translateY(-0.35rem);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+      border-color 0.2s ease, background-color 0.2s ease;
+
+    &.is-open {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transform: none;
+      transition: box-shadow 0.2s ease, border-color 0.2s ease,
+        background-color 0.2s ease;
+
+      &.is-open {
+        transform: none;
+      }
+    }
 
     @supports ((-webkit-backdrop-filter: blur(14px)) or (backdrop-filter: blur(14px))) {
       -webkit-backdrop-filter: blur(14px);

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -11,6 +11,25 @@ var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('.greedy-nav__more .hidden-links');
 var docClickHandler = null;
 var resizeTimer;
+var closeTimer = null;
+
+function raf(callback) {
+  if (typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(callback);
+    return;
+  }
+
+  window.setTimeout(callback, 16);
+}
+
+function cancelCloseHandlers() {
+  if (closeTimer !== null) {
+    window.clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+
+  $hlinks.off('transitionend.greedyNavVisibility');
+}
 
 function getVisibleItems() {
   return $vlinks.children();
@@ -38,9 +57,48 @@ function manageDocClickListener(shouldBind) {
   }
 }
 
-function setMenuOpen(isOpen) {
-  $hlinks.toggleClass('hidden', !isOpen);
-  $hlinks.attr('aria-hidden', isOpen ? 'false' : 'true');
+function setMenuOpen(isOpen, options) {
+  var settings = $.extend({ immediate: false }, options);
+
+  cancelCloseHandlers();
+
+  if (isOpen) {
+    $hlinks.removeClass('hidden');
+
+    var activate = function () {
+      $hlinks.addClass('is-open');
+    };
+
+    if (settings.immediate) {
+      activate();
+    } else {
+      raf(activate);
+    }
+
+    $hlinks.attr('aria-hidden', 'false');
+  } else {
+    $hlinks.removeClass('is-open');
+    $hlinks.attr('aria-hidden', 'true');
+
+    if (settings.immediate) {
+      $hlinks.addClass('hidden');
+    } else {
+      $hlinks.on('transitionend.greedyNavVisibility', function (event) {
+        if (event.target !== this) {
+          return;
+        }
+
+        cancelCloseHandlers();
+        $hlinks.addClass('hidden');
+      });
+
+      closeTimer = window.setTimeout(function () {
+        cancelCloseHandlers();
+        $hlinks.addClass('hidden');
+      }, 250);
+    }
+  }
+
   $btn.toggleClass('close', isOpen);
   $btn.attr('aria-expanded', isOpen ? 'true' : 'false');
   manageDocClickListener(isOpen);
@@ -87,8 +145,7 @@ function updateNav() {
     // Hide the dropdown btn if hidden list is empty
     if(getHiddenItems().length < 1) {
       $btn.addClass('hidden');
-      setMenuOpen(false);
-      $hlinks.attr('aria-hidden', 'true');
+      setMenuOpen(false, { immediate: true });
       $btn.attr('aria-expanded', 'false');
       breaks = [];
     }
@@ -120,7 +177,6 @@ $(window).on('resize', function() {
 $btn.on('click', function() {
   var isHidden = $hlinks.hasClass('hidden');
   setMenuOpen(isHidden);
-  $hlinks.attr('aria-hidden', isHidden ? 'false' : 'true');
 });
 
 $btn.on('keydown', function(event) {


### PR DESCRIPTION
## Summary
- add opacity and motion styles so the greedy navigation menu fades out smoothly
- delay reapplying the hidden class in the greedy navigation script until the closing animation finishes

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e27dbbe6c4832db5d70a7258e09b24