### PR TITLE
Add news filtering and expand functionality

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,62 +1,155 @@
-- en: "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/11164660))!"
+- year: 2025
+  tags:
+    - publication
+  en: "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/11164660))!"
   zh: "*2025/08* &nbsp;🎉 合作论文被 **IEEE T-FS** 录用（[链接](https://ieeexplore.ieee.org/document/11164660)）！"
-- en: "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-IE** ([Link](10.1109/TIE.2025.3600515))!"
+- year: 2025
+  tags:
+    - publication
+  en: "*08/2025* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-IE** ([Link](10.1109/TIE.2025.3600515))!"
   zh: "*2025/08* &nbsp;🎉 合作论文被 **IEEE T-IE** 录用（[链接](10.1109/TIE.2025.3600515)）！"
-- en: "*06/2025* &nbsp;👏 I was awarded the **Outstanding Graduates of Shanghai**!"
+- year: 2025
+  tags:
+    - honor
+  en: "*06/2025* &nbsp;👏 I was awarded the **Outstanding Graduates of Shanghai**!"
   zh: "*2025/06* &nbsp;👏 获评 **上海市优秀毕业生**！"
-- en: "*01/2025* &nbsp;👏🎉 I obtained **Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program** by CAST!"
+- year: 2025
+  tags:
+    - program
+  en: "*01/2025* &nbsp;👏🎉 I obtained **Inaugural Doctoral Special Program of Young Elite Scientist Sponsorship Program** by CAST!"
   zh: "*2025/01* &nbsp;👏🎉 入选中国科协 **青年人才托举工程博士生专项计划（首批）**！"
-- en: "*09/2024* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
+- year: 2024
+  tags:
+    - honor
+  en: "*09/2024* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
   zh: "*2024/09* &nbsp;👏👏 获得上海交通大学博士研究生 **国家奖学金**！"
-- en: "*08/2024* &nbsp;🎉 One paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!"
+- year: 2024
+  tags:
+    - publication
+  en: "*08/2024* &nbsp;🎉 One paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/))!"
   zh: "*2024/08* &nbsp;🎉 论文被 **IEEE T-VT** 录用（[链接](https://ieeexplore.ieee.org/document/)）！"
-- en: "*07/2024* &nbsp;🎉  One co-author's paper was accepted by IEEE **CDC** ([Link]())!"
+- year: 2024
+  tags:
+    - publication
+  en: "*07/2024* &nbsp;🎉  One co-author's paper was accepted by IEEE **CDC** ([Link]())!"
   zh: "*2024/07* &nbsp;🎉 合作论文被 IEEE **CDC** 录用（[链接]()）！"
-- en: "*07/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](10.1109/TFUZZ.2024.3434711))!"
+- year: 2024
+  tags:
+    - publication
+  en: "*07/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-FS** ([Link](10.1109/TFUZZ.2024.3434711))!"
   zh: "*2024/07* &nbsp;🎉 合作论文被 **IEEE T-FS** 录用（[链接](10.1109/TFUZZ.2024.3434711)）！"
-- en: "*03/2024* &nbsp;🎉 One  paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/10549852))!"
+- year: 2024
+  tags:
+    - publication
+  en: "*03/2024* &nbsp;🎉 One  paper was accepted by **IEEE T-FS** ([Link](https://ieeexplore.ieee.org/document/10549852))!"
   zh: "*2024/03* &nbsp;🎉 论文被 **IEEE T-FS** 录用（[链接](https://ieeexplore.ieee.org/document/10549852)）！"
-- en: "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/document/10462491))!"
+- year: 2024
+  tags:
+    - publication
+  en: "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/document/10462491))!"
   zh: "*2024/02* &nbsp;🎉 合作论文被 **IEEE T-CSII** 录用（[链接](https://ieeexplore.ieee.org/document/10462491)）！"
-- en: "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/10449447))!"
+- year: 2024
+  tags:
+    - publication
+  en: "*02/2024* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-VT** ([Link](https://ieeexplore.ieee.org/document/10449447))!"
   zh: "*2024/02* &nbsp;🎉 合作论文被 **IEEE T-VT** 录用（[链接](https://ieeexplore.ieee.org/document/10449447)）！"
-- en: "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/document/10416809))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/document/10416809))!"
   zh: "*2023/12* &nbsp;🎉 合作论文被 **IEEE T-CYB** 录用（[链接](https://ieeexplore.ieee.org/document/10416809)）！"
-- en: "*12/2023* &nbsp;👏 I obtained the **Scientific Research Talens Graduate Student Scholarship** awarded by Sanya Yazhou Bay Science and Technology City!"
+- year: 2023
+  tags:
+    - honor
+  en: "*12/2023* &nbsp;👏 I obtained the **Scientific Research Talens Graduate Student Scholarship** awarded by Sanya Yazhou Bay Science and Technology City!"
   zh: "*2023/12* &nbsp;👏 获得三亚崖州湾科技城的 **科研之星**荣誉称号！"
-- en: "*12/2023* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/document/10414035))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*12/2023* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/document/10414035))!"
   zh: "*2023/12* &nbsp;🎉 论文被 **IEEE T-SMCA** 录用（[链接](https://ieeexplore.ieee.org/document/10414035)）！"
-- en: "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*12/2023* &nbsp;🎉 One co-author's paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
   zh: "*2023/12* &nbsp;🎉 合作论文被 **OE** 录用（[链接](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497)）！"
-- en: "*11/2023* &nbsp;👏  My conference paper was awarded the **Best Student Paper Nomination Award** at 2023 7th CCSICC!"
+- year: 2023
+  tags:
+    - honor
+  en: "*11/2023* &nbsp;👏  My conference paper was awarded the **Best Student Paper Nomination Award** at 2023 7th CCSICC!"
   zh: "*2023/11* &nbsp;👏 会议论文荣获 2023 第七届 CCSICC **最佳学生论文提名奖**！"
-- en: "*11/2023* &nbsp;👏  I won the **National third prize** of the First Air Force Aviation Innovation Challenge in 2023!"
+- year: 2023
+  tags:
+    - honor
+  en: "*11/2023* &nbsp;👏  I won the **National third prize** of the First Air Force Aviation Innovation Challenge in 2023!"
   zh: "*2023/11* &nbsp;👏 获得 2023 年首届空军航空创新挑战赛 **全国三等奖**！"
-- en: "*11/2023* &nbsp;👏  I obtained the **First-class Scholarship** for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!"
+- year: 2023
+  tags:
+    - honor
+  en: "*11/2023* &nbsp;👏  I obtained the **First-class Scholarship** for doctoral students awarded by Hainan Research Institute, Shanghai Jiao Tong University!"
   zh: "*2023/11* &nbsp;👏 获得上海交通大学海南研究院博士研究生 **一等奖学金**！"
-- en: "*09/2023* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
+- year: 2023
+  tags:
+    - honor
+  en: "*09/2023* &nbsp;👏👏 I obtained the **National Scholarship** for doctoral students in Shanghai Jiao Tong University!"
   zh: "*2023/09* &nbsp;👏👏 获得上海交通大学博士研究生 **国家奖学金**！"
-- en: "*09/2023* &nbsp;🎉  One paper was accepted by **IEEE T-ITS** ([Link](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*09/2023* &nbsp;🎉  One paper was accepted by **IEEE T-ITS** ([Link](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979))!"
   zh: "*2023/09* &nbsp;🎉 论文被 **IEEE T-ITS** 录用（[链接](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=6979)）！"
-- en: "*08/2023* &nbsp;🎉  One paper was accepted by **IEEE CAA/JAS** ([Link](https://www.ieee-jas.net/indexen.html))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*08/2023* &nbsp;🎉  One paper was accepted by **IEEE CAA/JAS** ([Link](https://www.ieee-jas.net/indexen.html))!"
   zh: "*2023/08* &nbsp;🎉 论文被 **IEEE CAA/JAS** 录用（[链接](https://www.ieee-jas.net/indexen.html)）！"
-- en: "*07/2023* &nbsp;👏  I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!"
+- year: 2023
+  tags:
+    - program
+  en: "*07/2023* &nbsp;👏  I was selected by the State-Sponsored Postgraduate Program to study abroad in University of Victoria in Canada!"
   zh: "*2023/07* &nbsp;👏 获批国家建设高水平大学公派研究生项目！"
-- en: "*02/2023* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/abstract/document/10059139))!"
+- year: 2023
+  tags:
+    - publication
+  en: "*02/2023* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-CSII** ([Link](https://ieeexplore.ieee.org/abstract/document/10059139))!"
   zh: "*2023/02* &nbsp;🎉 合作论文被 **IEEE T-CSII** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/10059139)）！"
-- en: "*12/2022* &nbsp;🎉  I won the **First Prize** in the Hainan Free Trade Port Entrepreneurship Competition!"
+- year: 2022
+  tags:
+    - honor
+  en: "*12/2022* &nbsp;🎉  I won the **First Prize** in the Hainan Free Trade Port Entrepreneurship Competition!"
   zh: "*2022/12* &nbsp;🎉 获得海南自由贸易港创新创业大赛 **一等奖**！"
-- en: "*10/2022* &nbsp;🎉  One co-author's paper was accepted by IEEE **T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9950329))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*10/2022* &nbsp;🎉  One co-author's paper was accepted by IEEE **T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9950329))!"
   zh: "*2022/10* &nbsp;🎉 合作论文被 IEEE **T-IV** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/9950329)）！"
-- en: "*10/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*10/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497))!"
   zh: "*2022/10* &nbsp;🎉 论文被 **OE** 录用（[链接](https://www.sciencedirect.com/science/article/abs/pii/S0029801822021497)）！"
-- en: "*09/2022* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/abstract/document/9900363))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*09/2022* &nbsp;🎉  One paper was accepted by **IEEE T-SMCA** ([Link](https://ieeexplore.ieee.org/abstract/document/9900363))!"
   zh: "*2022/09* &nbsp;🎉 论文被 **IEEE T-SMCA** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/9900363)）！"
-- en: "*06/2022* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9878245))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*06/2022* &nbsp;🎉  One co-author's paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9878245))!"
   zh: "*2022/06* &nbsp;🎉 合作论文被 **IEEE T-IV** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/9878245)）！"
-- en: "*04/2022* &nbsp;🎉  One paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*04/2022* &nbsp;🎉  One paper was accepted by **IEEE T-IV** ([Link](https://ieeexplore.ieee.org/abstract/document/9762043))!"
   zh: "*2022/04* &nbsp;🎉 论文被 **IEEE T-IV** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/9762043)）！"
-- en: "*01/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!"
+- year: 2022
+  tags:
+    - publication
+  en: "*01/2022* &nbsp;🎉  One paper was accepted by **OE** ([Link](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445))!"
   zh: "*2022/01* &nbsp;🎉 论文被 **OE** 录用（[链接](https://www.sciencedirect.com/science/article/abs/pii/S0029801822001445)）！"
-- en: "*04/2021* &nbsp;🎉  One paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!"
+- year: 2021
+  tags:
+    - publication
+  en: "*04/2021* &nbsp;🎉  One paper was accepted by **IEEE T-CYB** ([Link](https://ieeexplore.ieee.org/abstract/document/9440777))!"
   zh: "*2021/04* &nbsp;🎉 论文被 **IEEE T-CYB** 录用（[链接](https://ieeexplore.ieee.org/abstract/document/9440777)）！"

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -5,6 +5,7 @@
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/map-reorder.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/news.js' | relative_url }}" defer></script>
 
 {% include analytics.html %}
 {% include fetch_google_scholar_stats.html %}

--- a/_pages/includes/news.md
+++ b/_pages/includes/news.md
@@ -14,27 +14,119 @@
   {% assign limit = news_count %}
 {% endif %}
 
-{% if limit > 0 %}
-{% for item in news_items limit: limit %}
-{% assign item_en = item.en | default: nil %}
-{% assign item_zh = item.zh | default: nil %}
-{% if item_en or item_zh %}
-- {% if item_en %}<span data-lang="en">{{ item_en }}</span>{% endif %}{% if item_zh %}<span data-lang="zh"{% if item_en %} hidden{% endif %}>{{ item_zh }}</span>{% endif %}
-{% else %}
-- {{ item }}
-{% endif %}
-{% endfor %}
-{: .news-list}
-{% else %}
-<p data-lang="en">No news items are available right now. Please check back later.</p>
-<p data-lang="zh" hidden>暂无消息更新，欢迎稍后再来查看。</p>
-{% endif %}
+{% assign has_items = news_count > 0 %}
+{% assign is_limited = limit < news_count %}
 
-{% if include.show_button and limit < news_count %}
-<!-- <p class="news-actions">
-  <a class="btn" href="{{ '/news/' | relative_url }}">
-    <span data-lang="en">-- Read More News --</span>
-    <span data-lang="zh" hidden>-- 查看更多消息 --</span>
-  </a>
-</p> -->
+{% if has_items %}
+  {% capture years_raw %}{% for item in news_items %}{% if item.year %}{{ item.year }},{% endif %}{% endfor %}{% endcapture %}
+  {% capture tags_raw %}{% for item in news_items %}{% if item.tags %}{% for tag in item.tags %}{{ tag }},{% endfor %}{% endif %}{% endfor %}{% endcapture %}
+  {% assign year_list = years_raw | split: ',' | uniq | sort | reverse %}
+  {% assign tag_list = tags_raw | split: ',' | uniq | sort %}
+  {% assign show_tag_filter = false %}
+  {% assign show_year_filter = false %}
+  {% for tag in tag_list %}
+    {% if tag != '' %}
+      {% assign show_tag_filter = true %}
+    {% endif %}
+  {% endfor %}
+  {% for year in year_list %}
+    {% if year != '' %}
+      {% assign show_year_filter = true %}
+    {% endif %}
+  {% endfor %}
+
+  <div class="news-widget" data-news-widget data-initial-limit="{{ limit }}" data-total-count="{{ news_count }}">
+    {% if show_tag_filter or show_year_filter %}
+    <div class="news-filters">
+      {% if show_tag_filter %}
+      <div class="news-filter-group" data-filter-group="tag" role="group">
+        <span class="news-filter-label">
+          <span data-lang="en">Category</span>
+          <span data-lang="zh" hidden>类别</span>
+        </span>
+        <div class="news-filter-options">
+          <button type="button" class="news-filter-button is-active" data-filter-button data-filter-group="tag" data-filter-value="" aria-pressed="true">
+            <span data-lang="en">All categories</span>
+            <span data-lang="zh" hidden>全部类别</span>
+          </button>
+          {% for tag in tag_list %}
+            {% if tag != '' %}
+              {% assign tag_label_en = tag %}
+              {% assign tag_label_zh = tag %}
+              {% case tag %}
+                {% when 'publication' %}
+                  {% assign tag_label_en = 'Publications' %}
+                  {% assign tag_label_zh = '论文成果' %}
+                {% when 'honor' %}
+                  {% assign tag_label_en = 'Honors & Awards' %}
+                  {% assign tag_label_zh = '荣誉与奖项' %}
+                {% when 'program' %}
+                  {% assign tag_label_en = 'Programs & Funding' %}
+                  {% assign tag_label_zh = '项目与资助' %}
+              {% endcase %}
+              <button type="button" class="news-filter-button" data-filter-button data-filter-group="tag" data-filter-value="{{ tag }}" aria-pressed="false">
+                <span data-lang="en">{{ tag_label_en }}</span>
+                <span data-lang="zh" hidden>{{ tag_label_zh }}</span>
+              </button>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+
+      {% if show_year_filter %}
+      <div class="news-filter-group" data-filter-group="year" role="group">
+        <span class="news-filter-label">
+          <span data-lang="en">Year</span>
+          <span data-lang="zh" hidden>年份</span>
+        </span>
+        <div class="news-filter-options">
+          <button type="button" class="news-filter-button is-active" data-filter-button data-filter-group="year" data-filter-value="" aria-pressed="true">
+            <span data-lang="en">All years</span>
+            <span data-lang="zh" hidden>全部年份</span>
+          </button>
+          {% for year in year_list %}
+            {% if year != '' %}
+            <button type="button" class="news-filter-button" data-filter-button data-filter-group="year" data-filter-value="{{ year }}" aria-pressed="false">
+              {{ year }}
+            </button>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+
+    <ul class="news-list" data-news-list>
+      {% for item in news_items %}
+        {% assign item_en = item.en | default: nil %}
+        {% assign item_zh = item.zh | default: nil %}
+        {% assign tags = item.tags | default: nil %}
+        {% assign tag_string = '' %}
+        {% if tags %}
+          {% assign tag_string = tags | join: ' ' %}
+        {% endif %}
+        <li class="news-item" data-news-item data-tags="{{ tag_string }}"{% if item.year %} data-year="{{ item.year }}"{% endif %}{% if is_limited and forloop.index > limit %} hidden{% endif %}>
+          {% if item_en %}<span data-lang="en">{{ item_en }}</span>{% endif %}
+          {% if item_zh %}<span data-lang="zh"{% if item_en %} hidden{% endif %}>{{ item_zh }}</span>{% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+
+    <p class="news-empty-message" data-news-empty hidden>
+      <span data-lang="en">No news items match the current filters.</span>
+      <span data-lang="zh" hidden>没有符合当前筛选条件的消息。</span>
+    </p>
+
+    {% if is_limited %}
+    <button type="button" class="news-expand-btn" data-action="expand-news" aria-expanded="false">
+      <span data-lang="en">Show all news</span>
+      <span data-lang="zh" hidden>展开全部</span>
+    </button>
+    {% endif %}
+  </div>
+{% else %}
+  <p data-lang="en">No news items are available right now. Please check back later.</p>
+  <p data-lang="zh" hidden>暂无消息更新，欢迎稍后再来查看。</p>
 {% endif %}

--- a/assets/js/news.js
+++ b/assets/js/news.js
@@ -1,0 +1,174 @@
+(function () {
+  function parseLimit(value, fallback) {
+    var number = Number.parseInt(value, 10);
+    if (Number.isNaN(number)) {
+      return fallback;
+    }
+    return number < 0 ? 0 : number;
+  }
+
+  function getTagsFromDataset(dataset) {
+    var tags = dataset.tags || '';
+    if (!tags) {
+      return [];
+    }
+    return tags
+      .split(/\s+/)
+      .map(function (tag) {
+        return tag.trim();
+      })
+      .filter(function (tag) {
+        return tag.length > 0;
+      });
+  }
+
+  function initNewsWidget(widget) {
+    if (!widget) {
+      return;
+    }
+
+    var list = widget.querySelector('[data-news-list]');
+    if (!list) {
+      return;
+    }
+
+    var items = Array.prototype.slice.call(list.querySelectorAll('[data-news-item]'));
+    if (!items.length) {
+      return;
+    }
+
+    var limit = parseLimit(widget.getAttribute('data-initial-limit'), items.length);
+    var totalCount = parseLimit(widget.getAttribute('data-total-count'), items.length);
+    if (!Number.isFinite(limit) || limit > totalCount) {
+      limit = totalCount;
+    }
+
+    var filterState = {};
+    var expandAll = false;
+    var expandButton = widget.querySelector('[data-action="expand-news"]');
+    var emptyMessage = widget.querySelector('[data-news-empty]');
+
+    function matchesFilters(item) {
+      var matches = true;
+      Object.keys(filterState).forEach(function (key) {
+        if (!matches) {
+          return;
+        }
+        var value = filterState[key];
+        if (!value) {
+          return;
+        }
+
+        if (key === 'tag') {
+          var tags = getTagsFromDataset(item.dataset);
+          matches = tags.indexOf(value) !== -1;
+          return;
+        }
+
+        if (key === 'year') {
+          matches = (item.getAttribute('data-year') || '') === value;
+          return;
+        }
+      });
+      return matches;
+    }
+
+    function applyFilters() {
+      var effectiveLimit = expandAll ? Number.POSITIVE_INFINITY : limit;
+      var matchedCount = 0;
+      var shownCount = 0;
+
+      items.forEach(function (item) {
+        var shouldDisplay = matchesFilters(item);
+        if (!shouldDisplay) {
+          item.hidden = true;
+          return;
+        }
+
+        matchedCount += 1;
+
+        if (!expandAll && effectiveLimit === 0) {
+          item.hidden = true;
+          return;
+        }
+
+        if (!expandAll && shownCount >= effectiveLimit) {
+          item.hidden = true;
+          return;
+        }
+
+        item.hidden = false;
+        shownCount += 1;
+      });
+
+      if (emptyMessage) {
+        emptyMessage.hidden = matchedCount !== 0;
+      }
+
+      if (expandButton) {
+        var hasMoreToShow = !expandAll && matchedCount > shownCount;
+        expandButton.hidden = !hasMoreToShow;
+        expandButton.setAttribute('aria-expanded', expandAll ? 'true' : 'false');
+      }
+    }
+
+    function resetExpand() {
+      expandAll = false;
+      applyFilters();
+    }
+
+    if (expandButton) {
+      expandButton.addEventListener('click', function () {
+        expandAll = true;
+        applyFilters();
+      });
+    }
+
+    var filterGroups = widget.querySelectorAll('[data-filter-group]');
+    Array.prototype.forEach.call(filterGroups, function (group) {
+      var groupName = group.getAttribute('data-filter-group');
+      if (!groupName) {
+        return;
+      }
+
+      var buttons = group.querySelectorAll('[data-filter-button]');
+      var activeButton = group.querySelector('[data-filter-button].is-active');
+      var activeValue = activeButton ? activeButton.getAttribute('data-filter-value') || '' : '';
+
+      filterState[groupName] = activeValue;
+
+      Array.prototype.forEach.call(buttons, function (button) {
+        button.addEventListener('click', function () {
+          if (button.classList.contains('is-active')) {
+            return;
+          }
+
+          Array.prototype.forEach.call(buttons, function (otherButton) {
+            otherButton.classList.remove('is-active');
+            otherButton.setAttribute('aria-pressed', 'false');
+          });
+
+          button.classList.add('is-active');
+          button.setAttribute('aria-pressed', 'true');
+
+          var value = button.getAttribute('data-filter-value') || '';
+          filterState[groupName] = value;
+          resetExpand();
+        });
+      });
+    });
+
+    applyFilters();
+  }
+
+  function init() {
+    var widgets = document.querySelectorAll('[data-news-widget]');
+    Array.prototype.forEach.call(widgets, initNewsWidget);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add tag metadata to the news data set so items can be categorized
- enhance the news include with filter controls, translated labels, and an on-page expand button
- introduce a dedicated client-side script to handle filtering and expansion logic and load it with the other site scripts

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not installed in the container)*
- bundle install *(fails: unable to download gems from rubygems.org, received HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3550240a0832dbb9d95327ec11158