### PR TITLE
Remove unused news window script

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,5 @@
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/toggles.js' | relative_url }}" defer></script>
-<script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- remove the `news-window.js` include from the shared scripts partial
- drop the unused `use_news_window` flag from the news page front matter

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ba8fd30c832d9a380357e697acae