### PR TITLE
Revert toggle enhancements to icon-only language switch

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,7 +9,7 @@
       aria-pressed="false"
     >
       <span class="toggle-button__icon" aria-hidden="true">
-        <i class="fas fa-globe"></i>
+        <i class="fa-duotone fa-solid fa-language"></i>
       </span>
     </button>
     {% endcapture %}


### PR DESCRIPTION
## Summary
- restore the masthead toggle markup and supporting assets to their original minimal structure while keeping the language icon set to `fa-language`
- remove the toggle label styling and JavaScript status helpers that were only needed for the extra inline text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3536b791c832db057704ca382f0f3