### PR TITLE
feat: improve greedy nav accessibility and hover handling

### DIFF
--- a/MENU_TOGGLE.md
+++ b/MENU_TOGGLE.md
@@ -1,0 +1,23 @@
+# 折叠菜单栏按钮的打开与关闭机制
+
+本文更新总结 `greedy-nav` 折叠菜单的状态管理、交互解耦与无障碍优化策略，帮助理解新版按钮的行为。
+
+## 状态管理与无障碍播报
+- 插件内部引入显式的 `isOpen` 状态，通过 `setMenuOpen()` 同步 DOM 类名、`aria-expanded`/`aria-hidden` 与按钮的 `data-state`，并在菜单隐藏或条目为空时强制回落到关闭态，保证状态一致性。【F:assets/js/plugins/jquery.greedy-navigation.js†L8-L83】
+- 初始化时为切换按钮附加 `aria-live="polite"` 的隐藏状态区，并在 `announceState()` 中播报“展开/收起”提示，满足屏幕阅读器对状态变更的感知需求。【F:assets/js/plugins/jquery.greedy-navigation.js†L15-L44】
+- `manageDocClickListener()` 动态注册/注销命名空间外部点击事件，既维持交互正确性，也避免无谓的全局监听。【F:assets/js/plugins/jquery.greedy-navigation.js†L46-L59】
+
+## 打开路径
+- “更多”按钮点击时根据当前 `isOpen` 状态切换，方向键 `ArrowDown/ArrowUp` 会自动展开菜单并把焦点定位到隐藏列表的首尾元素，完整支持键盘导航起点。【F:assets/js/plugins/jquery.greedy-navigation.js†L170-L203】
+- 当焦点进入 `.greedy-nav__more` 区域时，`focusin` 事件会触发展开，确保键盘逐项访问时不会漏掉隐藏条目。【F:assets/js/plugins/jquery.greedy-navigation.js†L248-L252】
+- 桌面端悬停逻辑独立在 `assets/js/nav-hover.js` 中：仅当命中 `(hover: hover) and (pointer: fine)` 媒体查询时绑定指针事件，并通过自定义事件 `greedyNav:open` 请求主插件展开菜单，触摸设备默认不响应悬停。【F:assets/js/nav-hover.js†L17-L128】【F:assets/js/plugins/jquery.greedy-navigation.js†L170-L179】
+
+## 关闭策略
+- “更多”按钮、隐藏列表项与 `focusout` 事件共同调用 `setMenuOpen(false)`：包括按 `Escape`、在隐藏列表里循环 Tab、焦点移出“更多”容器或用户点击页面其它区域时都会自动收起。【F:assets/js/plugins/jquery.greedy-navigation.js†L46-L258】
+- 桌面悬停在指针离开后会延迟 150ms 触发 `greedyNav:close`，并在指针能力变化（如插拔触控板）时自动解绑监听，避免在触摸端误触折叠。【F:assets/js/nav-hover.js†L63-L129】【F:assets/js/plugins/jquery.greedy-navigation.js†L170-L179】
+
+## 性能与事件委托
+- 窗口尺寸变化使用 150ms 防抖并优先通过 `requestAnimationFrame` 执行 `updateNav()`，减少布局抖动。【F:assets/js/plugins/jquery.greedy-navigation.js†L159-L168】
+- 隐藏列表使用事件委托集中处理键盘逻辑，避免为每个菜单项单独绑定监听器；文档级点击监听亦在关闭时解绑，实现更精简的事件管理。【F:assets/js/plugins/jquery.greedy-navigation.js†L46-L245】
+
+通过上述优化，折叠菜单在保留既有功能的同时进一步强化了性能与无障碍体验，并确保不同输入设备的交互互不干扰。

--- a/assets/js/nav-hover.js
+++ b/assets/js/nav-hover.js
@@ -14,10 +14,32 @@
       return;
     }
 
+    var pointerQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(hover: hover) and (pointer: fine)')
+        : null;
     var closeTimer = null;
 
     function hasHiddenItems() {
       return hiddenLinks.children.length > 0;
+    }
+
+    function isExpanded() {
+      return toggleButton.getAttribute('aria-expanded') === 'true';
+    }
+
+    function createToggleEvent(type) {
+      if (typeof window.CustomEvent === 'function') {
+        return new CustomEvent(type, { bubbles: true });
+      }
+
+      var event = document.createEvent('CustomEvent');
+      event.initCustomEvent(type, true, true, null);
+      return event;
+    }
+
+    function dispatchToggleEvent(type) {
+      toggleButton.dispatchEvent(createToggleEvent(type));
     }
 
     function openMenu() {
@@ -25,23 +47,23 @@
         return;
       }
 
-      if (toggleButton.getAttribute('aria-expanded') === 'true') {
-        return;
-      }
-
       if (!hasHiddenItems()) {
         return;
       }
 
-      toggleButton.click();
-    }
-
-    function closeMenu() {
-      if (toggleButton.getAttribute('aria-expanded') !== 'true') {
+      if (isExpanded()) {
         return;
       }
 
-      toggleButton.click();
+      dispatchToggleEvent('greedyNav:open');
+    }
+
+    function closeMenu() {
+      if (!isExpanded()) {
+        return;
+      }
+
+      dispatchToggleEvent('greedyNav:close');
     }
 
     function clearCloseTimer() {
@@ -54,32 +76,58 @@
     function scheduleClose() {
       clearCloseTimer();
       closeTimer = window.setTimeout(function () {
+        if (moreContainer.contains(document.activeElement)) {
+          closeTimer = null;
+          return;
+        }
+
         closeMenu();
         closeTimer = null;
       }, 150);
     }
 
-    moreContainer.addEventListener('mouseenter', function () {
+    var handlePointerEnter = function () {
       clearCloseTimer();
       openMenu();
-    });
+    };
 
-    moreContainer.addEventListener('mouseleave', function () {
+    var handlePointerLeave = function () {
       scheduleClose();
-    });
+    };
 
-    moreContainer.addEventListener('focusin', function () {
+    function bindHover() {
+      moreContainer.addEventListener('mouseenter', handlePointerEnter);
+      moreContainer.addEventListener('mouseleave', handlePointerLeave);
+    }
+
+    function unbindHover() {
+      moreContainer.removeEventListener('mouseenter', handlePointerEnter);
+      moreContainer.removeEventListener('mouseleave', handlePointerLeave);
       clearCloseTimer();
-      openMenu();
-    });
+      closeMenu();
+    }
 
-    moreContainer.addEventListener('focusout', function (event) {
-      if (event.relatedTarget && moreContainer.contains(event.relatedTarget)) {
-        return;
-      }
+    if (pointerQuery && pointerQuery.matches) {
+      bindHover();
+    }
 
-      scheduleClose();
-    });
+    if (pointerQuery && typeof pointerQuery.addEventListener === 'function') {
+      pointerQuery.addEventListener('change', function (event) {
+        if (event.matches) {
+          bindHover();
+        } else {
+          unbindHover();
+        }
+      });
+    } else if (pointerQuery && typeof pointerQuery.addListener === 'function') {
+      pointerQuery.addListener(function (event) {
+        if (event.matches) {
+          bindHover();
+        } else {
+          unbindHover();
+        }
+      });
+    }
   }
 
   if (document.readyState === 'loading') {

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -7,10 +7,21 @@
 
 var $nav = $('#site-nav');
 var $btn = $('[data-nav-toggle]');
+var $more = $('.greedy-nav__more');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('.greedy-nav__more .hidden-links');
 var docClickHandler = null;
 var resizeTimer;
+var $liveRegion = $('<span />', {
+  'class': 'sr-only greedy-nav__status',
+  'aria-live': 'polite',
+  'aria-atomic': 'true'
+});
+
+if($btn.length && !$btn.find('.greedy-nav__status').length) {
+  $btn.append($liveRegion);
+}
+var isOpen = false;
 
 function getVisibleItems() {
   return $vlinks.children();
@@ -21,6 +32,16 @@ function getHiddenItems() {
 }
 
 var breaks = [];
+
+function announceState() {
+  if(!$btn.length) {
+    return;
+  }
+
+  var statusMessage = isOpen ? 'Navigation menu expanded' : 'Navigation menu collapsed';
+  $btn.attr('data-state', isOpen ? 'expanded' : 'collapsed');
+  $btn.find('.greedy-nav__status').text(statusMessage);
+}
 
 function manageDocClickListener(shouldBind) {
   if(shouldBind) {
@@ -38,12 +59,27 @@ function manageDocClickListener(shouldBind) {
   }
 }
 
-function setMenuOpen(isOpen) {
+function setMenuOpen(shouldOpen) {
+  if(!$btn.length || !$hlinks.length) {
+    return;
+  }
+
+  if($btn.hasClass('hidden') || getHiddenItems().length < 1) {
+    shouldOpen = false;
+  }
+
+  if(isOpen === shouldOpen) {
+    manageDocClickListener(isOpen);
+    return;
+  }
+
+  isOpen = shouldOpen;
   $hlinks.toggleClass('hidden', !isOpen);
   $hlinks.attr('aria-hidden', isOpen ? 'false' : 'true');
   $btn.toggleClass('close', isOpen);
   $btn.attr('aria-expanded', isOpen ? 'true' : 'false');
   manageDocClickListener(isOpen);
+  announceState();
 }
 
 function updateNav() {
@@ -104,9 +140,23 @@ function updateNav() {
 
 }
 
+function focusFirstHiddenLink() {
+  var $focusable = $hlinks.find('a, button, [tabindex]').filter(':visible');
+  if($focusable.length) {
+    $focusable.first().focus();
+  }
+}
+
+function focusLastHiddenLink() {
+  var $focusable = $hlinks.find('a, button, [tabindex]').filter(':visible');
+  if($focusable.length) {
+    $focusable.last().focus();
+  }
+}
+
 // Window listeners
 
-$(window).on('resize', function() {
+$(window).on('resize.greedyNav', function() {
   clearTimeout(resizeTimer);
   resizeTimer = setTimeout(function() {
     if(typeof window.requestAnimationFrame === 'function') {
@@ -118,15 +168,95 @@ $(window).on('resize', function() {
 });
 
 $btn.on('click', function() {
-  var isHidden = $hlinks.hasClass('hidden');
-  setMenuOpen(isHidden);
-  $hlinks.attr('aria-hidden', isHidden ? 'false' : 'true');
+  setMenuOpen(!isOpen);
+});
+
+$btn.on('greedyNav:open', function() {
+  setMenuOpen(true);
+});
+
+$btn.on('greedyNav:close', function() {
+  setMenuOpen(false);
 });
 
 $btn.on('keydown', function(event) {
   if(event.key === 'Escape' || event.keyCode === 27) {
     setMenuOpen(false);
+    return;
+  }
+
+  if(event.key === 'ArrowDown' || event.keyCode === 40) {
+    if(!isOpen) {
+      setMenuOpen(true);
+    }
+    focusFirstHiddenLink();
+    event.preventDefault();
+  }
+
+  if(event.key === 'ArrowUp' || event.keyCode === 38) {
+    if(!isOpen) {
+      setMenuOpen(true);
+    }
+    focusLastHiddenLink();
+    event.preventDefault();
   }
 });
 
+$hlinks.on('keydown', 'a, button, [tabindex]', function(event) {
+  if(!isOpen) {
+    return;
+  }
+
+  var $focusable = $hlinks.find('a, button, [tabindex]').filter(':visible');
+  var $current = $(this);
+  var currentIndex = $focusable.index($current);
+
+  if(event.key === 'Escape' || event.keyCode === 27) {
+    setMenuOpen(false);
+    $btn.focus();
+    return;
+  }
+
+  if(event.key === 'ArrowDown' || event.keyCode === 40) {
+    event.preventDefault();
+    $focusable.eq((currentIndex + 1) % $focusable.length).focus();
+  }
+
+  if(event.key === 'ArrowUp' || event.keyCode === 38) {
+    event.preventDefault();
+    $focusable.eq((currentIndex - 1 + $focusable.length) % $focusable.length).focus();
+  }
+
+  if(event.key === 'Home' || event.keyCode === 36) {
+    event.preventDefault();
+    focusFirstHiddenLink();
+  }
+
+  if(event.key === 'End' || event.keyCode === 35) {
+    event.preventDefault();
+    focusLastHiddenLink();
+  }
+
+  if(event.key === 'Tab') {
+    var isShiftTab = !!event.shiftKey;
+    if((!isShiftTab && currentIndex === $focusable.length - 1) || (isShiftTab && currentIndex === 0)) {
+      setMenuOpen(false);
+    }
+  }
+});
+
+$more.on('focusin.greedyNav', function() {
+  if(!isOpen) {
+    setMenuOpen(true);
+  }
+});
+
+$more.on('focusout.greedyNav', function(event) {
+  var relatedTarget = event.relatedTarget || document.activeElement;
+  if(!$more.has(relatedTarget).length) {
+    setMenuOpen(false);
+  }
+});
+
+announceState();
 updateNav();


### PR DESCRIPTION
## Summary
- add explicit isOpen state, aria live messaging, and full keyboard support to the greedy navigation toggle
- update nav-hover.js to use custom greedyNav events, hover-capable media queries, and legacy-safe CustomEvent dispatchers
- refresh MENU_TOGGLE.md with the new interaction model, accessibility notes, and performance optimizations

## Testing
- bundle exec jekyll build *(fails: jekyll executable missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e660411768832dbbb7f2273583508c