### PR TITLE
Refine responsive CV logo presentation

### DIFF
--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -3,6 +3,9 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
+      <div class="cv-logo">
+        <img src="/images/logos/sjtu.svg" alt="Shanghai Jiao Tong University logo" loading="lazy">
+      </div>
       <div class="cv-main" data-lang="en">
         <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
         <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
@@ -25,6 +28,9 @@
 
   <li class="cv-item">
     <div class="cv-row">
+      <div class="cv-logo">
+        <img src="/images/logos/dmu.svg" alt="Dalian Maritime University logo" loading="lazy">
+      </div>
       <div class="cv-main" data-lang="en">
         <span class="cv-degree">M.E.</span>, Electrical Engineering in
         <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
@@ -47,6 +53,9 @@
 
   <li class="cv-item">
     <div class="cv-row">
+      <div class="cv-logo">
+        <img src="/images/logos/hust.svg" alt="Harbin University of Science and Technology logo" loading="lazy">
+      </div>
       <div class="cv-main" data-lang="en">
         <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
         <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -2,6 +2,9 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
+      <div class="cv-logo">
+        <img src="/images/logos/polyu.svg" alt="The Hong Kong Polytechnic University logo" loading="lazy">
+      </div>
       <div class="cv-main" data-lang="en">
         <span class="cv-role">Postdoctoral Fellow</span> in
         <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
@@ -25,6 +28,9 @@
 
   <li class="cv-item">
     <div class="cv-row">
+      <div class="cv-logo">
+        <img src="/images/logos/uvic.svg" alt="University of Victoria logo" loading="lazy">
+      </div>
       <div class="cv-main" data-lang="en">
         <span class="cv-role">Visiting Scholar</span> in
         <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -116,15 +116,61 @@ h1:before, .anchor:before {
 .cv-item:last-child { border-bottom: none; }
 
 .cv-row {
+  --cv-logo-size: clamp(48px, 6vw + 24px, 78px);
   display: grid;
-  grid-template-columns: 1fr auto;   /* 主体 + 右侧日期 */
-  gap: 12px;
-  align-items: baseline;
+  grid-template-columns: var(--cv-logo-size) minmax(0, 1fr) auto;
+  grid-template-areas: "logo main date";
+  column-gap: clamp(12px, 4vw, 28px);
+  row-gap: 6px;
+  align-items: center;
 }
 
-.cv-main { font-size: 15.5px; line-height: 1.5; color: #222; }
-.cv-role, .cv-degree { font-weight: 600; }
-.cv-date { font-size: 13px; color: #666; white-space: nowrap; }
+.cv-logo {
+  grid-area: logo;
+  width: var(--cv-logo-size);
+  height: var(--cv-logo-size);
+  border-radius: 18%;
+  overflow: hidden;
+  background: linear-gradient(145deg, #f8f9fb 0%, #eef1f6 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(6px, 1.1vw, 12px);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cv-row:hover .cv-logo {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.cv-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.12));
+}
+
+.cv-main {
+  grid-area: main;
+  font-size: clamp(15px, 1.8vw, 16px);
+  line-height: 1.55;
+  color: #222;
+}
+
+.cv-role,
+.cv-degree {
+  font-weight: 600;
+}
+
+.cv-date {
+  grid-area: date;
+  font-size: clamp(12px, 1.5vw, 13.5px);
+  color: #666;
+  white-space: nowrap;
+  align-self: center;
+}
 
 .cv-sub {
   margin-top: 2px;
@@ -136,9 +182,57 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 #experiences + h1, #educations + h1 { margin-top: 0; }
 
 /* 移动端收紧布局：日期换行到下一行 */
+@media (max-width: 960px) {
+  .cv-row {
+    --cv-logo-size: clamp(44px, 9vw, 68px);
+    grid-template-columns: var(--cv-logo-size) minmax(0, 1fr);
+    grid-template-areas:
+      "logo main"
+      "logo date";
+    align-items: start;
+  }
+
+  .cv-date {
+    white-space: normal;
+    align-self: end;
+    margin-top: 0.25rem;
+  }
+}
+
 @media (max-width: 640px) {
-  .cv-row { grid-template-columns: 1fr; gap: 4px; }
-  .cv-date { order: 2; }
+  .cv-row {
+    column-gap: 12px;
+    row-gap: 4px;
+  }
+
+  .cv-logo {
+    border-radius: 20%;
+  }
+
+  .cv-date {
+    font-size: clamp(11.5px, 3.2vw, 12.5px);
+    margin-top: 0.35rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .cv-row {
+    --cv-logo-size: clamp(40px, 16vw, 56px);
+    grid-template-columns: var(--cv-logo-size) minmax(0, 1fr);
+    grid-template-areas:
+      "logo main"
+      "logo main"
+      "logo date";
+  }
+
+  .cv-main {
+    font-size: clamp(14.5px, 4.4vw, 15.5px);
+  }
+
+  .cv-date {
+    grid-column: 2;
+    justify-self: start;
+  }
 }
 :root {
   --publication-control-height: 2.5rem;

--- a/images/logos/dmu.svg
+++ b/images/logos/dmu.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-labelledby="title desc">
+  <title id="title">Dalian Maritime University logo</title>
+  <desc id="desc">Blue circular emblem with stylized waves and the letters DMU</desc>
+  <circle cx="40" cy="40" r="34" fill="#0d3b8e" stroke="#0a2961" stroke-width="4" />
+  <path fill="#ffffff" d="M18 42c2.8-9.3 11.3-16 22-16 10.9 0 19.8 6.8 22.1 16h-6.7c-2-6.3-7.7-10.4-15.4-10.4-7.6 0-13.3 4-15.4 10.4H18Z" />
+  <path fill="#7fc8ff" d="M22 48c2.4 4.9 8.6 8.5 16.1 8.5 7.6 0 13.5-3.5 15.9-8.5H22Z" />
+  <text x="40" y="34" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif">DMU</text>
+</svg>

--- a/images/logos/hust.svg
+++ b/images/logos/hust.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-labelledby="title desc">
+  <title id="title">Harbin University of Science and Technology logo</title>
+  <desc id="desc">Green emblem with geometric lightning bolt and the letters HUST</desc>
+  <rect x="6" y="6" width="68" height="68" rx="16" fill="#0d9a44" />
+  <path fill="#ffffff" d="M24 52h8l6.2-10.8h.1L44 52h8l-10-17.4L52 24h-8l-6 10.1h-.1L32 24h-8l10.1 17.1L24 52Z" />
+  <text x="40" y="60" text-anchor="middle" font-size="12" font-weight="600" fill="#e9ffe6" font-family="'Segoe UI', Arial, sans-serif">HUST</text>
+</svg>

--- a/images/logos/polyu.svg
+++ b/images/logos/polyu.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-labelledby="title desc">
+  <title id="title">The Hong Kong Polytechnic University logo</title>
+  <desc id="desc">Deep red knot pattern with the letters PolyU</desc>
+  <rect x="6" y="6" width="68" height="68" rx="20" fill="#8c0027" />
+  <path fill="#f6d7d7" d="M27.5 22c-3 0-5.5 2.5-5.5 5.5v25c0 3 2.5 5.5 5.5 5.5h25c3 0 5.5-2.5 5.5-5.5v-25c0-3-2.5-5.5-5.5-5.5h-25Zm4.2 9.1 8.3 8.3-8.3 8.3-3.5-3.5 4.8-4.8-4.8-4.8 3.5-3.5Zm16.6 0 3.5 3.5-4.8 4.8 4.8 4.8-3.5 3.5-8.3-8.3 8.3-8.3Z" />
+  <text x="40" y="62" text-anchor="middle" font-size="12" font-weight="600" fill="#fff1f1" font-family="'Segoe UI', Arial, sans-serif">PolyU</text>
+</svg>

--- a/images/logos/sjtu.svg
+++ b/images/logos/sjtu.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-labelledby="title desc">
+  <title id="title">Shanghai Jiao Tong University logo</title>
+  <desc id="desc">Stylized red shield with the letters SJTU</desc>
+  <defs>
+    <linearGradient id="sjtuGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#d81921" />
+      <stop offset="1" stop-color="#a40018" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="72" height="72" rx="12" fill="url(#sjtuGradient)" />
+  <path fill="#ffffff" d="M19 56h10c5.4 0 9-3 9-7.6 0-3.7-2.3-6-5.8-6.6v-.2c2.9-.7 4.9-3 4.9-6.1 0-4.2-3.2-7.2-8.5-7.2H19v27.7Zm8.8-16.6h-4v-7.3h4.2c2.6 0 4 .9 4 3 0 2.1-1.5 3.3-4.2 3.3Zm.5 12.1h-4.5V44h4.6c3 0 4.6 1.1 4.6 3.6 0 2.4-1.7 4-4.7 4Zm17.9 4.5h6V43.7h.2l6.9 12.3h5.8l-7.2-12.4c3.9-1.3 6-4.4 6-8.5 0-5.8-4.2-9.6-10.9-9.6H46.2v27.7Zm6-23.1v-7.5h6c3.2 0 5.1 1.6 5.1 4 0 2.6-1.9 4.2-5.1 4.2h-6Z"/>
+</svg>

--- a/images/logos/uvic.svg
+++ b/images/logos/uvic.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" role="img" aria-labelledby="title desc">
+  <title id="title">University of Victoria logo</title>
+  <desc id="desc">Blue and gold shield with the letters UVic</desc>
+  <path fill="#0a2d5c" d="M12 18c0-3.3 2.7-6 6-6h44c3.3 0 6 2.7 6 6v24c0 14.4-12 26-28 26S12 56.4 12 42V18Z" />
+  <path fill="#f7d117" d="M40 59c10.4 0 19.4-7.1 21.5-16.5H18.5C20.6 51.9 29.6 59 40 59Z" />
+  <path fill="#ffffff" d="M21 22h10v22H21V22Zm14 0h10v22H35V22Zm14 0h10v22H49V22Z" />
+  <text x="40" y="67" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff" font-family="'Segoe UI', Arial, sans-serif">UVic</text>
+</svg>


### PR DESCRIPTION
## Summary
- redesign the CV entry grid to size and align logos with responsive CSS variables
- add hover polish and viewport-specific adjustments so dates and content reflow cleanly on narrow screens

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll; install missing gem executables with `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68e51c634e54832d916b030fada08416