### PR TITLE
Offer multiple Font Awesome language icon classes

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,7 +9,7 @@
       aria-pressed="false"
     >
       <span class="toggle-button__icon" aria-hidden="true">
-        <i class="fas fa-globe"></i>
+        <i class="fa-solid fa-language fas fa-language fa fa-language"></i>
       </span>
     </button>
     {% endcapture %}


### PR DESCRIPTION
## Summary
- include several Font Awesome language icon class variants so any available kit replaces the globe icon

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fdcfaf48832db90105f4e47a2738