### PR TITLE
Improve masthead toggle accessibility

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,6 +11,10 @@
       <span class="toggle-button__icon" aria-hidden="true">
         <i class="fas fa-globe"></i>
       </span>
+      <span class="toggle-button__label" aria-live="polite" aria-atomic="true" role="status">
+        <span data-lang="en">Current: English | Switch: 中文</span>
+        <span data-lang="zh" hidden>当前：中文 | 切换：English</span>
+      </span>
     </button>
     {% endcapture %}
     {% capture theme_toggle %}
@@ -26,6 +30,10 @@
       </span>
       <span class="toggle-button__icon toggle-button__icon--moon" aria-hidden="true">
         <i class="fas fa-moon"></i>
+      </span>
+      <span class="toggle-button__label" aria-live="polite" aria-atomic="true" role="status">
+        <span data-lang="en">Current: Light ☀ | Switch: Dark 🌙</span>
+        <span data-lang="zh" hidden>当前：浅色 ☀ | 切换：深色 🌙</span>
       </span>
     </button>
     {% endcapture %}

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -178,6 +178,16 @@
       line-height: 1;
     }
   }
+
+  &__label {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-left: 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    text-align: left;
+  }
 }
 
 .toggle-button--language {

--- a/assets/js/toggles.js
+++ b/assets/js/toggles.js
@@ -14,16 +14,65 @@
   const themeToggles = Array.from(document.querySelectorAll('[data-theme-toggle]'));
   const languageToggles = Array.from(document.querySelectorAll('[data-language-toggle]'));
 
-  function getActiveLanguage() {
-    return html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
-  }
+  const LANGUAGE_STATUS_TEXT = {
+    en: {
+      label: 'Current: English | Switch: 中文',
+      aria: 'Current language: English. Switch to Chinese.',
+    },
+    zh: {
+      label: '当前：中文 | 切换：English',
+      aria: '当前语言：中文。切换到英文。',
+    },
+  };
 
-  function getThemeAriaLabel(isDark, language) {
-    if (language === 'zh') {
-      return isDark ? '切换到浅色模式' : '切换到深色模式';
+  const THEME_STATUS_TEXT = {
+    light: {
+      en: {
+        label: 'Current: Light ☀ | Switch: Dark 🌙',
+        aria: 'Current theme: Light mode. Switch to dark mode.',
+      },
+      zh: {
+        label: '当前：浅色 ☀ | 切换：深色 🌙',
+        aria: '当前主题：浅色模式。切换到深色模式。',
+      },
+    },
+    dark: {
+      en: {
+        label: 'Current: Dark 🌙 | Switch: Light ☀',
+        aria: 'Current theme: Dark mode. Switch to light mode.',
+      },
+      zh: {
+        label: '当前：深色 🌙 | 切换：浅色 ☀',
+        aria: '当前主题：深色模式。切换到浅色模式。',
+      },
+    },
+  };
+
+  function updateToggleButtonLabel(toggle, labels) {
+    if (!toggle) {
+      return;
     }
 
-    return isDark ? 'Switch to light mode' : 'Switch to dark mode';
+    const labelContainer = toggle.querySelector('.toggle-button__label');
+
+    if (!labelContainer) {
+      return;
+    }
+
+    const englishLabel = labelContainer.querySelector('[data-lang="en"]');
+    const chineseLabel = labelContainer.querySelector('[data-lang="zh"]');
+
+    if (englishLabel && labels.en) {
+      englishLabel.textContent = labels.en;
+    }
+
+    if (chineseLabel && labels.zh) {
+      chineseLabel.textContent = labels.zh;
+    }
+  }
+
+  function getActiveLanguage() {
+    return html.getAttribute('data-language') === 'zh' ? 'zh' : 'en';
   }
 
   function updateMetaThemeColor(theme) {
@@ -48,7 +97,15 @@
 
     themeToggles.forEach(function (toggle) {
       toggle.setAttribute('aria-pressed', String(isDark));
-      toggle.setAttribute('aria-label', getThemeAriaLabel(isDark, language));
+      const statusText = THEME_STATUS_TEXT[normalized] || THEME_STATUS_TEXT.light;
+      const languageMessages = statusText[language] || statusText.en;
+
+      updateToggleButtonLabel(toggle, {
+        en: statusText.en ? statusText.en.label : '',
+        zh: statusText.zh ? statusText.zh.label : '',
+      });
+
+      toggle.setAttribute('aria-label', languageMessages.aria);
     });
 
     updateMetaThemeColor(normalized);
@@ -124,10 +181,14 @@
 
     languageToggles.forEach(function (toggle) {
       toggle.setAttribute('aria-pressed', String(isChinese));
-      toggle.setAttribute(
-        'aria-label',
-        isChinese ? '切换到英文' : 'Switch to Chinese'
-      );
+      const languageMessages = isChinese ? LANGUAGE_STATUS_TEXT.zh : LANGUAGE_STATUS_TEXT.en;
+
+      updateToggleButtonLabel(toggle, {
+        en: LANGUAGE_STATUS_TEXT.en ? LANGUAGE_STATUS_TEXT.en.label : '',
+        zh: LANGUAGE_STATUS_TEXT.zh ? LANGUAGE_STATUS_TEXT.zh.label : '',
+      });
+
+      toggle.setAttribute('aria-label', languageMessages.aria);
 
       toggle.dataset.nextLanguage = nextLanguage;
     });


### PR DESCRIPTION
## Summary
- add bilingual, aria-live status labels to the masthead language and theme toggle buttons
- synchronize toggle text and aria-labels in the language and theme scripts after each switch
- style the new toggle labels for readability within the masthead actions

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --livereload-port 35730 *(fails: `jekyll` executable not installed in container)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when downloading gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e3536b791c832db057704ca382f0f3