### PR TITLE
Simplify nav toggle animation

### DIFF
--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -293,10 +293,10 @@ body:hover .visually-hidden button {
   position: relative;
   width: $navicon-width;
   height: $navicon-height;
-  background: #fff;
+  background: currentColor;
   margin: auto;
-  -webkit-transition: 0.3s;
-  transition: 0.3s;
+  -webkit-transition: none;
+  transition: none;
 
   &:before,
   &:after {
@@ -305,9 +305,9 @@ body:hover .visually-hidden button {
     left: 0;
     width: $navicon-width;
     height: $navicon-height;
-    background: #fff;
-    -webkit-transition: 0.3s;
-    transition: 0.3s;
+    background: currentColor;
+    -webkit-transition: none;
+    transition: none;
   }
 
   &:before {
@@ -320,26 +320,21 @@ body:hover .visually-hidden button {
 }
 
 .close .navicon {
-  /* hide the middle line*/
-  background: transparent;
+  background: currentColor;
 
-  /* overlay the lines by setting both their top values to 0*/
-  &:before, &:after{
-    -webkit-transform-origin: 50% 50%;
-        -ms-transform-origin: 50% 50%;
-            transform-origin: 50% 50%;
-    top: 0;
-    width: $navicon-width;
+  &:before,
+  &:after {
+    -webkit-transform: none;
+        -ms-transform: none;
+            transform: none;
   }
 
-  /* rotate the lines to form the x shape*/
-  &:before{
-    -webkit-transform: rotate3d(0,0,1,45deg);
-            transform: rotate3d(0,0,1,45deg);
+  &:before {
+    top: (-2 * $navicon-height);
   }
-  &:after{
-    -webkit-transform: rotate3d(0,0,1,-45deg);
-            transform: rotate3d(0,0,1,-45deg);
+
+  &:after {
+    bottom: (-2 * $navicon-height);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the masthead navicon to inherit the current text color instead of using a fixed white fill
- remove the rotating close-state animation so the menu icon remains consistent when toggled

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68e547136420832d8581afd478e4129e