### PR TITLE
Replace publication GIF previews with lazy-loaded videos

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -33,7 +33,10 @@ redirect_from:
 <span data-lang="zh" hidden>点击 **[出版物](/publications/)** 查看完整列表。</span>
 
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.gif' | relative_url }}' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE/CAA JAS 2024</div><video class="paper-box-media" playsinline muted loop autoplay preload="metadata" poster="{{ '/assets/images/posters/wu-2023-ieee-jas.svg' | relative_url }}">
+  <source src="{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-JAS.mp4' | relative_url }}" type="video/mp4">
+  Your browser does not support the video tag.
+</video></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Safety-Critical Trajectory Tracking for Mobile Robots with Guaranteed Performance](/assets/papers/SCI/WuWentao-2023-IEEE-JAS.pdf)<br />
@@ -48,7 +51,10 @@ redirect_from:
 </div>
 
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.gif' | relative_url }}' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE TIV 2022</div><video class="paper-box-media" playsinline muted loop autoplay preload="metadata" poster="{{ '/assets/images/posters/wu-2022-ieee-tiv.svg' | relative_url }}">
+  <source src="{{ '/assets/Video/Video-Sim/WuWentao-2022-IEEE-TIV.mp4' | relative_url }}" type="video/mp4">
+  Your browser does not support the video tag.
+</video></div></div>
 <div class='paper-box-text' markdown="1">
 
 [A General Safety-Certified Cooperative Control Architecture for Interconnected Intelligent Surface Vehicles with Applications to Vessel Train](https://ieeexplore.ieee.org/abstract/document/9762043)<br />
@@ -62,7 +68,7 @@ redirect_from:
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='{{ '/assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' | relative_url }}' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-CYB 2021</div><img src='{{ '/assets/Video/Video-Exp/WuWentao-2021-IEEE-TCYB.png' | relative_url }}' alt="sym" width="100%" loading="lazy" decoding="async"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Network-Based Line-of-Sight Path Tracking of Underactuated Unmanned Surface Vehicles with Experiment Results](/assets/papers/SCI/WuWentao-2021-IEEE-TCYB.pdf)<br />
@@ -91,7 +97,7 @@ redirect_from:
 </div>
 </div>
 
-<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%"></div></div>
+<div class='paper-box'><div class='paper-box-image'><div><div class="badge">IEEE T-SMCA 2024</div><img src='{{ '/assets/Video/Video-Sim/WuWentao-2023-IEEE-TSMCA.gif' | relative_url }}' alt="sym" width="100%" loading="lazy" decoding="async"></div></div>
 <div class='paper-box-text' markdown="1">
 
 [Constrained Safe Cooperative Maneuvering of Autonomous Surface Vehicles: A Control Barrier Function Approach](/assets/papers/SCI/WuWentao-2023-IEEE-TSMCA.pdf)

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -56,10 +56,13 @@
         display: flex;
         width: 100%;
         order: 2;
-        img {
+        img,
+        video.paper-box-media {
             max-width: 400px;
             box-shadow: 3px 3px 6px #888;
             object-fit: cover;
+            width: 100%;
+            height: auto;
         }
     }
     

--- a/assets/images/posters/wu-2022-ieee-tiv.svg
+++ b/assets/images/posters/wu-2022-ieee-tiv.svg
@@ -1,0 +1,25 @@
+<svg width="800" height="450" viewBox="0 0 800 450" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-tiv" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#052e16" />
+      <stop offset="50%" stop-color="#15803d" />
+      <stop offset="100%" stop-color="#4ade80" />
+    </linearGradient>
+    <radialGradient id="pulse-tiv" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(640 120) scale(220 220)">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#grad-tiv)" rx="28" />
+  <circle cx="640" cy="120" r="180" fill="url(#pulse-tiv)" />
+  <rect x="40" y="48" width="720" height="354" rx="24" fill="#022c22" opacity="0.35" />
+  <g fill="#f0fdf4" font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">
+    <text x="400" y="200" font-size="46" font-weight="600">IEEE TIV 2022</text>
+    <text x="400" y="248" font-size="28" font-weight="500">Cooperative Control Architecture</text>
+    <text x="400" y="292" font-size="24" opacity="0.85">Simulation Preview</text>
+  </g>
+  <path d="M196 340C228 300 292 300 324 340" stroke="#f0fdf4" stroke-width="6" stroke-linecap="round" opacity="0.55" />
+  <path d="M476 340C508 300 572 300 604 340" stroke="#f0fdf4" stroke-width="6" stroke-linecap="round" opacity="0.55" />
+  <circle cx="260" cy="320" r="18" fill="#bbf7d0" opacity="0.65" />
+  <circle cx="540" cy="320" r="18" fill="#bbf7d0" opacity="0.65" />
+</svg>

--- a/assets/images/posters/wu-2023-ieee-jas.svg
+++ b/assets/images/posters/wu-2023-ieee-jas.svg
@@ -1,0 +1,26 @@
+<svg width="800" height="450" viewBox="0 0 800 450" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-jas" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="50%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="shine-jas" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.2" />
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#grad-jas)" rx="28" />
+  <rect x="32" y="36" width="736" height="378" fill="#0f172a" opacity="0.35" rx="20" />
+  <rect x="32" y="36" width="736" height="378" fill="url(#shine-jas)" opacity="0.4" rx="20" />
+  <g fill="#f8fafc" font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle">
+    <text x="400" y="198" font-size="48" font-weight="600">IEEE/CAA JAS 2024</text>
+    <text x="400" y="250" font-size="30" font-weight="500">Safety-Critical Trajectory Tracking</text>
+    <text x="400" y="302" font-size="24" opacity="0.8">Simulation Preview</text>
+  </g>
+  <circle cx="120" cy="88" r="42" fill="#38bdf8" opacity="0.45" />
+  <circle cx="696" cy="360" r="36" fill="#1d4ed8" opacity="0.45" />
+  <path d="M360 336L448 336" stroke="#f8fafc" stroke-width="6" stroke-linecap="round" opacity="0.5" />
+  <path d="M392 318L416 354" stroke="#f8fafc" stroke-width="6" stroke-linecap="round" opacity="0.5" />
+</svg>


### PR DESCRIPTION
## Summary
- replace the about page publication GIF thumbnails with autoplaying MP4 video elements that include lazy posters and async-decoding fallbacks
- extend the paper box styling to size both images and the new video elements consistently and add lightweight SVG poster artwork for the previews

## Testing
- bundle exec jekyll build *(fails: jekyll executable unavailable because gem installation is blocked by the environment proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba4a6954832da78a15a0a04128b3