### PR TITLE
Improve CV logo contrast across themes

### DIFF
--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -3,59 +3,74 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
-        <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
+      <div class="cv-logo">
+        <img src="{{ '/images/logos/SJTU.png' | relative_url }}" alt="SJTU logo" loading="lazy">
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">博士</span>（电子信息工程），
-        <a href="https://www.sjtu.edu.cn/">上海交通大学（SJTU）</a>，
-        <a href="https://sais.sjtu.edu.cn/">自动化与智能感知学院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>），中国上海
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
+          <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
+          <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">博士</span>（电子信息工程），
+          <a href="https://www.sjtu.edu.cn/">上海交通大学（SJTU）</a>，
+          <a href="https://sais.sjtu.edu.cn/">自动化与智能感知学院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>），中国上海
+        </div>
+        <div class="cv-sub" data-lang="en">
+          Supervisors: Chair Professor <a href="https://automation.sjtu.edu.cn/wdzhang"><b>Weidong Zhang</b></a> and Professor <a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>Junguo Lu</b></a>
+        </div>
+        <div class="cv-sub" data-lang="zh" hidden>
+          导师：<a href="https://automation.sjtu.edu.cn/wdzhang"><b>张卫东教授</b></a>、<a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>卢俊国教授</b></a>
+        </div>
       </div>
       <div class="cv-date">09/2021–03/2025</div>
     </div>
-    <div class="cv-sub" data-lang="en">
-      Supervisors: Chair Professor <a href="https://automation.sjtu.edu.cn/wdzhang"><b>Weidong Zhang</b></a> and Professor <a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>Junguo Lu</b></a>
-    </div>
-    <div class="cv-sub" data-lang="zh" hidden>
-      导师：<a href="https://automation.sjtu.edu.cn/wdzhang"><b>张卫东教授</b></a>、<a href="https://automation.sjtu.edu.cn/Jun-Guo"><b>卢俊国教授</b></a>
-    </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
-        <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
+      <div class="cv-logo">
+        <img src="{{ '/images/logos/DMU.png' | relative_url }}" alt="DMU logo" loading="lazy">
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">硕士</span>（电气工程），
-        <a href="https://www.dlmu.edu.cn/"> 大连海事大学（DMU）</a>，
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">船舶电气工程学院</a>，中国大连
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">M.E.</span>, Electrical Engineering in
+          <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
+          <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">硕士</span>（电气工程），
+          <a href="https://www.dlmu.edu.cn/"> 大连海事大学（DMU）</a>，
+          <a href="https://cbdq.dlmu.edu.cn/index.htm">船舶电气工程学院</a>，中国大连
+        </div>
+        <div class="cv-sub" data-lang="en">
+          Supervisors: Professor <a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>Dan Wang</b></a> and Professor <a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>Zhouhua Peng</b></a>
+        </div>
+        <div class="cv-sub" data-lang="zh" hidden>
+          导师：<a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>王丹教授</b></a>、<a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>彭周华教授</b></a>
+        </div>
       </div>
       <div class="cv-date">09/2018–06/2021</div>
     </div>
-    <div class="cv-sub" data-lang="en">
-      Supervisors: Professor <a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>Dan Wang</b></a> and Professor <a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>Zhouhua Peng</b></a>
-    </div>
-    <div class="cv-sub" data-lang="zh" hidden>
-      导师：<a href="https://scholar.google.com/citations?user=kc8gnlMAAAAJ"><b>王丹教授</b></a>、<a href="https://scholar.google.com/citations?user=hM_5JDYAAAAJ"><b>彭周华教授</b></a>
-    </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
-        <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
+      <div class="cv-logo">
+        <img src="{{ '/images/logos/HUST.png' | relative_url }}" alt="HUST logo" loading="lazy">
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">学士</span>（电气工程及其自动化），
-        <a href="http://www.hrbust.edu.cn/">哈尔滨理工大学（HUST）</a>，
-        <a href="https://ee.hrbust.edu.cn/main.htm">电气与电子工程学院</a>，中国哈尔滨
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
+          <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
+          <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">学士</span>（电气工程及其自动化），
+          <a href="http://www.hrbust.edu.cn/">哈尔滨理工大学（HUST）</a>，
+          <a href="https://ee.hrbust.edu.cn/main.htm">电气与电子工程学院</a>，中国哈尔滨
+        </div>
       </div>
       <div class="cv-date">09/2014–06/2018</div>
     </div>

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -2,45 +2,55 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-role">Postdoctoral Fellow</span> in
-        <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
-        <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
+      <div class="cv-logo">
+        <img src="{{ '/images/logos/PolyU.jpg' | relative_url }}" alt="PolyU logo" loading="lazy">
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-role">博士后研究员</span>，<a href="https://www.polyu.edu.hk/">香港理工大学（PolyU）</a>，
-        <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系（AAE）</a>、
-        <a href="https://www.polyu.edu.hk/rclae/">低空经济研究中心（RCLAE）</a>，中国香港
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-role">Postdoctoral Fellow</span> in
+          <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
+          <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
+          <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-role">博士后研究员</span>，<a href="https://www.polyu.edu.hk/">香港理工大学（PolyU）</a>，
+          <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系（AAE）</a>、
+          <a href="https://www.polyu.edu.hk/rclae/">低空经济研究中心（RCLAE）</a>，中国香港
+        </div>
+        <div class="cv-sub" data-lang="en">
+          Supervisor: Chair Professor <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>Wen-Hua Chen</b></a> (Fellow of IEEE, IMechE, IET, HEA)
+        </div>
+        <div class="cv-sub" data-lang="zh" hidden>
+          导师：<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>陈文华教授</b></a>（IEEE Fellow、IMechE Fellow、IET Fellow、HEA Fellow）
+        </div>
       </div>
       <div class="cv-date">04/2025–Present</div>
-    </div>
-    <div class="cv-sub" data-lang="en">
-      Supervisor: Chair Professor <a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>Wen-Hua Chen</b></a> (Fellow of IEEE, IMechE, IET, HEA)
-    </div>
-    <div class="cv-sub" data-lang="zh" hidden>
-      导师：<a href="https://scholar.google.com/citations?user=UfIb9GkAAAAJ"><b>陈文华教授</b></a>（IEEE Fellow、IMechE Fellow、IET Fellow、HEA Fellow）
     </div>
   </li>
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
-        <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
+      <div class="cv-logo">
+        <object data="{{ '/images/logos/UVIC.pdf' | relative_url }}" type="application/pdf" aria-label="UVic logo">UVic</object>
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-role">访问学者</span>，<a href="https://www.uvic.ca/">维多利亚大学（UVic）</a>，
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">机械工程系（ME）</a>，加拿大维多利亚
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-role">Visiting Scholar</span> in
+          <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
+          <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-role">访问学者</span>，<a href="https://www.uvic.ca/">维多利亚大学（UVic）</a>，
+          <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">机械工程系（ME）</a>，加拿大维多利亚
+        </div>
+        <div class="cv-sub" data-lang="en">
+          Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)
+        </div>
+        <div class="cv-sub" data-lang="zh" hidden>
+          导师：<a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>施阳教授</b></a>（加拿大皇家学会院士、加拿大工程院院士、加拿大工程研究院院士、IEEE Fellow、ASME Fellow、CSME Fellow）
+        </div>
       </div>
       <div class="cv-date">01/2024–11/2024</div>
-    </div>
-    <div class="cv-sub" data-lang="en">
-      Supervisor: Professor <a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>Yang Shi</b></a> (Fellow of RSC, CAE, EIC, IEEE, ASME, CSME)
-    </div>
-    <div class="cv-sub" data-lang="zh" hidden>
-      导师：<a href="https://scholar.google.com/citations?user=LVnHobEAAAAJ"><b>施阳教授</b></a>（加拿大皇家学会院士、加拿大工程院院士、加拿大工程研究院院士、IEEE Fellow、ASME Fellow、CSME Fellow）
     </div>
   </li>
 </ul>

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -243,6 +243,13 @@ html.theme-dark .cv-item {
   border-bottom-color: rgba(255, 255, 255, 0.12);
 }
 
+html.theme-dark .cv-logo,
+html[data-theme="dark"] .cv-logo {
+  background-color: rgba(241, 245, 249, 0.92);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.35);
+}
+
 html.theme-dark .cv-main {
   color: rgba(226, 232, 240, 0.92);
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -117,14 +117,49 @@ h1:before, .anchor:before {
 
 .cv-row {
   display: grid;
-  grid-template-columns: 1fr auto;   /* 主体 + 右侧日期 */
-  gap: 12px;
-  align-items: baseline;
+  grid-template-columns: auto 1fr auto;   /* 标识 + 主体 + 日期 */
+  gap: 16px;
+  align-items: center;
+}
+
+.cv-logo {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background-color: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+  padding: 6px;
+}
+
+.cv-logo img,
+.cv-logo object {
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+}
+
+.cv-logo object {
+  pointer-events: none;
+}
+
+.cv-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .cv-main { font-size: 15.5px; line-height: 1.5; color: #222; }
 .cv-role, .cv-degree { font-weight: 600; }
-.cv-date { font-size: 13px; color: #666; white-space: nowrap; }
+.cv-date {
+  font-size: 13px;
+  color: #666;
+  white-space: nowrap;
+  align-self: center;
+}
 
 .cv-sub {
   margin-top: 2px;
@@ -137,8 +172,22 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 /* 移动端收紧布局：日期换行到下一行 */
 @media (max-width: 640px) {
-  .cv-row { grid-template-columns: 1fr; gap: 4px; }
-  .cv-date { order: 2; }
+  .cv-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    align-items: start;
+  }
+  .cv-logo {
+    order: 1;
+    width: 52px;
+    height: 52px;
+    justify-content: flex-start;
+  }
+  .cv-details { order: 2; }
+  .cv-date {
+    order: 3;
+    align-self: start;
+  }
 }
 :root {
   --publication-control-height: 2.5rem;


### PR DESCRIPTION
## Summary
- embed organization logos within the experience and education sections using the assets in `images/logos`
- adjust the CV layout to display logos beside entries on wide screens and stack vertically on small screens
- add neutral backgrounds and borders so CV logos stay legible across light and dark themes

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e5ce7e6874832da7b8be770d75e96e