### PR TITLE
Remove CV logo background styling

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -131,9 +131,9 @@ h1:before, .anchor:before {
   justify-content: center;
   padding: 10px 12px;
   border-radius: 16px;
-  background: var(--cv-logo-bg);
-  border: 1px solid var(--cv-logo-border);
-  box-shadow: 0 12px 28px var(--cv-logo-shadow);
+  background: none;
+  border: none;
+  box-shadow: none;
 }
 
 .cv-logo img {
@@ -189,6 +189,9 @@ h1,h2,h3 { margin-top: 14px; margin-bottom: 10px; }
     width: auto;
     padding: 8px 10px;
     border-radius: 14px;
+    background: none;
+    border: none;
+    box-shadow: none;
   }
 
   .cv-logo img {


### PR DESCRIPTION
## Summary
- remove the decorative background, border, and shadow around CV logos so the images render without frames

## Testing
- not run (environment missing Jekyll gem)


------
https://chatgpt.com/codex/tasks/task_e_68e654a46664832da9a67a97efe74ea2