### PR TITLE
Enable greedy navigation dropdown hover behavior

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/nav-hover.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/toggles.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/citation-modal.js' | relative_url }}"></script>
 <script src="{{ '/assets/js/publications.js' | relative_url }}"></script>

--- a/assets/js/nav-hover.js
+++ b/assets/js/nav-hover.js
@@ -1,0 +1,90 @@
+(function () {
+  'use strict';
+
+  function initializeGreedyNavHover() {
+    var moreContainer = document.querySelector('.greedy-nav__more');
+    if (!moreContainer) {
+      return;
+    }
+
+    var toggleButton = moreContainer.querySelector('[data-nav-toggle]');
+    var hiddenLinks = moreContainer.querySelector('.hidden-links');
+
+    if (!toggleButton || !hiddenLinks) {
+      return;
+    }
+
+    var closeTimer = null;
+
+    function hasHiddenItems() {
+      return hiddenLinks.children.length > 0;
+    }
+
+    function openMenu() {
+      if (toggleButton.classList.contains('hidden')) {
+        return;
+      }
+
+      if (toggleButton.getAttribute('aria-expanded') === 'true') {
+        return;
+      }
+
+      if (!hasHiddenItems()) {
+        return;
+      }
+
+      toggleButton.click();
+    }
+
+    function closeMenu() {
+      if (toggleButton.getAttribute('aria-expanded') !== 'true') {
+        return;
+      }
+
+      toggleButton.click();
+    }
+
+    function clearCloseTimer() {
+      if (closeTimer !== null) {
+        window.clearTimeout(closeTimer);
+        closeTimer = null;
+      }
+    }
+
+    function scheduleClose() {
+      clearCloseTimer();
+      closeTimer = window.setTimeout(function () {
+        closeMenu();
+        closeTimer = null;
+      }, 150);
+    }
+
+    moreContainer.addEventListener('mouseenter', function () {
+      clearCloseTimer();
+      openMenu();
+    });
+
+    moreContainer.addEventListener('mouseleave', function () {
+      scheduleClose();
+    });
+
+    moreContainer.addEventListener('focusin', function () {
+      clearCloseTimer();
+      openMenu();
+    });
+
+    moreContainer.addEventListener('focusout', function (event) {
+      if (event.relatedTarget && moreContainer.contains(event.relatedTarget)) {
+        return;
+      }
+
+      scheduleClose();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeGreedyNavHover);
+  } else {
+    initializeGreedyNavHover();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a nav-hover helper script that opens the greedy navigation dropdown when the pointer or focus enters the toggle area and closes it on exit
- include the new helper script so the behavior is loaded on every page

## Testing
- `bundle exec jekyll serve --livereload --host 0.0.0.0 --port 4000` *(fails: jekyll executable missing)*
- `bundle install` *(fails: unable to download gems because of HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e51dea7c60832d9aa7273ba566e88a