### PR TITLE
Lazy load visitor map script

### DIFF
--- a/_includes/author-maps.html
+++ b/_includes/author-maps.html
@@ -15,11 +15,10 @@
   <div class="author__map author__map--visitors">
     <div class="author__map-frame author__map-frame--ratio">
       <div class="author__map-embed">
-        <script
-          type="text/javascript"
-          id="mapmyvisitors"
-          src="https://mapmyvisitors.com/map.js?cl=ffffff&w=a&t=tt&d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&co=919ba3&cmo=3acc3a&cmn=ff5353&ct=ffffff"
-        ></script>
+        <div
+          id="mapmyvisitors-placeholder"
+          data-script-src="https://mapmyvisitors.com/map.js?cl=ffffff&w=a&t=tt&d=O8KnN2KN9LurEKfnDLzKFXnBIkbpznU5gMV5OwVKB98&co=919ba3&cmo=3acc3a&cmn=ff5353&ct=ffffff"
+        ></div>
       </div>
     </div>
   </div>

--- a/assets/js/author-map.js
+++ b/assets/js/author-map.js
@@ -194,9 +194,65 @@
     loadMapScript(apiKey, language);
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
+  function initVisitorMapLazyLoad() {
+    var visitorContainer = document.querySelector('.author__map--visitors');
+    if (!visitorContainer) {
+      return;
+    }
+
+    var placeholder = visitorContainer.querySelector('#mapmyvisitors-placeholder');
+    if (!placeholder) {
+      return;
+    }
+
+    var scriptSrc = placeholder.getAttribute('data-script-src');
+    if (!scriptSrc) {
+      return;
+    }
+
+    var scriptLoaded = false;
+
+    function loadVisitorScript() {
+      if (scriptLoaded || document.getElementById('mapmyvisitors')) {
+        scriptLoaded = true;
+        return;
+      }
+
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.id = 'mapmyvisitors';
+      script.src = scriptSrc;
+      placeholder.appendChild(script);
+      scriptLoaded = true;
+    }
+
+    if (!('IntersectionObserver' in window)) {
+      loadVisitorScript();
+      return;
+    }
+
+    var observer = new window.IntersectionObserver(function (entries) {
+      for (var i = 0; i < entries.length; i += 1) {
+        var entry = entries[i];
+        if (entry.isIntersecting) {
+          loadVisitorScript();
+          observer.disconnect();
+          break;
+        }
+      }
+    });
+
+    observer.observe(visitorContainer);
+  }
+
+  function initAuthorMaps() {
     init();
+    initVisitorMapLazyLoad();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAuthorMaps);
+  } else {
+    initAuthorMaps();
   }
 })();


### PR DESCRIPTION
## Summary
- replace the inline MapMyVisitors embed with a placeholder container
- defer loading the visitor map script until the map enters the viewport using IntersectionObserver

## Testing
- bundle exec jekyll build *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba689304832d8a2f3d84a68ea26f