### PR TITLE
Conditionally load publications script

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,7 +2,9 @@
 <script src="{{ '/assets/js/toggles.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/news-window.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
+{% if page.uses_publications_js %}
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>
+{% endif %}
 <script src="{{ '/assets/js/author-map.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/map-reorder.js' | relative_url }}"></script>
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -4,6 +4,7 @@ permalink: /publications/
 title: ""
 author_profile: true
 hide_author_maps_on_mobile: true
+uses_publications_js: true
 ---
 
 <span class='anchor' id='-publications'></span>


### PR DESCRIPTION
## Summary
- guard the publications JavaScript include behind a page-level flag
- enable the publications script on the publications page

## Testing
- `bundle exec jekyll build` *(fails: missing command `jekyll` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bf54a0f0832da9c9474bb11a3ad9