### PR TITLE
Use Font Awesome 4 language icon in masthead

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -9,7 +9,7 @@
       aria-pressed="false"
     >
       <span class="toggle-button__icon" aria-hidden="true">
-        <i class="fas fa-globe"></i>
+        <i class="fa fa-language" aria-hidden="true"></i>
       </span>
     </button>
     {% endcapture %}


### PR DESCRIPTION
## Summary
- replace the masthead language toggle icon with the Font Awesome 4 `fa fa-language` markup required by the user

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fdcfaf48832db90105f4e47a2738