### PR TITLE
Fix collapse menu label sync

### DIFF
--- a/assets/js/collapse.js
+++ b/assets/js/collapse.js
@@ -6,9 +6,11 @@
       var $header = $(this);
       var $content = $header.next();
 
-      $content.stop(true, true).slideToggle(500, function () {
-        $header.text($content.is(':visible') ? 'Collapse' : 'Expand');
-      });
+      var willBeVisible = !$content.is(':visible');
+
+      $header.text(willBeVisible ? 'Collapse' : 'Expand');
+
+      $content.stop(true, true).slideToggle(500);
     });
   });
 })(jQuery);


### PR DESCRIPTION
## Summary
- update the collapse toggle script so the header label switches immediately when the menu opens or closes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e28131b0b4832db82c23e93e9a3d95