### PR TITLE
Add institution logos to experiences and education sections

### DIFF
--- a/_pages/includes/edu.md
+++ b/_pages/includes/edu.md
@@ -3,15 +3,21 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
-        <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
-        <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
+      <div class="cv-logo">
+        <img src="/images/logos/SJTU.png" alt="SJTU logo" loading="lazy" />
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">博士</span>（电子信息工程），
-        <a href="https://www.sjtu.edu.cn/">上海交通大学（SJTU）</a>，
-        <a href="https://sais.sjtu.edu.cn/">自动化与智能感知学院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>），中国上海
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">Ph.D.</span>, Electronic Information Engineering in
+          <a href="https://sais.sjtu.edu.cn/">School of Automation and Intelligent Sensing</a> (<a href="https://automation.sjtu.edu.cn/">Department of Automation</a>),
+          <a href="https://www.sjtu.edu.cn/">Shanghai Jiao Tong University (SJTU)</a>, Shanghai, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">博士</span>（电子信息工程），
+          <a href="https://www.sjtu.edu.cn/">上海交通大学（SJTU）</a>，
+          <a href="https://sais.sjtu.edu.cn/">自动化与智能感知学院</a>（<a href="https://automation.sjtu.edu.cn/">自动化系</a>），
+          中国上海
+        </div>
       </div>
       <div class="cv-date">09/2021–03/2025</div>
     </div>
@@ -25,15 +31,20 @@
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">M.E.</span>, Electrical Engineering in
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
-        <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
+      <div class="cv-logo">
+        <img src="/images/logos/DMU.png" alt="Dalian Maritime University logo" loading="lazy" />
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">硕士</span>（电气工程），
-        <a href="https://www.dlmu.edu.cn/"> 大连海事大学（DMU）</a>，
-        <a href="https://cbdq.dlmu.edu.cn/index.htm">船舶电气工程学院</a>，中国大连
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">M.E.</span>, Electrical Engineering in
+          <a href="https://cbdq.dlmu.edu.cn/index.htm">College of Marine Electrical Engineering</a>,
+          <a href="https://www.dlmu.edu.cn/">Dalian Maritime University (DMU)</a>, Dalian, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">硕士</span>（电气工程），
+          <a href="https://www.dlmu.edu.cn/"> 大连海事大学（DMU）</a>，
+          <a href="https://cbdq.dlmu.edu.cn/index.htm">船舶电气工程学院</a>，中国大连
+        </div>
       </div>
       <div class="cv-date">09/2018–06/2021</div>
     </div>
@@ -47,15 +58,20 @@
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
-        <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
-        <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
+      <div class="cv-logo">
+        <img src="/images/logos/HUST.png" alt="Harbin University of Science and Technology logo" loading="lazy" />
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-degree">学士</span>（电气工程及其自动化），
-        <a href="http://www.hrbust.edu.cn/">哈尔滨理工大学（HUST）</a>，
-        <a href="https://ee.hrbust.edu.cn/main.htm">电气与电子工程学院</a>，中国哈尔滨
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-degree">B.E.</span>, Electrical Engineering and Automation in
+          <a href="https://www.seiee.sjtu.edu.cn/">School of Electrical and Electronic Engineering</a>,
+          <a href="http://www.hrbust.edu.cn/">Harbin University of Science and Technology (HUST)</a>, Harbin, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-degree">学士</span>（电气工程及其自动化），
+          <a href="http://www.hrbust.edu.cn/">哈尔滨理工大学（HUST）</a>，
+          <a href="https://ee.hrbust.edu.cn/main.htm">电气与电子工程学院</a>，中国哈尔滨
+        </div>
       </div>
       <div class="cv-date">09/2014–06/2018</div>
     </div>

--- a/_pages/includes/exp.md
+++ b/_pages/includes/exp.md
@@ -2,16 +2,21 @@
 <ul class="cv-list">
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-role">Postdoctoral Fellow</span> in
-        <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
-        <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
-        <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
+      <div class="cv-logo">
+        <img src="/images/logos/PolyU.svg" alt="PolyU logo" loading="lazy" />
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-role">博士后研究员</span>，<a href="https://www.polyu.edu.hk/">香港理工大学（PolyU）</a>，
-        <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系（AAE）</a>、
-        <a href="https://www.polyu.edu.hk/rclae/">低空经济研究中心（RCLAE）</a>，中国香港
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-role">Postdoctoral Fellow</span> in
+          <a href="https://www.polyu.edu.hk/rclae/">Research Centre for Low Altitude Economy (RCLAE)</a>,
+          <a href="https://www.polyu.edu.hk/aae/">Department of Aeronautical and Aviation Engineering (AAE)</a>,
+          <a href="https://www.polyu.edu.hk/">The Hong Kong Polytechnic University (PolyU)</a>, Hong Kong, China
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-role">博士后研究员</span>，<a href="https://www.polyu.edu.hk/">香港理工大学（PolyU）</a>，
+          <a href="https://www.polyu.edu.hk/aae/">航空及民航工程学系（AAE）</a>、
+          <a href="https://www.polyu.edu.hk/rclae/">低空经济研究中心（RCLAE）</a>，中国香港
+        </div>
       </div>
       <div class="cv-date">04/2025–Present</div>
     </div>
@@ -25,14 +30,19 @@
 
   <li class="cv-item">
     <div class="cv-row">
-      <div class="cv-main" data-lang="en">
-        <span class="cv-role">Visiting Scholar</span> in
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
-        <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
+      <div class="cv-logo">
+        <img src="/images/logos/UVic.svg" alt="University of Victoria logo" loading="lazy" />
       </div>
-      <div class="cv-main" data-lang="zh" hidden>
-        <span class="cv-role">访问学者</span>，<a href="https://www.uvic.ca/">维多利亚大学（UVic）</a>，
-        <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">机械工程系（ME）</a>，加拿大维多利亚
+      <div class="cv-details">
+        <div class="cv-main" data-lang="en">
+          <span class="cv-role">Visiting Scholar</span> in
+          <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">Department of Mechanical Engineering (ME)</a>,
+          <a href="https://www.uvic.ca/">University of Victoria (UVic)</a>, Victoria, Canada
+        </div>
+        <div class="cv-main" data-lang="zh" hidden>
+          <span class="cv-role">访问学者</span>，<a href="https://www.uvic.ca/">维多利亚大学（UVic）</a>，
+          <a href="https://www.uvic.ca/ecs/mechanical/prospective-students/undergraduate/index.php">机械工程系（ME）</a>，加拿大维多利亚
+        </div>
       </div>
       <div class="cv-date">01/2024–11/2024</div>
     </div>

--- a/_sass/_custom-theme.scss
+++ b/_sass/_custom-theme.scss
@@ -243,6 +243,18 @@ html.theme-dark .cv-item {
   border-bottom-color: rgba(255, 255, 255, 0.12);
 }
 
+html.theme-dark .cv-logo,
+html[data-theme="dark"] .cv-logo {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(148, 163, 184, 0.28);
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.65);
+}
+
+html.theme-dark .cv-logo img,
+html[data-theme="dark"] .cv-logo img {
+  filter: brightness(1.15) saturate(1.08);
+}
+
 html.theme-dark .cv-main {
   color: rgba(226, 232, 240, 0.92);
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -117,14 +117,54 @@ h1:before, .anchor:before {
 
 .cv-row {
   display: grid;
-  grid-template-columns: 1fr auto;   /* 主体 + 右侧日期 */
-  gap: 12px;
-  align-items: baseline;
+  grid-template-columns: minmax(64px, 96px) minmax(0, 1fr) auto;
+  grid-template-areas: "logo main date";
+  gap: 16px;
+  align-items: center;
+}
+
+.cv-logo {
+  grid-area: logo;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cv-logo img {
+  width: 100%;
+  max-width: 72px;
+  height: auto;
+  object-fit: contain;
+  filter: saturate(1.05);
+}
+
+.cv-logo:focus-within,
+.cv-logo:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.14);
+}
+
+.cv-details {
+  grid-area: main;
+  display: grid;
+  gap: 6px;
 }
 
 .cv-main { font-size: 15.5px; line-height: 1.5; color: #222; }
 .cv-role, .cv-degree { font-weight: 600; }
-.cv-date { font-size: 13px; color: #666; white-space: nowrap; }
+.cv-date {
+  grid-area: date;
+  font-size: 13px;
+  color: #666;
+  white-space: nowrap;
+  align-self: start;
+}
 
 .cv-sub {
   margin-top: 2px;
@@ -137,8 +177,25 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
 
 /* 移动端收紧布局：日期换行到下一行 */
 @media (max-width: 640px) {
-  .cv-row { grid-template-columns: 1fr; gap: 4px; }
-  .cv-date { order: 2; }
+  .cv-row {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "logo"
+      "main"
+      "date";
+    gap: 8px;
+  }
+
+  .cv-logo {
+    justify-self: start;
+    padding: 10px;
+    border-radius: 12px;
+  }
+
+  .cv-date {
+    justify-self: start;
+    margin-top: 2px;
+  }
 }
 :root {
   --publication-control-height: 2.5rem;

--- a/images/logos/UVic.svg
+++ b/images/logos/UVic.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>University of Victoria logo</title>
+  <defs>
+    <linearGradient id="uvic-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0c2340" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="uvic-accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fb923c" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#uvic-bg)" />
+  <path d="M0 0h64L0 64z" fill="#c8102e" opacity="0.85" />
+  <path d="M128 128H48l80-48z" fill="url(#uvic-accent)" opacity="0.9" />
+  <g fill="#f8fafc" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="64" y="66" font-size="46" font-weight="700" letter-spacing="1">UV</text>
+    <text x="64" y="100" font-size="28" font-weight="600" letter-spacing="2">IC</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- embed organisation logos in the Experiences and Educations sections with responsive layouts and language-aware wrappers
- refresh CV styling to accommodate the new logo column and ensure readability in both light and dark themes
- add a custom University of Victoria SVG logo asset used by the new layout

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Bundler Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e62073c540832d81fa3da261cb350b