### PR TITLE
Conditionally load news window script

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,8 @@
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/toggles.js' | relative_url }}" defer></script>
+{% if page.use_news_window %}
 <script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
+{% endif %}
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -4,6 +4,7 @@ permalink: /news/
 title: "News"
 author_profile: true
 hide_author_maps_on_mobile: true
+use_news_window: true
 ---
 
 {% include_relative includes/news.md %}


### PR DESCRIPTION
## Summary
- load the news window JavaScript only when `page.use_news_window` is enabled
- enable the news page to opt into the scrolling news window behavior via front matter

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not available in the container)*
- bundle install *(fails: rubygems.org returns 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba8fd30c832d9a380357e697acae